### PR TITLE
chore: add Claude Code repository config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm test)",
+      "Bash(npm test *)",
+      "Bash(npm run test:unit)",
+      "Bash(npm run test:unit *)",
+      "Bash(node --test *)",
+      "Bash(git status)",
+      "Bash(git status *)",
+      "Bash(git diff)",
+      "Bash(git diff *)",
+      "Bash(git log)",
+      "Bash(git log *)",
+      "Bash(git branch)",
+      "Bash(git branch *)",
+      "Bash(git show *)",
+      "Bash(gh issue *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr list)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr diff *)"
+    ]
+  }
+}

--- a/.claude/skills/crawler-playwright
+++ b/.claude/skills/crawler-playwright
@@ -1,0 +1,1 @@
+../../skills/crawler-playwright

--- a/.claude/skills/dataform-modeling
+++ b/.claude/skills/dataform-modeling
@@ -1,0 +1,1 @@
+../../skills/dataform-modeling

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ playwright-report/
 test-results/
 data/
 .local/
+
+# .claude is ignored by ~/.config/git/ignore — re-allow shared Claude Code config
+!.claude/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/skills/crawler-playwright/SKILL.md
+++ b/skills/crawler-playwright/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: crawler-playwright
+description: ride-oasis の店舗クローラを実装/更新するときに使用する。`scripts/*_pref_ndjson.js` を追加・改修する場合、新しいチェーンを追加する場合、サイト構造変更で既存スクレイパが壊れた場合、`raw.stores_scraped_*` のスキーマと NDJSON 出力を整える場合に利用する。API/JSON 取得を DOM 抽出より優先する方針を含む。
+---
+
 # Skill: crawler-playwright
 
 公式サイトの店舗情報を Playwright で安定的に収集し、`raw.stores_scraped_*` へ投入するための作業手順。

--- a/skills/dataform-modeling/SKILL.md
+++ b/skills/dataform-modeling/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: dataform-modeling
+description: ride-oasis の Dataform 定義を追加/更新するときに使用する。`dataform/definitions/{raw,stg,mart,ops}/*.sqlx` を変更する場合、`supply_point_id = chain:store_id` の一意性を維持する場合、`stg` の最新化や `ops` の品質メトリクスを整備する場合に利用する。Dataform 内では外部 I/O や npm 実行を行わない原則を含む。
+---
+
 # Skill: dataform-modeling
 
 `raw` → `stg` → `mart` → `ops` を Dataform で整備するための作業手順。


### PR DESCRIPTION
## Summary
- `CLAUDE.md` を `AGENTS.md` への symlink にして Codex/Claude 共通ルール化
- `skills/crawler-playwright`, `skills/dataform-modeling` に YAML frontmatter を追加し、`.claude/skills/` から symlink して Claude Code から自動発見できるようにする
- `.claude/settings.json` に読み取り系コマンド (`npm test`, `git status/diff/log/branch/show`, `gh issue/pr view/list/diff`, `node --test`) の allowlist を追加
- `~/.config/git/ignore` の `**/.claude/` を override し、共有設定だけ追跡しつつ `settings.local.json` は引き続き個人用として ignore

## Test plan
- [x] \`npm test\` (46/46 pass)
- [ ] Claude Code セッションを開いて `.claude/skills/{crawler-playwright,dataform-modeling}` が Skill として認識されることを確認
- [ ] `gh pr view` 等の許可済みコマンドが追加プロンプトなしで実行できることを確認
- [ ] 別 clone で `.claude/settings.json` と skill symlink が反映されることを確認