### PR TITLE
Rename famima crawler script/output naming to familymart

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 ```bash
 node scripts/7eleven_pref_ndjson.js --pref osaka
 node scripts/lawson_pref_ndjson.js --pref tokyo
-node scripts/famima_pref_ndjson.js --pref kanagawa
+node scripts/familymart_pref_ndjson.js --pref kanagawa
 node scripts/daily_yamazaki_pref_ndjson.js --pref hokkaido
 node scripts/michi_no_eki_pref_ndjson.js --pref kochi
 node scripts/ministop_pref_ndjson.js --pref osaka

--- a/scripts/familymart_pref_ndjson.js
+++ b/scripts/familymart_pref_ndjson.js
@@ -199,7 +199,7 @@ async function main() {
     return;
   }
 
-  const outDir = path.join('data', 'famima', 'ndjson');
+  const outDir = path.join('data', 'familymart', 'ndjson');
   fs.mkdirSync(outDir, { recursive: true });
 
   const browser = await chromium.launch({ headless: true });
@@ -261,7 +261,7 @@ async function main() {
         }
       }
 
-      const outPath = path.join(outDir, `stores_famima_pref_${pref}.ndjson`);
+      const outPath = path.join(outDir, `stores_familymart_pref_${pref}.ndjson`);
       if (lines.length > 0) {
         fs.writeFileSync(outPath, `${lines.join('\n')}\n`);
         console.log(`${pref}: ${lines.length} -> ${outPath}`);


### PR DESCRIPTION
## Summary
- rename crawler entrypoint from `scripts/famima_pref_ndjson.js` to `scripts/familymart_pref_ndjson.js`
- switch generated output path/prefix to `data/familymart/ndjson/stores_familymart_pref_*.ndjson`
- update README usage example to use the renamed script

## Notes
- no backward compatibility (as requested)
- source website URL still contains `famima` and remains unchanged