### PR TITLE
Refine supply point popup and sidebar interactions

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -135,15 +135,27 @@ function buildPointList(points) {
     const item = document.createElement('button');
     item.type = 'button';
     item.className = 'point-item';
+    item.dataset.supplyPointId = String(props.supply_point_id);
     if (props.supply_point_id === activeSupplyPointId) {
       item.classList.add('active');
     }
-    item.innerHTML = [
-      `<div class="chain">${escapeHtml(props.chain)}</div>`,
-      `<div class="title">${escapeHtml(props.name)}</div>`,
-      `<div class="meta">${Math.round(props.route_distance_m)}m</div>`,
-      `<div class="address">${escapeHtml(props.address_norm || '-')}</div>`
-    ].join('');
+    const chain = document.createElement('span');
+    chain.className = 'chain';
+    chain.textContent = props.chain;
+
+    const title = document.createElement('span');
+    title.className = 'title';
+    title.textContent = props.name;
+
+    const meta = document.createElement('span');
+    meta.className = 'meta';
+    meta.textContent = `${Math.round(props.route_distance_m)}m`;
+
+    const address = document.createElement('span');
+    address.className = 'address';
+    address.textContent = props.address_norm || '-';
+
+    item.append(chain, title, meta, address);
     item.addEventListener('mouseenter', () => previewPoint(props.supply_point_id));
     item.addEventListener('mouseleave', () => clearPreviewPoint(props.supply_point_id));
     item.addEventListener('focus', () => previewPoint(props.supply_point_id));
@@ -151,6 +163,15 @@ function buildPointList(points) {
     item.addEventListener('click', () => activatePoint(props.supply_point_id));
     elements.pointList.appendChild(item);
   }
+}
+
+/** Builds the popup HTML for a selected supply point. */
+function buildPopupHtml(props) {
+  return [
+    `<div class="popup-chain">${escapeHtml(props.chain)}</div>`,
+    `<div class="popup-title">${escapeHtml(props.name)}</div>`,
+    `<div class="popup-distance">${Math.round(props.route_distance_m)}m</div>`
+  ].join('');
 }
 
 /** Escapes text before inserting it into HTML fragments. */
@@ -161,15 +182,6 @@ function escapeHtml(value) {
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
-}
-
-/** Builds the popup HTML for a selected supply point. */
-function buildPopupHtml(props) {
-  return [
-    `<div class="popup-chain">${escapeHtml(props.chain)}</div>`,
-    `<div class="popup-title">${escapeHtml(props.name)}</div>`,
-    `<div class="popup-distance">${Math.round(props.route_distance_m)}m</div>`
-  ].join('');
 }
 
 /** Returns the currently highlighted supply point id. */
@@ -193,6 +205,13 @@ function syncPointHighlight() {
   }
 }
 
+/** Updates active styling in the side list without rebuilding focused elements. */
+function syncPointListSelection() {
+  for (const item of elements.pointList.querySelectorAll('.point-item[data-supply-point-id]')) {
+    item.classList.toggle('active', item.dataset.supplyPointId === String(activeSupplyPointId));
+  }
+}
+
 /** Opens the popup for one rendered feature. */
 function openPopupForFeature(feature) {
   popupOverlay.setPosition(feature.getGeometry().getCoordinates());
@@ -205,9 +224,9 @@ function activatePoint(supplyPointId) {
   activeSupplyPointId = supplyPointId;
   previewSupplyPointId = null;
   syncPointHighlight();
+  syncPointListSelection();
   const feature = findPointFeature(supplyPointId);
   if (feature) openPopupForFeature(feature);
-  buildPointList(matchedPoints);
 }
 
 /** Temporarily previews one supply point from the side list. */
@@ -239,7 +258,7 @@ function clearPopup() {
   elements.popup.hidden = true;
   popupOverlay.setPosition(undefined);
   syncPointHighlight();
-  buildPointList(matchedPoints);
+  syncPointListSelection();
 }
 
 /** Updates summary cards for route points, candidates, and matches. */

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -104,6 +104,7 @@ let routeFeature = null;
 let routeCoordinates = [];
 let matchedPoints = [];
 let activeSupplyPointId = null;
+let previewSupplyPointId = null;
 const API_PAGE_LIMIT = 10000;
 
 /** Updates the top-right status badge. */
@@ -138,10 +139,15 @@ function buildPointList(points) {
       item.classList.add('active');
     }
     item.innerHTML = [
+      `<div class="chain">${escapeHtml(props.chain)}</div>`,
       `<div class="title">${escapeHtml(props.name)}</div>`,
-      `<div class="meta">${escapeHtml(props.chain)} · ${Math.round(props.route_distance_m)}m</div>`,
-      `<div class="meta">${escapeHtml(props.address_norm || '-')}</div>`
+      `<div class="meta">${Math.round(props.route_distance_m)}m</div>`,
+      `<div class="address">${escapeHtml(props.address_norm || '-')}</div>`
     ].join('');
+    item.addEventListener('mouseenter', () => previewPoint(props.supply_point_id));
+    item.addEventListener('mouseleave', () => clearPreviewPoint(props.supply_point_id));
+    item.addEventListener('focus', () => previewPoint(props.supply_point_id));
+    item.addEventListener('blur', () => clearPreviewPoint(props.supply_point_id));
     item.addEventListener('click', () => activatePoint(props.supply_point_id));
     elements.pointList.appendChild(item);
   }
