### PR TITLE
feat: 補給地点マップに現在地モードを追加

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3,6 +3,7 @@ const API_BASE = window.RIDEOASIS_API_BASE || '/api';
 const elements = {
   status: document.getElementById('status'),
   gpxFile: document.getElementById('gpx-file'),
+  useCurrentLocation: document.getElementById('use-current-location'),
   distanceThreshold: document.getElementById('distance-threshold'),
   minPointLevel: document.getElementById('min-point-level'),
   refresh: document.getElementById('refresh'),
@@ -20,6 +21,7 @@ const routeGeoJsonFormat = new ol.format.GeoJSON({ featureProjection: 'EPSG:3857
 const routeSource = new ol.source.Vector();
 const pointSource = new ol.source.Vector();
 const endpointSource = new ol.source.Vector();
+const currentLocationSource = new ol.source.Vector();
 
 const routeLayer = new ol.layer.Vector({
   source: routeSource,
@@ -64,13 +66,25 @@ const endpointLayer = new ol.layer.Vector({
   }
 });
 
+const currentLocationLayer = new ol.layer.Vector({
+  source: currentLocationSource,
+  style: new ol.style.Style({
+    image: new ol.style.Circle({
+      radius: 7,
+      fill: new ol.style.Fill({ color: '#c76b12' }),
+      stroke: new ol.style.Stroke({ color: '#ffffff', width: 2 })
+    })
+  })
+});
+
 const map = new ol.Map({
   target: 'map',
   layers: [
     new ol.layer.Tile({ source: new ol.source.OSM() }),
     routeLayer,
     pointLayer,
-    endpointLayer
+    endpointLayer,
+    currentLocationLayer
   ],
   view: new ol.View({
     center: ol.proj.fromLonLat([139.767, 35.681]),
@@ -211,6 +225,7 @@ function updateSummary(candidateCount, matchedCount) {
 function renderRoute(feature) {
   routeSource.clear();
   endpointSource.clear();
+  currentLocationSource.clear();
   routeSource.addFeature(feature);
 
   const coordinates = feature.getGeometry().getCoordinates();
@@ -225,6 +240,18 @@ function renderRoute(feature) {
     goal.set('kind', 'goal');
     endpointSource.addFeatures([start, goal]);
   }
+}
+
+/** Renders a single current-location marker instead of a route line. */
+function renderCurrentLocation(coord) {
+  routeSource.clear();
+  endpointSource.clear();
+  currentLocationSource.clear();
+  currentLocationSource.addFeature(
+    new ol.Feature({
+      geometry: new ol.geom.Point(ol.proj.fromLonLat(coord))
+    })
+  );
 }
 
 /** Converts matched GeoJSON points into OpenLayers features. */
@@ -245,7 +272,7 @@ function renderMatchedPoints(points) {
 function fitToVisibleData() {
   const extent = ol.extent.createEmpty();
   let hasData = false;
-  for (const source of [routeSource, pointSource, endpointSource]) {
+  for (const source of [routeSource, pointSource, endpointSource, currentLocationSource]) {
     const sourceExtent = source.getExtent();
     if (sourceExtent && !ol.extent.isEmpty(sourceExtent)) {
       ol.extent.extend(extent, sourceExtent);
@@ -315,12 +342,12 @@ async function fetchCandidatePoints(distanceMeters) {
 
 /** Applies the browser-side point-to-route distance filter. */
 function filterMatchedPoints(featureCollection, distanceMeters) {
+  const origin = routeCoordinates[0] || null;
   return featureCollection.features
     .map((feature) => {
-      const distance = window.RouteMath.pointToRouteDistanceMeters(
-        feature.geometry.coordinates,
-        routeCoordinates
-      );
+      const distance = routeCoordinates.length >= 2
+        ? window.RouteMath.pointToRouteDistanceMeters(feature.geometry.coordinates, routeCoordinates)
+        : window.RouteMath.pointToPointDistanceMeters(feature.geometry.coordinates, origin);
       return {
         ...feature,
         properties: {
@@ -336,7 +363,7 @@ function filterMatchedPoints(featureCollection, distanceMeters) {
 /** Refreshes API candidates and matched points for the loaded route. */
 async function refreshMap() {
   if (!routeCoordinates.length) {
-    setStatus('先に GPX を読み込んでください');
+    setStatus('先に GPX か現在地を読み込んでください');
     return;
   }
 
@@ -376,9 +403,45 @@ async function handleGpxFile(event) {
   }
 }
 
+/** Prompts the browser for the device's current position and refreshes nearby points. */
+async function handleCurrentLocation() {
+  if (!navigator.geolocation) {
+    setStatus('このブラウザは現在地取得に対応していません');
+    return;
+  }
+
+  setStatus('現在地を取得中...');
+  try {
+    const position = await new Promise((resolve, reject) => {
+      navigator.geolocation.getCurrentPosition(resolve, reject, {
+        enableHighAccuracy: true,
+        timeout: 10000,
+        maximumAge: 60000
+      });
+    });
+    const coord = [position.coords.longitude, position.coords.latitude];
+    routeFeature = null;
+    routeCoordinates = [coord];
+    renderCurrentLocation(coord);
+    updateSummary(0, 0);
+    fitToVisibleData();
+    setStatus('現在地を取得しました');
+    await refreshMap();
+  } catch (error) {
+    const message = error?.code === 1
+      ? '位置情報の利用が許可されていません'
+      : error?.code === 3
+        ? '現在地の取得がタイムアウトしました'
+        : '現在地の取得に失敗しました';
+    setStatus(message);
+    console.error(error);
+  }
+}
+
 /** Wires DOM and map click events for the static frontend. */
 function bindEvents() {
   elements.gpxFile.addEventListener('change', handleGpxFile);
+  elements.useCurrentLocation.addEventListener('click', handleCurrentLocation);
   elements.refresh.addEventListener('click', refreshMap);
   elements.popupClose.addEventListener('click', clearPopup);
   map.on('singleclick', (event) => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -441,8 +441,8 @@ async function handleCurrentLocation() {
 /** Wires DOM and map click events for the static frontend. */
 function bindEvents() {
   elements.gpxFile.addEventListener('change', handleGpxFile);
-  elements.useCurrentLocation.addEventListener('click', handleCurrentLocation);
-  elements.refresh.addEventListener('click', refreshMap);
+  elements.useCurrentLocation?.addEventListener('click', handleCurrentLocation);
+  elements.refresh?.addEventListener('click', refreshMap);
   elements.popupClose.addEventListener('click', clearPopup);
   map.on('singleclick', (event) => {
     const feature = map.forEachFeatureAtPixel(event.pixel, (candidate) => candidate);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,9 +15,9 @@
       <header class="topbar">
         <div>
           <h1>RideOasis Map</h1>
-          <p class="subtitle">GPX 経路の近傍にある補給地点を可視化</p>
+          <p class="subtitle">GPX 経路または現在地の近傍にある補給地点を可視化</p>
         </div>
-        <div class="status" id="status">GPX を読み込んでください</div>
+        <div class="status" id="status">GPX か現在地を読み込んでください</div>
       </header>
 
       <section class="panel controls">
@@ -25,6 +25,8 @@
           <span>GPX ファイル</span>
           <input id="gpx-file" type="file" accept=".gpx,application/gpx+xml,text/xml,application/xml" />
         </label>
+
+        <button id="use-current-location" type="button" class="secondary-action">現在地を使う</button>
 
         <label>
           <span>近傍距離 (m)</span>

--- a/frontend/route_math.js
+++ b/frontend/route_math.js
@@ -68,6 +68,17 @@
     return minDistance;
   }
 
+  /** Computes the direct distance between two lon/lat points in meters. */
+  function pointToPointDistanceMeters(pointA, pointB) {
+    if (!Array.isArray(pointA) || !Array.isArray(pointB) || pointA.length < 2 || pointB.length < 2) {
+      return Number.POSITIVE_INFINITY;
+    }
+    const referenceLat = (pointA[1] + pointB[1]) / 2;
+    const a = projectLonLatToMeters(pointA, referenceLat);
+    const b = projectLonLatToMeters(pointB, referenceLat);
+    return Math.hypot(a[0] - b[0], a[1] - b[1]);
+  }
+
   /** Converts a meter padding value to degree deltas around a latitude. */
   function metersToDegreePadding(latitude, meters) {
     const latPadding = meters / 111320;
@@ -111,6 +122,7 @@
   return {
     computeBbox,
     expandBbox,
+    pointToPointDistanceMeters,
     pointToRouteDistanceMeters
   };
 });

--- a/frontend/route_math.js
+++ b/frontend/route_math.js
@@ -70,7 +70,12 @@
 
   /** Computes the direct distance between two lon/lat points in meters. */
   function pointToPointDistanceMeters(pointA, pointB) {
-    if (!Array.isArray(pointA) || !Array.isArray(pointB) || pointA.length < 2 || pointB.length < 2) {
+    const isValidPoint = (point) =>
+      Array.isArray(point) &&
+      point.length >= 2 &&
+      Number.isFinite(point[0]) &&
+      Number.isFinite(point[1]);
+    if (!isValidPoint(pointA) || !isValidPoint(pointB)) {
       return Number.POSITIVE_INFINITY;
     }
     const referenceLat = (pointA[1] + pointB[1]) / 2;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -119,6 +119,12 @@ body {
 
 .controls .secondary-action:hover {
   background: #fbf3e8;
+  color: var(--accent-deep);
+}
+
+.controls .secondary-action:focus-visible {
+  background: #fbf3e8;
+  color: var(--accent-deep);
 }
 
 .chains {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -112,6 +112,15 @@ body {
   background: var(--accent-deep);
 }
 
+.controls .secondary-action {
+  background: #fff;
+  color: var(--accent-deep);
+}
+
+.controls .secondary-action:hover {
+  background: #fbf3e8;
+}
+
 .chains {
   display: grid;
   grid-template-columns: repeat(2, minmax(110px, 1fr));

--- a/tests/route_math.test.js
+++ b/tests/route_math.test.js
@@ -1,7 +1,12 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { computeBbox, expandBbox, pointToRouteDistanceMeters } = require('../frontend/route_math');
+const {
+  computeBbox,
+  expandBbox,
+  pointToPointDistanceMeters,
+  pointToRouteDistanceMeters
+} = require('../frontend/route_math');
 const { parseCoordinateTokens, parseGpxText } = require('../frontend/gpx');
 
 test('Route Math: GPX から trkpt を順序通り抽出できる', () => {
@@ -73,4 +78,10 @@ test('Route Math: 経路から離れた点は数百メートル以上になる',
     ]
   );
   assert.ok(distance > 500);
+});
+
+test('Route Math: 単一点どうしの距離をメートル換算できる', () => {
+  const distance = pointToPointDistanceMeters([139.0, 35.0], [139.001, 35.0]);
+  assert.ok(distance > 80);
+  assert.ok(distance < 100);
 });

--- a/tests/route_math.test.js
+++ b/tests/route_math.test.js
@@ -85,3 +85,8 @@ test('Route Math: 単一点どうしの距離をメートル換算できる', ()
   assert.ok(distance > 80);
   assert.ok(distance < 100);
 });
+
+test('Route Math: 非数値の座標は無限距離として扱う', () => {
+  const distance = pointToPointDistanceMeters([139.0, Number.NaN], [139.001, 35.0]);
+  assert.equal(distance, Number.POSITIVE_INFINITY);
+});


### PR DESCRIPTION
## 概要
- 補給地点マップで GPX だけでなく端末の現在地からも周辺補給地点を表示できるようにします
- 現在地モード用の UI と単一点向け距離計算を追加します

## 変更内容
- `現在地を使う` ボタンを追加し、`navigator.geolocation` で現在地を取得
- 現在地マーカーを地図に表示し、単一点でも近傍補給地点を検索できるように変更
- `pointToPointDistanceMeters` を追加して現在地ベースの距離絞り込みに対応
- 単体テストを追加

## 確認
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 現在地を取得して地図に単一マーカー表示できるようになりました
  * 「現在地を使う」ボタンでGPX入力と並んで現在地モードを選択可能に

* **改善**
  * 現在地モード用に検索範囲と表示の振る舞いを調整（ルート表示との切替、視界へのフィット、状態表示の更新）
  * 距離フィルタリングが現在地モード向けにポイント間距離計算に切替わるよう最適化

* **Style**
  * 新しいコントロールボタン用のスタイルを追加

* **Tests**
  * 現在地向け距離計算の単体テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->