### PR TITLE
ドキュメント更新: AGENTS・README・Skillsを現行実装に同期

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@
 - 目的は「補給地点DB」を BigQuery マートとして提供すること
 - 公式サイトの変更に追従しやすいよう、クロールは Codex + Playwright 前提
 - 住所正規化/座標付与は Cloud Run 側で実行し、Dataform は BQ 内完結
-- 対象チェーンは 7-Eleven / Lawson / FamilyMart（拡張可能な設計）
+- `plan.md` 上のコア対象チェーンは 7-Eleven / Lawson / FamilyMart（拡張可能な設計）
+- 現在の実装済みクローラは 7-Eleven / Lawson / FamilyMart / Daily Yamazaki / 道の駅 / MINISTOP
 
 ## コンポーネント責務
 
@@ -22,6 +23,9 @@
 - `raw.stores_geocoded` は単一テーブルで共通スキーマを維持する
 - 住所正規化は 1 住所 1 回を原則とし、再計算を避ける
 - Dataform 側で外部 I/O や npm 実行を行わない
+- 取得元に詳細URLが存在しない場合は `detail_url` を無理に生成しない
+- API/JSONが使えるサイトでは、DOM抽出より API/JSON 取得を優先する
+- リトライ処理にはタイムアウトを設定し、最終試行後の不要な待機を避ける
 
 ## 変更時のチェック
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,18 @@
 
 ## 目的
 
-- セブン‐イレブン / ローソン / ファミリーマートの店舗情報を収集
+- コア対象: セブン‐イレブン / ローソン / ファミリーマートの店舗情報を収集
 - 住所を正規化し、緯度経度を付与
 - BigQuery 上で最新化・重複排除し `mart.rideoasis_supply_points` を提供
+
+## 実装済みクローラ
+
+- 7-Eleven
+- Lawson
+- FamilyMart
+- Daily Yamazaki
+- 道の駅
+- MINISTOP
 
 ## アーキテクチャ
 
