### PR TITLE
ローソン都道府県スクレイパーを追加

### DIFF
--- a/scripts/lawson_pref_ndjson.js
+++ b/scripts/lawson_pref_ndjson.js
@@ -57,7 +57,7 @@ async function extractAreaUrlsFromPage(page) {
       if (!href) continue;
       const abs = href.startsWith('http') ? href : `${sourceUrl}${href.replace(/^\//, '')}`;
       const normalized = abs
-        .replace(/([?&])page=\\d+&?/g, '$1')
+        .replace(/([?&])page=\d+&?/g, '$1')
         .replace(/[?&]$/, '');
       out.add(normalized);
     }
@@ -130,15 +130,15 @@ async function fetchStoresByArea(page, areaUrl) {
   all.push(...(await extractStoresFromCurrentPage(page, areaUrl)));
 
   const maxPage = await extractMaxPageFromCurrentPage(page);
-  for (let pageNo = 1; pageNo <= maxPage; pageNo += 1) {
+  for (let pageNo = 2; pageNo <= maxPage; pageNo += 1) {
     const base = areaUrl
-      .replace(/([?&])page=\\d+&?/g, '$1')
+      .replace(/([?&])page=\d+&?/g, '$1')
       .replace(/[?&]$/, '');
     const sep = base.includes('?') ? '&' : '?';
     const pageUrl = `${base}${sep}page=${pageNo}`;
     const okPage = await gotoWithRetry(page, pageUrl);
     if (!okPage) continue;
-    all.push(...(await extractStoresFromCurrentPage(page, areaUrl)));
+    all.push(...(await extractStoresFromCurrentPage(page, pageUrl)));
   }
 
   return all;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Lawson店舗データの自動取得機能を追加。全都道府県またはフィルタリング対象の都道府県のLawson店舗情報（ID、名称、住所、電話番号、営業時間、詳細URL）をNDJSONファイルで抽出。重複排除機能搭載。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->