### PR TITLE
CI: UnitテストのGitHub Actions導入とNode matrix化

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,31 @@
+name: Unit Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test:unit


### PR DESCRIPTION
## 変更内容
- `.github/workflows/unit-tests.yml` を追加
- `pull_request` / `main` への `push` で Unit テストを実行
- Node.js を matrix (`20`, `22`) で実行
- `npm ci` 後に `npm run test:unit` を実行

## 確認
- ローカルで `npm run test:unit` が全件成功（19 passed）

## 補足
- `main` ブランチ保護の Required status checks に以下を設定済み
  - `unit-tests (20)`
  - `unit-tests (22)`