@@ -53,6 +62,12 @@ node scripts/daily_yamazaki_pref_ndjson.js --pref 27
 node scripts/michi_no_eki_pref_ndjson.js --pref 48
 node scripts/ministop_pref_ndjson.js --pref 27
 ```
+
+補足:
+
+- `michi_no_eki` は都道府県コード体系が独自（例: 高知は `48`）
+- `ministop` は配信 JSON（`_next/data/.../map.json`）を利用するため高速
+- 取得元データに存在しない場合、`detail_url` は出力しません
 
 ## 注意事項
 

--- a/skills/crawler-playwright/SKILL.md
+++ b/skills/crawler-playwright/SKILL.md
@@ -6,14 +6,15 @@
 
 - サイト変更に強い抽出ロジックを作る
 - 収集結果を `raw` へ Upsert しやすい形に整形する
+- API/JSON 優先で高速・安定な取得を実現する
 
 ## 手順（最短ルート）
 
 1. 対象サイトの一覧/詳細ページを調査し、XHR/JSON 取得の有無を確認
-2. XHR がある場合はそれを優先（HTML 直接抽出は最後の手段）
+2. XHR/JSON がある場合はそれを優先（HTML 直接抽出は最後の手段）
 3. store_id の取得方法を確定（公式 ID がなければハッシュ）
 4. 取得項目を `raw.stores_scraped_{chain}` に合わせて整形
-5. 取得失敗時のリトライ、rate limit、ログ出力を実装
+5. 取得失敗時のリトライ、タイムアウト、ログ出力を実装
 6. 出力スキーマを `plan.md` の「案」に合わせて更新
 
 ## 抽出の基本方針
@@ -21,11 +22,20 @@
 - セレクタは安定性優先（id/data 属性、API レスポンス優先）
 - 取得元 URL は `source_url` として必ず保存
 - 取得した生データは `payload_json` に保存
+- 取得元に存在しない項目は無理に補完しない（例: `detail_url`）
 
-## 住所整形の前提
+## 実装パターン（現行）
 
-- 住所正規化は Cloud Run 内で実行
-- 郵便番号や都道府県の欠落があれば補完を試みる
+- 7-Eleven: `search-by-condition` API 直取得
+- Daily Yamazaki: `search-by-condition` API 直取得
+- MINISTOP: `/_next/data/{buildId}/map.json` から全店舗取得して都道府県フィルタ
+- Lawson / FamilyMart / 道の駅: 一覧と詳細の HTML を段階取得（必要最小限）
+
+## リトライ実装の注意
+
+- `fetch`/`goto` には必ずタイムアウトを設定する
+- 指数バックオフを使う
+- 最終試行失敗後は不要な `sleep` を入れない
 
 ## 期待する出力（最小）
 
@@ -33,35 +43,8 @@
 - `store_name`
 - `address_raw`
 - `postal_code`
+- `phone_number`
+- `hours_text`
 - `source_url`
 - `scraped_at`
 - `payload_json`
-
-## 例（詳細取得）
-
-店名クリック（`/info/{kyo_id}`）の詳細応答から、営業時間とサービスを取得できる。
-
-```json
-{
-  "store_id": "377584",
-  "store_name": "高知丸池町",
-  "address": "高知県高知市丸池町１番２号",
-  "phone": "088-882-2027",
-  "hours_start": "06:00",
-  "hours_end": "24:00",
-  "services": [
-    "ペットボトル回収機",
-    "店舗留置サービス",
-    "セブンミール",
-    "７ＮＯＷ",
-    "セブンカフェスムージー",
-    "セブンカフェ",
-    "揚げ物惣菜",
-    "マルチコピー機",
-    "たばこ",
-    "お酒",
-    "ATM",
-    "お会計セルフレジ"
-  ]
-}
-```

--- a/skills/dataform-modeling/SKILL.md
+++ b/skills/dataform-modeling/SKILL.md
@@ -20,9 +20,17 @@
 - `supply_point_id = CONCAT(chain, ':', store_id)` を一意キーにする
 - `updated_at` は Dataform の生成日時または upstream の最新日時
 - `point_level` の閾値は運用開始後に可変とする
+- Dataform 内で外部 I/O や npm 実行は行わない（住所正規化は Cloud Run 側）
 
 ## テーブル要件
 
 - `stg` は最新化・整形に限定（重いロジックは避ける）
 - `mart` は 1 行 1 供給点を厳守
 - `ops` は可視化しやすい粒度で作成
+
+## スキーマ運用の注意
+
+- `raw.stores_scraped_*` はチェーンごとの差異を許容する
+- `raw.stores_geocoded` は共通スキーマを維持する
+- 欠損があり得る列（例: `postal_code`, `hours_text`）は NULL 許容で扱う
+- 生成列の命名はチェーン依存語を避け、横断的に理解できる名前を優先する


### PR DESCRIPTION
## 概要
- ドキュメント類（README / AGENTS / Skills）を現行実装に合わせて更新
- plan.md の方針を維持しつつ、運用で確定した実務ルールを明文化

## 変更内容
- `AGENTS.md`
  - コア対象チェーン（plan準拠）と実装済みクローラを明記
  - API/JSON優先、`detail_url` 無理生成禁止、タイムアウト付きリトライ方針を追記
- `README.md`
  - 実装済みクローラ一覧を追加
  - 取得スクリプト実行例に現行チェーンを反映
  - `michi_no_eki` の都道府県コード体系、`ministop` の取得方式補足を追記
- `skills/crawler-playwright/SKILL.md`
  - 現行の収集パターン（7-Eleven / Daily Yamazaki / MINISTOP など）を反映
  - リトライ実装の注意点（タイムアウト、最終試行後の不要sleep回避）を追記
- `skills/dataform-modeling/SKILL.md`
  - Dataform 側の禁止事項（外部I/O・npm実行なし）を明記
  - 欠損許容・命名方針などスキーマ運用注意を追記

## 背景
- 直近でチェーン追加とレビュー対応を重ねたため、ドキュメントとのズレを解消する目的。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * コンビニエンスストアクローラの対応チェーンを拡大（7-Eleven、Lawson、FamilyMart、Daily Yamazaki、道の駅、MINISTOP）
  * API/JSON抽出を優先する設計方針に更新
  * データフロー、BigQueryスキーマ、アーキテクチャの全体像を明確化
  * リトライ処理とタイムアウト設定のガイドラインを強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->