@@ -157,60 +163,82 @@ function escapeHtml(value) {
     .replaceAll("'", '&#39;');
 }
 
-/** Allows only http/https URLs for outbound source links shown in the popup. */
-function safeExternalUrl(value) {
-  if (!value) return null;
-  try {
-    const url = new URL(String(value));
-    if (url.protocol === 'http:' || url.protocol === 'https:') {
-      return url.toString();
-    }
-    return null;
-  } catch {
-    return null;
+/** Builds the popup HTML for a selected supply point. */
+function buildPopupHtml(props) {
+  return [
+    `<div class="popup-chain">${escapeHtml(props.chain)}</div>`,
+    `<div class="popup-title">${escapeHtml(props.name)}</div>`,
+    `<div class="popup-distance">${Math.round(props.route_distance_m)}m</div>`
+  ].join('');
+}
+
+/** Returns the currently highlighted supply point id. */
+function highlightedSupplyPointId() {
+  return previewSupplyPointId ?? activeSupplyPointId;
+}
+
+/** Finds the rendered feature for a supply point id. */
+function findPointFeature(supplyPointId) {
+  return (
+    pointSource.getFeatures().find((feature) => feature.get('properties').supply_point_id === supplyPointId) ||
+    null
+  );
+}
+
+/** Updates marker highlight state from current active or preview selection. */
+function syncPointHighlight() {
+  const highlightedId = highlightedSupplyPointId();
+  for (const feature of pointSource.getFeatures()) {
+    feature.set('active', feature.get('properties').supply_point_id === highlightedId);
   }
 }
 
-/** Builds the popup HTML for a selected supply point. */
-function buildPopupHtml(props) {
-  const safeUrl = safeExternalUrl(props.source_url);
-  const link = safeUrl
-    ? `<a href="${escapeHtml(safeUrl)}" target="_blank" rel="noreferrer">source</a>`
-    : '-';
-  return [
-    `<strong>${escapeHtml(props.name)}</strong>`,
-    `<div>chain: ${escapeHtml(props.chain)}</div>`,
-    `<div>distance: ${Math.round(props.route_distance_m)}m</div>`,
-    `<div>point_level: ${escapeHtml(props.geocode_point_level ?? '-')}</div>`,
-    `<div>updated_at: ${escapeHtml(props.updated_at || '-')}</div>`,
-    `<div>${escapeHtml(props.address_norm || '-')}</div>`,
-    `<div>${link}</div>`
-  ].join('');
+/** Opens the popup for one rendered feature. */
+function openPopupForFeature(feature) {
+  popupOverlay.setPosition(feature.getGeometry().getCoordinates());
+  elements.popupBody.innerHTML = buildPopupHtml(feature.get('properties'));
+  elements.popup.hidden = false;
 }
 
 /** Marks one supply point active and opens its popup. */
 function activatePoint(supplyPointId) {
   activeSupplyPointId = supplyPointId;
-  for (const feature of pointSource.getFeatures()) {
-    const isActive = feature.get('properties').supply_point_id === supplyPointId;
-    feature.set('active', isActive);
-    if (isActive) {
-      popupOverlay.setPosition(feature.getGeometry().getCoordinates());
-      elements.popupBody.innerHTML = buildPopupHtml(feature.get('properties'));
-      elements.popup.hidden = false;
-    }
-  }
+  previewSupplyPointId = null;
+  syncPointHighlight();
+  const feature = findPointFeature(supplyPointId);
+  if (feature) openPopupForFeature(feature);
   buildPointList(matchedPoints);
+}
+
+/** Temporarily previews one supply point from the side list. */
+function previewPoint(supplyPointId) {
+  previewSupplyPointId = supplyPointId;
+  syncPointHighlight();
+  const feature = findPointFeature(supplyPointId);
+  if (feature) openPopupForFeature(feature);
+}
+
+/** Clears one temporary preview and restores the active popup if present. */
+function clearPreviewPoint(supplyPointId) {
+  if (previewSupplyPointId !== supplyPointId) return;
+  previewSupplyPointId = null;
+  syncPointHighlight();
+  const activeFeature = activeSupplyPointId ? findPointFeature(activeSupplyPointId) : null;
+  if (activeFeature) {
+    openPopupForFeature(activeFeature);
+    return;
+  }
+  elements.popup.hidden = true;
+  popupOverlay.setPosition(undefined);
 }
 
 /** Clears popup and active marker state. */
 function clearPopup() {
   activeSupplyPointId = null;
+  previewSupplyPointId = null;
   elements.popup.hidden = true;
   popupOverlay.setPosition(undefined);
-  for (const feature of pointSource.getFeatures()) {
-    feature.set('active', false);
-  }
+  syncPointHighlight();
   buildPointList(matchedPoints);
 }
 
@@ -262,7 +290,7 @@ function renderMatchedPoints(points) {
       geometry: new ol.geom.Point(ol.proj.fromLonLat(feature.geometry.coordinates))
     });
     olFeature.set('properties', feature.properties);
-    olFeature.set('active', feature.properties.supply_point_id === activeSupplyPointId);
+    olFeature.set('active', feature.properties.supply_point_id === highlightedSupplyPointId());
     return olFeature;
   });
   pointSource.addFeatures(features);

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -187,8 +187,9 @@ body {
 .point-item {
   border: 1px solid var(--line);
   background: #fff;
-  padding: 10px;
+  padding: 11px 12px;
   cursor: pointer;
+  text-align: left;
 }
 
 .point-item:hover,
@@ -197,15 +198,32 @@ body {
   box-shadow: inset 0 0 0 1px var(--point);
 }
 
+.point-item .chain {
+  color: var(--accent-deep);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .point-item .title {
-  font-size: 14px;
-  font-weight: 600;
+  margin-top: 4px;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.35;
 }
 
 .point-item .meta {
   margin-top: 4px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.point-item .address {
+  margin-top: 4px;
   font-size: 12px;
   color: var(--muted);
+  line-height: 1.4;
 }
 
 .map-shell {
@@ -220,13 +238,13 @@ body {
 }
 
 .popup {
-  position: absolute;
-  left: 16px;
-  bottom: 16px;
-  width: min(320px, calc(100% - 32px));
-  padding: 12px 14px;
-  background: rgba(255, 253, 247, 0.97);
-  box-shadow: 0 10px 24px rgba(54, 35, 19, 0.12);
+  min-width: 220px;
+  max-width: min(320px, calc(100vw - 40px));
+  padding: 14px 40px 14px 14px;
+  background: rgba(255, 253, 247, 0.98);
+  box-shadow: 0 14px 30px rgba(54, 35, 19, 0.18);
+  border-radius: 14px;
+  writing-mode: horizontal-tb;
 }
 
 .popup[hidden] {
@@ -247,6 +265,30 @@ body {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  font-size: 14px;
+  line-height: 1.4;
+  min-width: 0;
+}
+
+.popup-chain {
+  color: var(--accent-deep);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.popup-title {
+  font-size: 17px;
+  font-weight: 700;
+  line-height: 1.3;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+.popup-distance {
+  margin-top: 2px;
+  color: var(--muted);
   font-size: 13px;
 }
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -196,12 +196,19 @@ body {
 }
 
 .point-item:hover,
-.point-item.active {
+.point-item.active,
+.point-item:focus-visible {
   border-color: var(--point);
   box-shadow: inset 0 0 0 1px var(--point);
 }
 
+.point-item:focus-visible {
+  outline: 2px solid var(--point);
+  outline-offset: 2px;
+}
+
 .point-item .chain {
+  display: block;
   color: var(--accent-deep);
   font-size: 11px;
   font-weight: 700;
@@ -210,6 +217,7 @@ body {
 }
 
 .point-item .title {
+  display: block;
   margin-top: 4px;
   font-size: 15px;
   font-weight: 700;
@@ -217,12 +225,14 @@ body {
 }
 
 .point-item .meta {
+  display: block;
   margin-top: 4px;
   font-size: 13px;
   color: var(--muted);
 }
 
 .point-item .address {
+  display: block;
   margin-top: 4px;
   font-size: 12px;
   color: var(--muted);

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -150,6 +150,7 @@ body {
   grid-template-columns: 280px 1fr;
   gap: 12px;
   min-height: 600px;
+  align-items: start;
 }
 
 .sidebar {
@@ -157,6 +158,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  height: 600px;
+  min-height: 600px;
 }
 
 .summary-card {
@@ -228,12 +231,13 @@ body {
 
 .map-shell {
   position: relative;
+  height: 600px;
   min-height: 600px;
 }
 
 .map {
   height: 100%;
-  min-height: 600px;
+  min-height: 0;
   border: 1px solid var(--line);
 }
 
@@ -306,7 +310,9 @@ body {
   }
 
   .map,
+  .sidebar,
   .map-shell {
+    height: 440px;
     min-height: 440px;
   }
 }


### PR DESCRIPTION
## Summary
- refine the supply point sidebar information hierarchy and popup layout
- show the map popup when hovering or focusing items in the side list
- keep the map height fixed even when the sidebar list grows

## Testing
- not run (frontend visual changes only)