### PR TITLE
ci: unit-tests ワークフローの JUnit 実行ステップ名を明確化

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run unit tests
+      - name: Run unit tests (JUnit)
         run: |
           mkdir -p test-results
           node --test --test-reporter=junit --test-reporter-destination=test-results/junit-node-${{ matrix.node-version }}.xml tests/*.test.js


### PR DESCRIPTION
### Motivation
- `.github/workflows/unit-tests.yml` のテスト実行ステップ名を JUnit 出力であることが明確に分かるように変更するため。

### Description
- ワークフロー内のステップ名を `Run unit tests` から `Run unit tests (JUnit)` に変更し、実行コマンド（`node --test --test-reporter=junit ...`）および成果物アップロード設定はそのまま維持しました。

### Testing
- `npm test` を実行し、既存のユニットテスト（19件）がすべて成功することを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e9be50ac08328b43d37bbbf68e94b)