### PR TITLE
ci: run junit via existing test:unit script

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,9 +28,11 @@ jobs:
         run: npm ci
 
       - name: Run unit tests
+        env:
+          NODE_OPTIONS: --test-reporter=junit --test-reporter-destination=test-results/junit-node-${{ matrix.node-version }}.xml
         run: |
           mkdir -p test-results
-          npm run test:unit -- --test-reporter=junit --test-reporter-destination=test-results/junit-node-${{ matrix.node-version }}.xml tests/*.test.js
+          npm run test:unit
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
### Motivation
- レビュー指摘に従い、CI 用の専用スクリプトを増やさず既存の `test:unit` を再利用して JUnit 出力を得るため。 

### Description
- `package.json` から `test:unit:junit` スクリプトを削除しました. 
- `.github/workflows/unit-tests.yml` のテスト実行を直接 `node --test ...` で呼ぶ方法から `npm run test:unit -- --test-reporter=junit --test-reporter-destination=test-results/junit-node-${{ matrix.node-version }}.xml tests/*.test.js` へ変更しました. 

### Testing
- `npm test` を実行しユニットテストがすべて通過しました。 
- `npm run test:unit -- --test-reporter=junit --test-reporter-destination=/tmp/ride-oasis-junit.xml tests/*.test.js` を実行し JUnit 形式の出力先指定でテストがすべて通過しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e9be50ac08328b43d37bbbf68e94b)