### PR TITLE
地図検索UIを自動更新型に整理

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,14 +1,20 @@
 const API_BASE = window.RIDEOASIS_API_BASE || '/api';
 
+const PRECISE_POINT_LEVEL = 8;
+const DEFAULT_MIN_POINT_LEVEL = 3;
+const DISTANCE_OPTIONS = [100, 250, 500, 1000, 2000, 5000, 10000];
+
 const elements = {
   status: document.getElementById('status'),
   gpxFile: document.getElementById('gpx-file'),
   useCurrentLocation: document.getElementById('use-current-location'),
-  distanceThreshold: document.getElementById('distance-threshold'),
-  minPointLevel: document.getElementById('min-point-level'),
-  refresh: document.getElementById('refresh'),
-  pointList: document.getElementById('point-list'),
+  gpxPanel: document.getElementById('gpx-panel'),
+  currentLocationPanel: document.getElementById('current-location-panel'),
+  gpxFileName: document.getElementById('gpx-file-name'),
   routePointCount: document.getElementById('route-point-count'),
+  distanceThreshold: document.getElementById('distance-threshold'),
+  distanceCurrent: document.getElementById('distance-current'),
+  pointList: document.getElementById('point-list'),
   candidateCount: document.getElementById('candidate-count'),
   matchedCount: document.getElementById('matched-count'),
   popup: document.getElementById('popup'),
@@ -102,21 +108,82 @@ map.addOverlay(popupOverlay);
 
 let routeFeature = null;
 let routeCoordinates = [];
-let matchedPoints = [];
+let allMatchedPoints = [];
+let filteredPoints = [];
 let activeSupplyPointId = null;
 let previewSupplyPointId = null;
+let lastCandidateCount = 0;
 const API_PAGE_LIMIT = 10000;
+
+/** Returns the currently selected route source mode. */
+function selectedSourceMode() {
+  return document.querySelector('input[name="source-mode"]:checked')?.value || 'gpx';
+}
+
+/** Formats a distance for compact UI labels. */
+function formatDistance(distanceMeters) {
+  return distanceMeters >= 1000 ? `${distanceMeters / 1000}km` : `${distanceMeters}m`;
+}
+
+/** Returns the selected ladder distance in meters. */
+function selectedDistanceMeters() {
+  const index = Number(elements.distanceThreshold?.value);
+  return DISTANCE_OPTIONS[index] ?? 1000;
+}
+
+/** Syncs the visible distance label beside the ladder. */
+function syncDistanceUi() {
+  elements.distanceCurrent.textContent = formatDistance(selectedDistanceMeters());
+}
+
+/** Returns the currently enabled chain filters from the result toolbar. */
+function selectedResultChains() {
+  return Array.from(document.querySelectorAll('.chain-filters input[type="checkbox"]:checked')).map(
+    (input) => input.value
+  );
+}
+
+/** Returns the active precision filters for result narrowing. */
+function selectedPrecisionFilters() {
+  return new Set(
+    Array.from(document.querySelectorAll('input[name="precision-filter"]:checked')).map((input) => input.value)
+  );
+}
+
+/** Maps point level to a UI-friendly precision label. */
+function precisionLabel(pointLevel) {
+  return Number(pointLevel) >= PRECISE_POINT_LEVEL ? '正確' : 'あいまい';
+}
 
 /** Updates the top-right status badge. */
 function setStatus(message) {
   elements.status.textContent = message;
 }
 
-/** Returns the currently enabled chain filters from the UI. */
-function selectedChains() {
-  return Array.from(document.querySelectorAll('.chains input[type="checkbox"]:checked')).map(
-    (input) => input.value
-  );
+/** Syncs source-mode panel state so only one input path is active at a time. */
+function syncSourceModeUi() {
+  const gpxActive = selectedSourceMode() === 'gpx';
+  elements.gpxFile.disabled = !gpxActive;
+  elements.useCurrentLocation.disabled = gpxActive;
+  elements.gpxPanel.classList.toggle('inactive', !gpxActive);
+  elements.currentLocationPanel.classList.toggle('inactive', gpxActive);
+}
+
+/** Resets visible and cached result points before a new search. */
+function resetResults() {
+  allMatchedPoints = [];
+  filteredPoints = [];
+  lastCandidateCount = 0;
+  pointSource.clear();
+  buildPointList([]);
+  updateSummary(0, 0);
+  clearPopup();
+}
+
+/** Updates route-point count near the route input controls. */
+function updateRoutePointCount() {
+  const count = routeCoordinates.length;
+  elements.routePointCount.textContent = `経路点数: ${count > 0 ? count : '-'}`;
 }
 
 /** Renders the matched supply point list beside the map. */
@@ -125,7 +192,7 @@ function buildPointList(points) {
   if (points.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'point-item';
-    empty.textContent = '近傍の補給地点は見つかりませんでした';
+    empty.textContent = '該当する補給地点はありません';
     elements.pointList.appendChild(empty);
     return;
   }
@@ -139,6 +206,7 @@ function buildPointList(points) {
     if (props.supply_point_id === activeSupplyPointId) {
       item.classList.add('active');
     }
+
     const chain = document.createElement('span');
     chain.className = 'chain';
     chain.textContent = props.chain;
@@ -149,7 +217,7 @@ function buildPointList(points) {
 
     const meta = document.createElement('span');
     meta.className = 'meta';
-    meta.textContent = `${Math.round(props.route_distance_m)}m`;
+    meta.textContent = `${Math.round(props.route_distance_m)}m ・ ${precisionLabel(props.geocode_point_level)}`;
 
     const address = document.createElement('span');
     address.className = 'address';
@@ -170,7 +238,7 @@ function buildPopupHtml(props) {
   return [
     `<div class="popup-chain">${escapeHtml(props.chain)}</div>`,
     `<div class="popup-title">${escapeHtml(props.name)}</div>`,
-    `<div class="popup-distance">${Math.round(props.route_distance_m)}m</div>`
+    `<div class="popup-distance">${Math.round(props.route_distance_m)}m ・ ${escapeHtml(precisionLabel(props.geocode_point_level))}</div>`
   ].join('');
 }
 
@@ -261,11 +329,10 @@ function clearPopup() {
   syncPointListSelection();
 }
 
-/** Updates summary cards for route points, candidates, and matches. */
-function updateSummary(candidateCount, matchedCount) {
-  elements.routePointCount.textContent = routeCoordinates.length ? String(routeCoordinates.length) : '-';
+/** Updates summary cards for API candidates and visible results. */
+function updateSummary(candidateCount, visibleCount) {
   elements.candidateCount.textContent = String(candidateCount);
-  elements.matchedCount.textContent = String(matchedCount);
+  elements.matchedCount.textContent = String(visibleCount);
 }
 
 /** Renders the uploaded route and its start/end markers. */
@@ -277,13 +344,9 @@ function renderRoute(feature) {
 
   const coordinates = feature.getGeometry().getCoordinates();
   if (coordinates.length >= 2) {
-    const start = new ol.Feature({
-      geometry: new ol.geom.Point(coordinates[0])
-    });
+    const start = new ol.Feature({ geometry: new ol.geom.Point(coordinates[0]) });
     start.set('kind', 'start');
-    const goal = new ol.Feature({
-      geometry: new ol.geom.Point(coordinates[coordinates.length - 1])
-    });
+    const goal = new ol.Feature({ geometry: new ol.geom.Point(coordinates[coordinates.length - 1]) });
     goal.set('kind', 'goal');
     endpointSource.addFeatures([start, goal]);
   }
@@ -346,8 +409,6 @@ function expandedBboxForQuery(distanceMeters) {
 
 /** Loads candidate supply points from the local API for the current filters. */
 async function fetchCandidatePoints(distanceMeters) {
-  const chains = selectedChains();
-  const minPointLevel = Number(elements.minPointLevel.value) || 8;
   const bbox = expandedBboxForQuery(distanceMeters);
   const features = [];
   const seenIds = new Set();
@@ -358,8 +419,7 @@ async function fetchCandidatePoints(distanceMeters) {
     if (bbox) {
       params.set('bbox', bbox.join(','));
     }
-    params.set('chains', chains.length > 0 ? chains.join(',') : '');
-    params.set('min_point_level', String(minPointLevel));
+    params.set('min_point_level', String(DEFAULT_MIN_POINT_LEVEL));
     params.set('limit', String(API_PAGE_LIMIT));
     params.set('offset', String(offset));
 
@@ -407,40 +467,58 @@ function filterMatchedPoints(featureCollection, distanceMeters) {
     .sort((a, b) => a.properties.route_distance_m - b.properties.route_distance_m);
 }
 
+/** Applies result-screen chain and precision filters without requerying the API. */
+function applyResultFilters() {
+  const chains = new Set(selectedResultChains());
+  const precisionFilters = selectedPrecisionFilters();
+  filteredPoints = allMatchedPoints.filter((feature) => {
+    const chainMatched = chains.has(feature.properties.chain);
+    const precisionMatched = precisionFilters.has(
+      Number(feature.properties.geocode_point_level) >= PRECISE_POINT_LEVEL ? 'precise' : 'rough'
+    );
+    return chainMatched && precisionMatched;
+  });
+  clearPopup();
+  renderMatchedPoints(filteredPoints);
+  buildPointList(filteredPoints);
+  updateSummary(lastCandidateCount, filteredPoints.length);
+  fitToVisibleData();
+  setStatus(`${filteredPoints.length} 件を表示中`);
+}
+
 /** Refreshes API candidates and matched points for the loaded route. */
 async function refreshMap() {
   if (!routeCoordinates.length) {
-    setStatus('先に GPX か現在地を読み込んでください');
+    setStatus('先に GPX か現在地を指定してください');
     return;
   }
 
   clearPopup();
-  const distanceMeters = Math.max(100, Number(elements.distanceThreshold.value) || 1000);
+  const distanceMeters = selectedDistanceMeters();
   setStatus('補給地点を検索中...');
 
   try {
     const candidates = await fetchCandidatePoints(distanceMeters);
-    matchedPoints = filterMatchedPoints(candidates, distanceMeters);
-    renderMatchedPoints(matchedPoints);
-    buildPointList(matchedPoints);
-    updateSummary(candidates.features.length, matchedPoints.length);
-    fitToVisibleData();
-    setStatus(`${matchedPoints.length} 件の補給地点が ${distanceMeters}m 以内にあります`);
+    allMatchedPoints = filterMatchedPoints(candidates, distanceMeters);
+    lastCandidateCount = candidates.features.length;
+    applyResultFilters();
   } catch (error) {
     setStatus('補給地点の取得に失敗しました');
     console.error(error);
   }
 }
 
-/** Reads the selected GPX file and triggers the initial map render. */
+/** Reads the selected GPX file and refreshes the map candidates. */
 async function handleGpxFile(event) {
   const file = event.target.files?.[0];
   if (!file) return;
   try {
+    elements.gpxFileName.textContent = file.name;
     const gpxText = await file.text();
     routeFeature = createRouteFeatureFromGpx(gpxText);
     renderRoute(routeFeature);
-    updateSummary(0, 0);
+    resetResults();
+    updateRoutePointCount();
     fitToVisibleData();
     setStatus(`GPX を読み込みました: ${file.name}`);
     await refreshMap();
@@ -470,7 +548,8 @@ async function handleCurrentLocation() {
     routeFeature = null;
     routeCoordinates = [coord];
     renderCurrentLocation(coord);
-    updateSummary(0, 0);
+    resetResults();
+    updateRoutePointCount();
     fitToVisibleData();
     setStatus('現在地を取得しました');
     await refreshMap();
@@ -487,9 +566,21 @@ async function handleCurrentLocation() {
 
 /** Wires DOM and map click events for the static frontend. */
 function bindEvents() {
+  for (const input of document.querySelectorAll('input[name="source-mode"]')) {
+    input.addEventListener('change', syncSourceModeUi);
+  }
+  elements.distanceThreshold?.addEventListener('input', syncDistanceUi);
+  elements.distanceThreshold?.addEventListener('change', () => {
+    syncDistanceUi();
+    if (routeCoordinates.length) {
+      refreshMap();
+    }
+  });
+  for (const input of document.querySelectorAll('.result-filters input[type="checkbox"]')) {
+    input.addEventListener('change', applyResultFilters);
+  }
   elements.gpxFile.addEventListener('change', handleGpxFile);
   elements.useCurrentLocation?.addEventListener('click', handleCurrentLocation);
-  elements.refresh?.addEventListener('click', refreshMap);
   elements.popupClose.addEventListener('click', clearPopup);
   map.on('singleclick', (event) => {
     const feature = map.forEachFeatureAtPixel(event.pixel, (candidate) => candidate);
@@ -501,4 +592,9 @@ function bindEvents() {
   });
 }
 
+syncSourceModeUi();
+updateRoutePointCount();
+syncDistanceUi();
+buildPointList([]);
+updateSummary(0, 0);
 bindEvents();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -135,15 +135,27 @@ function buildPointList(points) {
     const item = document.createElement('button');
     item.type = 'button';
     item.className = 'point-item';
+    item.dataset.supplyPointId = String(props.supply_point_id);
     if (props.supply_point_id === activeSupplyPointId) {
       item.classList.add('active');
     }
-    item.innerHTML = [
-      `<div class="chain">${escapeHtml(props.chain)}</div>`,
-      `<div class="title">${escapeHtml(props.name)}</div>`,
-      `<div class="meta">${Math.round(props.route_distance_m)}m</div>`,
-      `<div class="address">${escapeHtml(props.address_norm || '-')}</div>`
-    ].join('');
+    const chain = document.createElement('span');
+    chain.className = 'chain';
+    chain.textContent = props.chain;
+
+    const title = document.createElement('span');
+    title.className = 'title';
+    title.textContent = props.name;
+
+    const meta = document.createElement('span');
+    meta.className = 'meta';
+    meta.textContent = `${Math.round(props.route_distance_m)}m`;
+
+    const address = document.createElement('span');
+    address.className = 'address';
+    address.textContent = props.address_norm || '-';
+
+    item.append(chain, title, meta, address);
     item.addEventListener('mouseenter', () => previewPoint(props.supply_point_id));
     item.addEventListener('mouseleave', () => clearPreviewPoint(props.supply_point_id));
     item.addEventListener('focus', () => previewPoint(props.supply_point_id));
@@ -151,6 +163,15 @@ function buildPointList(points) {
     item.addEventListener('click', () => activatePoint(props.supply_point_id));
     elements.pointList.appendChild(item);
   }
+}
+
+/** Builds the popup HTML for a selected supply point. */
+function buildPopupHtml(props) {
+  return [
+    `<div class="popup-chain">${escapeHtml(props.chain)}</div>`,
+    `<div class="popup-title">${escapeHtml(props.name)}</div>`,
+    `<div class="popup-distance">${Math.round(props.route_distance_m)}m</div>`
+  ].join('');
 }
 
 /** Escapes text before inserting it into HTML fragments. */
@@ -161,15 +182,6 @@ function escapeHtml(value) {
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
-}
-
-/** Builds the popup HTML for a selected supply point. */
-function buildPopupHtml(props) {
-  return [
-    `<div class="popup-chain">${escapeHtml(props.chain)}</div>`,
-    `<div class="popup-title">${escapeHtml(props.name)}</div>`,
-    `<div class="popup-distance">${Math.round(props.route_distance_m)}m</div>`
-  ].join('');
 }
 
 /** Returns the currently highlighted supply point id. */
@@ -193,6 +205,13 @@ function syncPointHighlight() {
   }
 }
 
+/** Updates active styling in the side list without rebuilding focused elements. */
+function syncPointListSelection() {
+  for (const item of elements.pointList.querySelectorAll('.point-item[data-supply-point-id]')) {
+    item.classList.toggle('active', item.dataset.supplyPointId === String(activeSupplyPointId));
+  }
+}
+
 /** Opens the popup for one rendered feature. */
 function openPopupForFeature(feature) {
   popupOverlay.setPosition(feature.getGeometry().getCoordinates());
@@ -205,9 +224,9 @@ function activatePoint(supplyPointId) {
   activeSupplyPointId = supplyPointId;
   previewSupplyPointId = null;
   syncPointHighlight();
+  syncPointListSelection();
   const feature = findPointFeature(supplyPointId);
   if (feature) openPopupForFeature(feature);
-  buildPointList(matchedPoints);
 }
 
 /** Temporarily previews one supply point from the side list. */
@@ -239,7 +258,7 @@ function clearPopup() {
   elements.popup.hidden = true;
   popupOverlay.setPosition(undefined);
   syncPointHighlight();
-  buildPointList(matchedPoints);
+  syncPointListSelection();
 }
 
 /** Updates summary cards for route points, candidates, and matches. */

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -111,7 +111,6 @@ let allMatchedPoints = [];
 let filteredPoints = [];
 let activeSupplyPointId = null;
 let previewSupplyPointId = null;
-let lastCandidateCount = 0;
 const API_PAGE_LIMIT = 10000;
 
 /** Returns the currently selected route source mode. */
@@ -126,13 +125,15 @@ function formatDistance(distanceMeters) {
 
 /** Returns the selected ladder distance in meters. */
 function selectedDistanceMeters() {
-  const index = Number(elements.distanceThreshold?.value);
+  const index = Number(elements.distanceThreshold.value);
   return DISTANCE_OPTIONS[index] ?? 1000;
 }
 
 /** Syncs the visible distance label beside the ladder. */
 function syncDistanceUi() {
-  elements.distanceCurrent.textContent = formatDistance(selectedDistanceMeters());
+  const distanceText = formatDistance(selectedDistanceMeters());
+  elements.distanceCurrent.textContent = distanceText;
+  elements.distanceThreshold.setAttribute('aria-valuetext', `${distanceText}以内`);
 }
 
 /** Returns the currently enabled chain filters from the result toolbar. */
@@ -172,10 +173,9 @@ function syncSourceModeUi() {
 function resetResults() {
   allMatchedPoints = [];
   filteredPoints = [];
-  lastCandidateCount = 0;
   pointSource.clear();
   buildPointList([]);
-  updateSummary(0, 0);
+  updateSummary(0);
   clearPopup();
 }
 
@@ -329,7 +329,7 @@ function clearPopup() {
 }
 
 /** Updates summary card for visible results. */
-function updateSummary(_candidateCount, visibleCount) {
+function updateSummary(visibleCount) {
   elements.matchedCount.textContent = String(visibleCount);
 }
 
@@ -469,6 +469,8 @@ function filterMatchedPoints(featureCollection, distanceMeters) {
 function applyResultFilters() {
   const chains = new Set(selectedResultChains());
   const precisionFilters = selectedPrecisionFilters();
+  const activeId = activeSupplyPointId;
+  const previewId = previewSupplyPointId;
   filteredPoints = allMatchedPoints.filter((feature) => {
     const chainMatched = chains.has(feature.properties.chain);
     const precisionMatched = precisionFilters.has(
@@ -476,10 +478,26 @@ function applyResultFilters() {
     );
     return chainMatched && precisionMatched;
   });
-  clearPopup();
+  const visibleIds = new Set(filteredPoints.map((feature) => feature.properties.supply_point_id));
+  if (activeId && !visibleIds.has(activeId)) {
+    activeSupplyPointId = null;
+  }
+  if (previewId && !visibleIds.has(previewId)) {
+    previewSupplyPointId = null;
+  }
   renderMatchedPoints(filteredPoints);
   buildPointList(filteredPoints);
-  updateSummary(lastCandidateCount, filteredPoints.length);
+  syncPointHighlight();
+  syncPointListSelection();
+  const highlightedId = highlightedSupplyPointId();
+  const highlightedFeature = highlightedId ? findPointFeature(highlightedId) : null;
+  if (highlightedFeature) {
+    openPopupForFeature(highlightedFeature);
+  } else {
+    elements.popup.hidden = true;
+    popupOverlay.setPosition(undefined);
+  }
+  updateSummary(filteredPoints.length);
   fitToVisibleData();
   setStatus(`${filteredPoints.length} 件を表示中`);
 }
@@ -498,7 +516,6 @@ async function refreshMap() {
   try {
     const candidates = await fetchCandidatePoints(distanceMeters);
     allMatchedPoints = filterMatchedPoints(candidates, distanceMeters);
-    lastCandidateCount = candidates.features.length;
     applyResultFilters();
   } catch (error) {
     setStatus('補給地点の取得に失敗しました');
@@ -567,8 +584,8 @@ function bindEvents() {
   for (const input of document.querySelectorAll('input[name="source-mode"]')) {
     input.addEventListener('change', syncSourceModeUi);
   }
-  elements.distanceThreshold?.addEventListener('input', syncDistanceUi);
-  elements.distanceThreshold?.addEventListener('change', () => {
+  elements.distanceThreshold.addEventListener('input', syncDistanceUi);
+  elements.distanceThreshold.addEventListener('change', () => {
     syncDistanceUi();
     if (routeCoordinates.length) {
       refreshMap();
@@ -594,5 +611,5 @@ syncSourceModeUi();
 updateRoutePointCount();
 syncDistanceUi();
 buildPointList([]);
-updateSummary(0, 0);
+updateSummary(0);
 bindEvents();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -113,6 +113,8 @@ let activeSupplyPointId = null;
 let previewSupplyPointId = null;
 const API_PAGE_LIMIT = 10000;
 const featureIndex = new Map();
+let latestRouteLoadToken = 0;
+let latestRefreshToken = 0;
 
 /** Returns the currently selected route source mode. */
 function selectedSourceMode() {
@@ -185,6 +187,11 @@ function resetResults() {
 function updateRoutePointCount() {
   const count = routeCoordinates.length;
   elements.routePointCount.textContent = `経路点数: ${count > 0 ? count : '-'}`;
+}
+
+/** Invalidates in-flight candidate refreshes after route source changes. */
+function cancelPendingRefreshes() {
+  latestRefreshToken += 1;
 }
 
 /** Renders the matched supply point list beside the map. */
@@ -401,19 +408,21 @@ function fitToVisibleData() {
 /** Parses GPX text and converts it into an OpenLayers route feature. */
 function createRouteFeatureFromGpx(gpxText) {
   const parsed = window.GpxParser.parseGpxText(gpxText);
-  routeCoordinates = parsed.geometry.coordinates;
-  return routeGeoJsonFormat.readFeature(parsed);
+  return {
+    coordinates: parsed.geometry.coordinates,
+    feature: routeGeoJsonFormat.readFeature(parsed)
+  };
 }
 
 /** Expands the route bbox so the API can return nearby candidate points. */
-function expandedBboxForQuery(distanceMeters) {
-  const routeBbox = window.RouteMath.computeBbox(routeCoordinates);
+function expandedBboxForQuery(routeSnapshot, distanceMeters) {
+  const routeBbox = window.RouteMath.computeBbox(routeSnapshot);
   return window.RouteMath.expandBbox(routeBbox, Math.max(distanceMeters, 2000));
 }
 
 /** Loads candidate supply points from the local API for the current filters. */
-async function fetchCandidatePoints(distanceMeters) {
-  const bbox = expandedBboxForQuery(distanceMeters);
+async function fetchCandidatePoints(routeSnapshot, distanceMeters) {
+  const bbox = expandedBboxForQuery(routeSnapshot, distanceMeters);
   const features = [];
   const seenIds = new Set();
   let offset = 0;
@@ -452,12 +461,12 @@ async function fetchCandidatePoints(distanceMeters) {
 }
 
 /** Applies the browser-side point-to-route distance filter. */
-function filterMatchedPoints(featureCollection, distanceMeters) {
-  const origin = routeCoordinates[0] || null;
+function filterMatchedPoints(featureCollection, routeSnapshot, distanceMeters) {
+  const origin = routeSnapshot[0] || null;
   return featureCollection.features
     .map((feature) => {
-      const distance = routeCoordinates.length >= 2
-        ? window.RouteMath.pointToRouteDistanceMeters(feature.geometry.coordinates, routeCoordinates)
+      const distance = routeSnapshot.length >= 2
+        ? window.RouteMath.pointToRouteDistanceMeters(feature.geometry.coordinates, routeSnapshot)
         : window.RouteMath.pointToPointDistanceMeters(feature.geometry.coordinates, origin);
       return {
         ...feature,
@@ -509,21 +518,25 @@ function applyResultFilters() {
 }
 
 /** Refreshes API candidates and matched points for the loaded route. */
-async function refreshMap() {
-  if (!routeCoordinates.length) {
+async function refreshMap(routeSnapshot = [...routeCoordinates]) {
+  if (!routeSnapshot.length) {
     setStatus('先に GPX か現在地を指定してください');
     return;
   }
 
   clearPopup();
   const distanceMeters = selectedDistanceMeters();
+  const refreshToken = ++latestRefreshToken;
   setStatus('補給地点を検索中...');
 
   try {
-    const candidates = await fetchCandidatePoints(distanceMeters);
-    allMatchedPoints = filterMatchedPoints(candidates, distanceMeters);
+    const candidates = await fetchCandidatePoints(routeSnapshot, distanceMeters);
+    if (refreshToken !== latestRefreshToken) return;
+    allMatchedPoints = filterMatchedPoints(candidates, routeSnapshot, distanceMeters);
+    if (refreshToken !== latestRefreshToken) return;
     applyResultFilters();
   } catch (error) {
+    if (refreshToken !== latestRefreshToken) return;
     setStatus('補給地点の取得に失敗しました');
     console.error(error);
   }
@@ -533,17 +546,26 @@ async function refreshMap() {
 async function handleGpxFile(event) {
   const file = event.target.files?.[0];
   if (!file) return;
+  const loadToken = ++latestRouteLoadToken;
+  cancelPendingRefreshes();
+  const previousFileName = elements.gpxFileName.textContent;
   try {
-    elements.gpxFileName.textContent = file.name;
     const gpxText = await file.text();
-    routeFeature = createRouteFeatureFromGpx(gpxText);
+    if (loadToken !== latestRouteLoadToken) return;
+    const parsedRoute = createRouteFeatureFromGpx(gpxText);
+    if (loadToken !== latestRouteLoadToken) return;
+    routeFeature = parsedRoute.feature;
+    routeCoordinates = parsedRoute.coordinates;
+    elements.gpxFileName.textContent = file.name;
     renderRoute(routeFeature);
     resetResults();
     updateRoutePointCount();
     fitToVisibleData();
     setStatus(`GPX を読み込みました: ${file.name}`);
-    await refreshMap();
+    await refreshMap([...routeCoordinates]);
   } catch (error) {
+    if (loadToken !== latestRouteLoadToken) return;
+    elements.gpxFileName.textContent = previousFileName;
     setStatus(error?.message || 'GPX の読み込みに失敗しました');
     console.error(error);
   }
@@ -556,6 +578,8 @@ async function handleCurrentLocation() {
     return;
   }
 
+  const loadToken = ++latestRouteLoadToken;
+  cancelPendingRefreshes();
   setStatus('現在地を取得中...');
   try {
     const position = await new Promise((resolve, reject) => {
@@ -565,6 +589,7 @@ async function handleCurrentLocation() {
         maximumAge: 60000
       });
     });
+    if (loadToken !== latestRouteLoadToken) return;
     const coord = [position.coords.longitude, position.coords.latitude];
     routeFeature = null;
     routeCoordinates = [coord];
@@ -573,8 +598,9 @@ async function handleCurrentLocation() {
     updateRoutePointCount();
     fitToVisibleData();
     setStatus('現在地を取得しました');
-    await refreshMap();
+    await refreshMap([...routeCoordinates]);
   } catch (error) {
+    if (loadToken !== latestRouteLoadToken) return;
     const message = error?.code === 1
       ? '位置情報の利用が許可されていません'
       : error?.code === 3

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -104,6 +104,7 @@ let routeFeature = null;
 let routeCoordinates = [];
 let matchedPoints = [];
 let activeSupplyPointId = null;
+let previewSupplyPointId = null;
 const API_PAGE_LIMIT = 10000;
 
 /** Updates the top-right status badge. */
@@ -138,10 +139,15 @@ function buildPointList(points) {
       item.classList.add('active');
     }
     item.innerHTML = [
+      `<div class="chain">${escapeHtml(props.chain)}</div>`,
       `<div class="title">${escapeHtml(props.name)}</div>`,
-      `<div class="meta">${escapeHtml(props.chain)} · ${Math.round(props.route_distance_m)}m</div>`,
-      `<div class="meta">${escapeHtml(props.address_norm || '-')}</div>`
+      `<div class="meta">${Math.round(props.route_distance_m)}m</div>`,
+      `<div class="address">${escapeHtml(props.address_norm || '-')}</div>`
     ].join('');
+    item.addEventListener('mouseenter', () => previewPoint(props.supply_point_id));
+    item.addEventListener('mouseleave', () => clearPreviewPoint(props.supply_point_id));
+    item.addEventListener('focus', () => previewPoint(props.supply_point_id));
+    item.addEventListener('blur', () => clearPreviewPoint(props.supply_point_id));
     item.addEventListener('click', () => activatePoint(props.supply_point_id));
     elements.pointList.appendChild(item);
   }
@@ -157,60 +163,82 @@ function escapeHtml(value) {
     .replaceAll("'", '&#39;');
 }
 
-/** Allows only http/https URLs for outbound source links shown in the popup. */
-function safeExternalUrl(value) {
-  if (!value) return null;
-  try {
-    const url = new URL(String(value));
-    if (url.protocol === 'http:' || url.protocol === 'https:') {
-      return url.toString();
-    }
-    return null;
-  } catch {
-    return null;
+/** Builds the popup HTML for a selected supply point. */
+function buildPopupHtml(props) {
+  return [
+    `<div class="popup-chain">${escapeHtml(props.chain)}</div>`,
+    `<div class="popup-title">${escapeHtml(props.name)}</div>`,
+    `<div class="popup-distance">${Math.round(props.route_distance_m)}m</div>`
+  ].join('');
+}
+
+/** Returns the currently highlighted supply point id. */
+function highlightedSupplyPointId() {
+  return previewSupplyPointId ?? activeSupplyPointId;
+}
+
+/** Finds the rendered feature for a supply point id. */
+function findPointFeature(supplyPointId) {
+  return (
+    pointSource.getFeatures().find((feature) => feature.get('properties').supply_point_id === supplyPointId) ||
+    null
+  );
+}
+
+/** Updates marker highlight state from current active or preview selection. */
+function syncPointHighlight() {
+  const highlightedId = highlightedSupplyPointId();
+  for (const feature of pointSource.getFeatures()) {
+    feature.set('active', feature.get('properties').supply_point_id === highlightedId);
   }
 }
 
-/** Builds the popup HTML for a selected supply point. */
-function buildPopupHtml(props) {
-  const safeUrl = safeExternalUrl(props.source_url);
-  const link = safeUrl
-    ? `<a href="${escapeHtml(safeUrl)}" target="_blank" rel="noreferrer">source</a>`
-    : '-';
-  return [
-    `<strong>${escapeHtml(props.name)}</strong>`,
-    `<div>chain: ${escapeHtml(props.chain)}</div>`,
-    `<div>distance: ${Math.round(props.route_distance_m)}m</div>`,
-    `<div>point_level: ${escapeHtml(props.geocode_point_level ?? '-')}</div>`,
-    `<div>updated_at: ${escapeHtml(props.updated_at || '-')}</div>`,
-    `<div>${escapeHtml(props.address_norm || '-')}</div>`,
-    `<div>${link}</div>`
-  ].join('');
+/** Opens the popup for one rendered feature. */
+function openPopupForFeature(feature) {
+  popupOverlay.setPosition(feature.getGeometry().getCoordinates());
+  elements.popupBody.innerHTML = buildPopupHtml(feature.get('properties'));
+  elements.popup.hidden = false;
 }
 
 /** Marks one supply point active and opens its popup. */
 function activatePoint(supplyPointId) {
   activeSupplyPointId = supplyPointId;
-  for (const feature of pointSource.getFeatures()) {
-    const isActive = feature.get('properties').supply_point_id === supplyPointId;
-    feature.set('active', isActive);
-    if (isActive) {
-      popupOverlay.setPosition(feature.getGeometry().getCoordinates());
-      elements.popupBody.innerHTML = buildPopupHtml(feature.get('properties'));
-      elements.popup.hidden = false;
-    }
-  }
+  previewSupplyPointId = null;
+  syncPointHighlight();
+  const feature = findPointFeature(supplyPointId);
+  if (feature) openPopupForFeature(feature);
   buildPointList(matchedPoints);
+}
+
+/** Temporarily previews one supply point from the side list. */
+function previewPoint(supplyPointId) {
+  previewSupplyPointId = supplyPointId;
+  syncPointHighlight();
+  const feature = findPointFeature(supplyPointId);
+  if (feature) openPopupForFeature(feature);
+}
+
+/** Clears one temporary preview and restores the active popup if present. */
+function clearPreviewPoint(supplyPointId) {
+  if (previewSupplyPointId !== supplyPointId) return;
+  previewSupplyPointId = null;
+  syncPointHighlight();
+  const activeFeature = activeSupplyPointId ? findPointFeature(activeSupplyPointId) : null;
+  if (activeFeature) {
+    openPopupForFeature(activeFeature);
+    return;
+  }
+  elements.popup.hidden = true;
+  popupOverlay.setPosition(undefined);
 }
 
 /** Clears popup and active marker state. */
 function clearPopup() {
   activeSupplyPointId = null;
+  previewSupplyPointId = null;
   elements.popup.hidden = true;
   popupOverlay.setPosition(undefined);
-  for (const feature of pointSource.getFeatures()) {
-    feature.set('active', false);
-  }
+  syncPointHighlight();
   buildPointList(matchedPoints);
 }
 
@@ -262,7 +290,7 @@ function renderMatchedPoints(points) {
       geometry: new ol.geom.Point(ol.proj.fromLonLat(feature.geometry.coordinates))
     });
     olFeature.set('properties', feature.properties);
-    olFeature.set('active', feature.properties.supply_point_id === activeSupplyPointId);
+    olFeature.set('active', feature.properties.supply_point_id === highlightedSupplyPointId());
     return olFeature;
   });
   pointSource.addFeatures(features);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -15,7 +15,6 @@ const elements = {
   distanceThreshold: document.getElementById('distance-threshold'),
   distanceCurrent: document.getElementById('distance-current'),
   pointList: document.getElementById('point-list'),
-  candidateCount: document.getElementById('candidate-count'),
   matchedCount: document.getElementById('matched-count'),
   popup: document.getElementById('popup'),
   popupBody: document.getElementById('popup-body'),
@@ -329,9 +328,8 @@ function clearPopup() {
   syncPointListSelection();
 }
 
-/** Updates summary cards for API candidates and visible results. */
-function updateSummary(candidateCount, visibleCount) {
-  elements.candidateCount.textContent = String(candidateCount);
+/** Updates summary card for visible results. */
+function updateSummary(_candidateCount, visibleCount) {
   elements.matchedCount.textContent = String(visibleCount);
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -44,7 +44,9 @@
 
         <fieldset class="distance-ladder">
           <legend>近傍距離</legend>
-          <div class="distance-current" id="distance-current">1km</div>
+          <div class="distance-header">
+            <div class="distance-current" id="distance-current">1km</div>
+          </div>
           <input
             id="distance-threshold"
             type="range"
@@ -77,19 +79,8 @@
 
       <section class="content">
         <aside class="sidebar">
-          <div class="summary-row">
-            <div class="summary-card compact">
-              <div class="summary-label">候補</div>
-              <div class="summary-value" id="candidate-count">-</div>
-            </div>
-            <div class="summary-card compact">
-              <div class="summary-label">表示</div>
-              <div class="summary-value" id="matched-count">-</div>
-            </div>
-          </div>
-
-          <details class="filter-panel" open>
-            <summary>絞り込み</summary>
+          <details class="filter-panel">
+            <summary>絞り込み <span class="filter-summary-count">表示 <span id="matched-count">-</span></span></summary>
             <fieldset class="chains result-filters chain-filters">
               <legend>チェーン</legend>
               <label><input type="checkbox" value="7eleven" checked />7-Eleven</label>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,56 +15,98 @@
       <header class="topbar">
         <div>
           <h1>RideOasis Map</h1>
-          <p class="subtitle">GPX 経路または現在地の近傍にある補給地点を可視化</p>
+          <p class="subtitle">位置と近傍距離だけ決めて、結果をあとから絞り込む</p>
         </div>
-        <div class="status" id="status">GPX か現在地を読み込んでください</div>
+        <div class="status" id="status">GPX か現在地を指定してください</div>
       </header>
 
       <section class="panel controls">
-        <label class="file-input">
-          <span>GPX ファイル</span>
-          <input id="gpx-file" type="file" accept=".gpx,application/gpx+xml,text/xml,application/xml" />
-        </label>
-
-        <button id="use-current-location" type="button" class="secondary-action">現在地を使う</button>
-
-        <label>
-          <span>近傍距離 (m)</span>
-          <input id="distance-threshold" type="number" min="100" step="100" value="1000" />
-        </label>
-
-        <label>
-          <span>最小 point_level</span>
-          <input id="min-point-level" type="number" min="1" step="1" value="8" />
-        </label>
-
-        <fieldset class="chains">
-          <legend>チェーン</legend>
-          <label><input type="checkbox" value="7eleven" checked />7-Eleven</label>
-          <label><input type="checkbox" value="lawson" checked />Lawson</label>
-          <label><input type="checkbox" value="familymart" checked />FamilyMart</label>
-          <label><input type="checkbox" value="daily_yamazaki" checked />Daily Yamazaki</label>
-          <label><input type="checkbox" value="ministop" checked />MINISTOP</label>
-          <label><input type="checkbox" value="michi_no_eki" checked />道の駅</label>
+        <fieldset class="source-mode">
+          <legend>ルートの指定</legend>
+          <label><input type="radio" name="source-mode" value="gpx" checked />GPX ファイル</label>
+          <label><input type="radio" name="source-mode" value="current" />現在地</label>
         </fieldset>
 
-        <button id="refresh" type="button">再計算</button>
+        <div class="source-panel" id="gpx-panel">
+          <label class="file-picker-button" for="gpx-file">
+            GPX を選ぶ
+            <input id="gpx-file" type="file" accept=".gpx,application/gpx+xml,text/xml,application/xml" />
+          </label>
+          <div class="source-meta">
+            <div class="file-name" id="gpx-file-name">未選択</div>
+            <div class="route-meta" id="route-point-count">経路点数: -</div>
+          </div>
+        </div>
+
+        <div class="source-panel" id="current-location-panel">
+          <button id="use-current-location" type="button" class="secondary-action">現在地を使う</button>
+        </div>
+
+        <fieldset class="distance-ladder">
+          <legend>近傍距離</legend>
+          <div class="distance-current" id="distance-current">1km</div>
+          <input
+            id="distance-threshold"
+            type="range"
+            min="0"
+            max="6"
+            step="1"
+            value="3"
+            list="distance-threshold-labels"
+          />
+          <datalist id="distance-threshold-labels">
+            <option value="0" label="100m"></option>
+            <option value="1" label="250m"></option>
+            <option value="2" label="500m"></option>
+            <option value="3" label="1km"></option>
+            <option value="4" label="2km"></option>
+            <option value="5" label="5km"></option>
+            <option value="6" label="10km"></option>
+          </datalist>
+          <div class="distance-scale" aria-hidden="true">
+            <span>100m</span>
+            <span>250m</span>
+            <span>500m</span>
+            <span>1km</span>
+            <span>2km</span>
+            <span>5km</span>
+            <span>10km</span>
+          </div>
+        </fieldset>
       </section>
 
       <section class="content">
         <aside class="sidebar">
-          <div class="summary-card">
-            <div class="summary-label">経路点数</div>
-            <div class="summary-value" id="route-point-count">-</div>
+          <div class="summary-row">
+            <div class="summary-card compact">
+              <div class="summary-label">候補</div>
+              <div class="summary-value" id="candidate-count">-</div>
+            </div>
+            <div class="summary-card compact">
+              <div class="summary-label">表示</div>
+              <div class="summary-value" id="matched-count">-</div>
+            </div>
           </div>
-          <div class="summary-card">
-            <div class="summary-label">候補件数</div>
-            <div class="summary-value" id="candidate-count">-</div>
-          </div>
-          <div class="summary-card">
-            <div class="summary-label">近傍件数</div>
-            <div class="summary-value" id="matched-count">-</div>
-          </div>
+
+          <details class="filter-panel" open>
+            <summary>絞り込み</summary>
+            <fieldset class="chains result-filters chain-filters">
+              <legend>チェーン</legend>
+              <label><input type="checkbox" value="7eleven" checked />7-Eleven</label>
+              <label><input type="checkbox" value="lawson" checked />Lawson</label>
+              <label><input type="checkbox" value="familymart" checked />FamilyMart</label>
+              <label><input type="checkbox" value="daily_yamazaki" checked />Daily Yamazaki</label>
+              <label><input type="checkbox" value="ministop" checked />MINISTOP</label>
+              <label><input type="checkbox" value="michi_no_eki" checked />道の駅</label>
+            </fieldset>
+
+            <fieldset class="chains result-filters precision-filters">
+              <legend>位置の確かさ</legend>
+              <label><input type="checkbox" name="precision-filter" value="precise" checked />正確</label>
+              <label><input type="checkbox" name="precision-filter" value="rough" checked />あいまい</label>
+            </fieldset>
+          </details>
+
           <div class="point-list" id="point-list"></div>
         </aside>
         <div class="map-shell">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -43,7 +43,7 @@
         </div>
 
         <fieldset class="distance-ladder">
-          <legend>近傍距離</legend>
+          <legend id="distance-threshold-label">近傍距離</legend>
           <div class="distance-header">
             <div class="distance-current" id="distance-current">1km</div>
           </div>
@@ -55,6 +55,9 @@
             step="1"
             value="3"
             list="distance-threshold-labels"
+            aria-labelledby="distance-threshold-label"
+            aria-valuemin="100"
+            aria-valuemax="10000"
           />
           <datalist id="distance-threshold-labels">
             <option value="0" label="100m"></option>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,14 +1,18 @@
 :root {
-  --bg: #efe7da;
-  --panel: rgba(255, 251, 244, 0.95);
-  --panel-strong: #fffdf7;
-  --ink: #1f1a14;
-  --muted: #6d6458;
-  --accent: #9e3d22;
-  --accent-deep: #6d2712;
-  --line: #d7c7b1;
-  --route: #225ea8;
-  --point: #12836b;
+  --bg: #f7f5f1;
+  --panel: #ffffff;
+  --panel-muted: #fbfaf7;
+  --ink: #1f1f1c;
+  --muted: #6c6a63;
+  --accent: #245f99;
+  --accent-soft: #eef4fb;
+  --line: #ddd8cf;
+  --line-strong: #c9c3b8;
+  --route: #245f99;
+  --point: #1f7a67;
+  --radius-lg: 16px;
+  --radius-md: 12px;
+  --radius-sm: 8px;
 }
 
 * {
@@ -19,14 +23,14 @@ body {
   margin: 0;
   color: var(--ink);
   font-family: "Space Grotesk", "Hiragino Sans", sans-serif;
-  background:
-    radial-gradient(circle at top left, rgba(255, 255, 255, 0.65), transparent 35%),
-    linear-gradient(180deg, #f7f0e4, var(--bg));
+  background: var(--bg);
 }
 
 .app {
+  max-width: 1440px;
   min-height: 100vh;
-  padding: 18px;
+  margin: 0 auto;
+  padding: 16px;
   display: flex;
   flex-direction: column;
   gap: 14px;
@@ -35,121 +39,222 @@ body {
 .topbar,
 .panel,
 .sidebar,
-.popup {
+.popup,
+.map {
   border: 1px solid var(--line);
   background: var(--panel);
-  backdrop-filter: blur(10px);
 }
 
 .topbar {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 16px;
-  padding: 14px 18px;
+  padding: 16px 18px;
 }
 
 .topbar h1 {
   margin: 0;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 26px;
 }
 
 .subtitle {
-  margin: 4px 0 0;
+  margin: 6px 0 0;
   color: var(--muted);
   font-size: 13px;
 }
 
 .status {
-  font-size: 12px;
-  padding: 7px 10px;
+  flex-shrink: 0;
+  padding: 8px 10px;
   border: 1px solid var(--line);
-  background: #f6eee1;
-  max-width: 340px;
+  background: var(--panel-muted);
+  color: var(--muted);
+  font-size: 12px;
 }
 
 .controls {
+  padding: 12px;
   display: grid;
-  grid-template-columns: repeat(4, minmax(120px, 1fr)) auto;
+  grid-template-columns: 0.9fr 1.05fr 0.85fr 1.2fr;
   gap: 12px;
-  padding: 14px;
-  align-items: end;
+  align-items: stretch;
 }
 
-.controls label,
+.source-mode,
+.distance-ladder,
+.chains,
+.source-panel {
+  border: 1px solid var(--line);
+  background: var(--panel-muted);
+}
+
+.source-mode,
+.distance-ladder,
 .chains {
+  padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 8px;
   font-size: 12px;
   color: var(--muted);
 }
 
-.controls input[type="number"],
-.controls input[type="file"] {
+.source-mode legend,
+.distance-ladder legend,
+.chains legend {
+  padding: 0;
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.source-mode label,
+.chains label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.source-mode input,
+.chains input {
+  accent-color: var(--accent);
+}
+
+.source-panel {
+  min-height: 88px;
+  padding: 12px;
+  display: flex;
+  align-items: center;
+}
+
+#gpx-panel {
+  display: grid;
+  grid-template-columns: minmax(150px, 180px) minmax(0, 1fr);
+  gap: 12px;
+}
+
+#current-location-panel {
+  justify-content: center;
+}
+
+.source-panel.inactive {
+  opacity: 0.5;
+}
+
+.source-panel button {
   width: 100%;
 }
 
-.controls input,
-.controls button {
-  border: 1px solid var(--line);
+.file-picker-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 48px;
+  border: 1px solid var(--line-strong);
   background: #fff;
   color: var(--ink);
-  padding: 9px 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+  text-align: center;
+  font-weight: 700;
+}
+
+.file-picker-button:hover,
+.file-picker-button:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.file-picker-button input[type="file"] {
+  display: none;
+}
+
+.source-meta {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-end;
+}
+
+.file-name {
+  width: 100%;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 700;
+  text-align: right;
+  word-break: break-all;
+}
+
+.route-meta {
+  width: 100%;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: right;
+}
+
+.distance-current {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.distance-ladder input[type="range"] {
+  width: 100%;
+  margin: 2px 0 0;
+  accent-color: var(--accent);
+}
+
+.distance-scale {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 4px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.distance-scale span {
+  text-align: center;
+}
+
+button,
+input {
   font: inherit;
 }
 
-.controls button {
-  background: var(--accent);
-  color: #fff;
-  cursor: pointer;
-  min-width: 120px;
-}
-
-.controls button:hover {
-  background: var(--accent-deep);
-}
-
-.controls .secondary-action {
+button {
+  border: 1px solid var(--line-strong);
   background: #fff;
-  color: var(--accent-deep);
-}
-
-.controls .secondary-action:hover {
-  background: #fbf3e8;
-  color: var(--accent-deep);
-}
-
-.controls .secondary-action:focus-visible {
-  background: #fbf3e8;
-  color: var(--accent-deep);
-}
-
-.chains {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(110px, 1fr));
-  gap: 6px 10px;
-  padding: 8px 10px 10px;
-}
-
-.chains legend {
-  padding: 0 4px;
   color: var(--ink);
+  padding: 10px 12px;
+  cursor: pointer;
 }
 
-.chains label {
-  flex-direction: row;
-  align-items: center;
-  gap: 6px;
+button:hover,
+button:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+button.secondary-action {
+  background: #fff;
+}
+
+button:disabled,
+input:disabled {
+  cursor: not-allowed;
 }
 
 .content {
   display: grid;
-  grid-template-columns: 280px 1fr;
-  gap: 12px;
-  min-height: 600px;
+  grid-template-columns: 300px 1fr;
+  gap: 14px;
+  min-height: 640px;
   align-items: start;
 }
 
@@ -157,40 +262,83 @@ body {
   padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  height: 600px;
-  min-height: 600px;
+  gap: 8px;
+  height: 640px;
+  min-height: 640px;
+}
+
+.summary-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
 }
 
 .summary-card {
   border: 1px solid var(--line);
-  background: var(--panel-strong);
+  background: var(--panel-muted);
   padding: 10px 12px;
 }
 
 .summary-label {
-  font-size: 12px;
+  font-size: 11px;
   color: var(--muted);
 }
 
 .summary-value {
-  margin-top: 4px;
+  margin-top: 2px;
   font-size: 24px;
   font-weight: 700;
+  line-height: 1.1;
+}
+
+.filter-panel {
+  border: 1px solid var(--line);
+  background: var(--panel-muted);
+}
+
+.filter-panel summary {
+  padding: 10px 12px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--ink);
+  list-style: none;
+}
+
+.filter-panel summary::-webkit-details-marker {
+  display: none;
+}
+
+.filter-panel summary::after {
+  content: "開く";
+  float: right;
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.filter-panel[open] summary::after {
+  content: "閉じる";
+}
+
+.filter-panel .chains {
+  border: 0;
+  border-top: 1px solid var(--line);
+  background: transparent;
 }
 
 .point-list {
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  min-height: 0;
-  overflow: auto;
 }
 
 .point-item {
   border: 1px solid var(--line);
   background: #fff;
-  padding: 11px 12px;
+  padding: 10px 12px;
   cursor: pointer;
   text-align: left;
 }
@@ -198,28 +346,28 @@ body {
 .point-item:hover,
 .point-item.active,
 .point-item:focus-visible {
-  border-color: var(--point);
-  box-shadow: inset 0 0 0 1px var(--point);
+  border-color: var(--accent);
+  background: var(--accent-soft);
 }
 
 .point-item:focus-visible {
-  outline: 2px solid var(--point);
+  outline: 2px solid rgba(36, 95, 153, 0.18);
   outline-offset: 2px;
 }
 
 .point-item .chain {
-  display: block;
-  color: var(--accent-deep);
+  display: inline-block;
+  color: var(--accent);
   font-size: 11px;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
 .point-item .title {
   display: block;
-  margin-top: 4px;
-  font-size: 15px;
+  margin-top: 6px;
+  font-size: 14px;
   font-weight: 700;
   line-height: 1.35;
 }
@@ -227,13 +375,13 @@ body {
 .point-item .meta {
   display: block;
   margin-top: 4px;
-  font-size: 13px;
+  font-size: 12px;
   color: var(--muted);
 }
 
 .point-item .address {
   display: block;
-  margin-top: 4px;
+  margin-top: 3px;
   font-size: 12px;
   color: var(--muted);
   line-height: 1.4;
@@ -241,24 +389,19 @@ body {
 
 .map-shell {
   position: relative;
-  height: 600px;
-  min-height: 600px;
+  height: 640px;
+  min-height: 640px;
 }
 
 .map {
   height: 100%;
   min-height: 0;
-  border: 1px solid var(--line);
 }
 
 .popup {
   min-width: 220px;
   max-width: min(320px, calc(100vw - 40px));
-  padding: 14px 40px 14px 14px;
-  background: rgba(255, 253, 247, 0.98);
-  box-shadow: 0 14px 30px rgba(54, 35, 19, 0.18);
-  border-radius: 14px;
-  writing-mode: horizontal-tb;
+  padding: 14px 38px 14px 14px;
 }
 
 .popup[hidden] {
@@ -273,6 +416,9 @@ body {
   background: transparent;
   font-size: 20px;
   cursor: pointer;
+  min-width: 0;
+  padding: 0;
+  color: var(--muted);
 }
 
 .popup-body {
@@ -285,15 +431,15 @@ body {
 }
 
 .popup-chain {
-  color: var(--accent-deep);
+  color: var(--accent);
   font-size: 11px;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
 .popup-title {
-  font-size: 17px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.3;
   word-break: keep-all;
@@ -301,7 +447,6 @@ body {
 }
 
 .popup-distance {
-  margin-top: 2px;
   color: var(--muted);
   font-size: 13px;
 }
@@ -310,19 +455,42 @@ body {
   color: var(--accent);
 }
 
-@media (max-width: 1000px) {
-  .controls {
-    grid-template-columns: 1fr 1fr;
-  }
-
+@media (max-width: 1100px) {
+  .controls,
   .content {
     grid-template-columns: 1fr;
+  }
+
+  #gpx-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .source-meta,
+  .file-name,
+  .route-meta {
+    text-align: left;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .app {
+    padding: 12px;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .distance-scale {
+    font-size: 10px;
   }
 
   .map,
   .sidebar,
   .map-shell {
-    height: 440px;
-    min-height: 440px;
+    height: 460px;
+    min-height: 460px;
   }
 }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -187,8 +187,9 @@ body {
 .point-item {
   border: 1px solid var(--line);
   background: #fff;
-  padding: 10px;
+  padding: 11px 12px;
   cursor: pointer;
+  text-align: left;
 }
 
 .point-item:hover,
@@ -197,15 +198,32 @@ body {
   box-shadow: inset 0 0 0 1px var(--point);
 }
 
+.point-item .chain {
+  color: var(--accent-deep);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .point-item .title {
-  font-size: 14px;
-  font-weight: 600;
+  margin-top: 4px;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.35;
 }
 
 .point-item .meta {
   margin-top: 4px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.point-item .address {
+  margin-top: 4px;
   font-size: 12px;
   color: var(--muted);
+  line-height: 1.4;
 }
 
 .map-shell {
@@ -220,13 +238,13 @@ body {
 }
 
 .popup {
-  position: absolute;
-  left: 16px;
-  bottom: 16px;
-  width: min(320px, calc(100% - 32px));
-  padding: 12px 14px;
-  background: rgba(255, 253, 247, 0.97);
-  box-shadow: 0 10px 24px rgba(54, 35, 19, 0.12);
+  min-width: 220px;
+  max-width: min(320px, calc(100vw - 40px));
+  padding: 14px 40px 14px 14px;
+  background: rgba(255, 253, 247, 0.98);
+  box-shadow: 0 14px 30px rgba(54, 35, 19, 0.18);
+  border-radius: 14px;
+  writing-mode: horizontal-tb;
 }
 
 .popup[hidden] {
@@ -247,6 +265,30 @@ body {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  font-size: 14px;
+  line-height: 1.4;
+  min-width: 0;
+}
+
+.popup-chain {
+  color: var(--accent-deep);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.popup-title {
+  font-size: 17px;
+  font-weight: 700;
+  line-height: 1.3;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+.popup-distance {
+  margin-top: 2px;
+  color: var(--muted);
   font-size: 13px;
 }
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -196,12 +196,19 @@ body {
 }
 
 .point-item:hover,
-.point-item.active {
+.point-item.active,
+.point-item:focus-visible {
   border-color: var(--point);
   box-shadow: inset 0 0 0 1px var(--point);
 }
 
+.point-item:focus-visible {
+  outline: 2px solid var(--point);
+  outline-offset: 2px;
+}
+
 .point-item .chain {
+  display: block;
   color: var(--accent-deep);
   font-size: 11px;
   font-weight: 700;
@@ -210,6 +217,7 @@ body {
 }
 
 .point-item .title {
+  display: block;
   margin-top: 4px;
   font-size: 15px;
   font-weight: 700;
@@ -217,12 +225,14 @@ body {
 }
 
 .point-item .meta {
+  display: block;
   margin-top: 4px;
   font-size: 13px;
   color: var(--muted);
 }
 
 .point-item .address {
+  display: block;
   margin-top: 4px;
   font-size: 12px;
   color: var(--muted);

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -270,7 +270,6 @@ input:disabled {
   flex-direction: column;
   gap: 8px;
   height: 640px;
-  min-height: 640px;
 }
 
 .filter-panel {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -150,6 +150,7 @@ body {
   grid-template-columns: 280px 1fr;
   gap: 12px;
   min-height: 600px;
+  align-items: start;
 }
 
 .sidebar {
@@ -157,6 +158,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  height: 600px;
+  min-height: 600px;
 }
 
 .summary-card {
@@ -228,12 +231,13 @@ body {
 
 .map-shell {
   position: relative;
+  height: 600px;
   min-height: 600px;
 }
 
 .map {
   height: 100%;
-  min-height: 600px;
+  min-height: 0;
   border: 1px solid var(--line);
 }
 
@@ -306,7 +310,9 @@ body {
   }
 
   .map,
+  .sidebar,
   .map-shell {
+    height: 440px;
     min-height: 440px;
   }
 }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -204,6 +204,12 @@ body {
   color: var(--ink);
 }
 
+.distance-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-start;
+}
+
 .distance-ladder input[type="range"] {
   width: 100%;
   margin: 2px 0 0;
@@ -267,30 +273,6 @@ input:disabled {
   min-height: 640px;
 }
 
-.summary-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 8px;
-}
-
-.summary-card {
-  border: 1px solid var(--line);
-  background: var(--panel-muted);
-  padding: 10px 12px;
-}
-
-.summary-label {
-  font-size: 11px;
-  color: var(--muted);
-}
-
-.summary-value {
-  margin-top: 2px;
-  font-size: 24px;
-  font-weight: 700;
-  line-height: 1.1;
-}
-
 .filter-panel {
   border: 1px solid var(--line);
   background: var(--panel-muted);
@@ -303,6 +285,10 @@ input:disabled {
   font-weight: 700;
   color: var(--ink);
   list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .filter-panel summary::-webkit-details-marker {
@@ -318,6 +304,17 @@ input:disabled {
 
 .filter-panel[open] summary::after {
   content: "閉じる";
+}
+
+.filter-summary-count {
+  margin-left: auto;
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.filter-summary-count span {
+  color: var(--ink);
+  font-weight: 700;
 }
 
 .filter-panel .chains {


### PR DESCRIPTION
## 概要
- GPX/現在地の選択後に自動で再検索される地図検索 UI に整理
- 近傍距離を離散ラダー化し、結果側でチェーンと位置の確かさを絞り込めるように変更
- 画面全体の余白と配色をミニマル寄りに見直し、結果件数の表示位置を調整

## 変更内容
- 事前条件からチェーン指定を外し、結果側フィルタに移動
- `補給地点を探す` ボタンを廃止し、GPX 読み込み・現在地取得・距離変更で自動再検索
- GPX のファイル選択 UI と経路点数表示を入力周辺に整理
- サイドバーの `候補` 表示を削除し、`表示` 件数のみを絞り込み見出しに表示
- CSS を装飾過多からミニマル寄りに調整

## テスト
- `npm test`
