### PR TITLE
feat: 手動2点指定モードで GPX 無しでも近傍補給地点を出せるようにする

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -696,7 +696,16 @@ async function handleCurrentLocation() {
 /** Wires DOM and map click events for the static frontend. */
 function bindEvents() {
   for (const input of document.querySelectorAll('input[name="source-mode"]')) {
-    input.addEventListener('change', syncSourceModeUi);
+    input.addEventListener('change', () => {
+      const mode = selectedSourceMode();
+      if (mode !== 'manual' && manualPoints.length > 0) {
+        resetManualState();
+      }
+      syncSourceModeUi();
+      if (mode === 'manual' && manualPoints.length === 0 && routeCoordinates.length === 0) {
+        setStatus('地図をクリックして出発地を指定してください');
+      }
+    });
   }
   elements.distanceThreshold.addEventListener('input', syncDistanceUi);
   elements.distanceThreshold.addEventListener('change', () => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -10,6 +10,8 @@ const elements = {
   useCurrentLocation: document.getElementById('use-current-location'),
   gpxPanel: document.getElementById('gpx-panel'),
   currentLocationPanel: document.getElementById('current-location-panel'),
+  manualPanel: document.getElementById('manual-panel'),
+  manualReset: document.getElementById('manual-reset'),
   gpxFileName: document.getElementById('gpx-file-name'),
   routePointCount: document.getElementById('route-point-count'),
   distanceThreshold: document.getElementById('distance-threshold'),
@@ -107,6 +109,7 @@ map.addOverlay(popupOverlay);
 
 let routeFeature = null;
 let routeCoordinates = [];
+let manualPoints = [];
 let allMatchedPoints = [];
 let filteredPoints = [];
 let activeSupplyPointId = null;
@@ -165,11 +168,13 @@ function setStatus(message) {
 
 /** Syncs source-mode panel state so only one input path is active at a time. */
 function syncSourceModeUi() {
-  const gpxActive = selectedSourceMode() === 'gpx';
-  elements.gpxFile.disabled = !gpxActive;
-  elements.useCurrentLocation.disabled = gpxActive;
-  elements.gpxPanel.classList.toggle('inactive', !gpxActive);
-  elements.currentLocationPanel.classList.toggle('inactive', gpxActive);
+  const mode = selectedSourceMode();
+  elements.gpxFile.disabled = mode !== 'gpx';
+  elements.useCurrentLocation.disabled = mode !== 'current';
+  elements.manualReset.disabled = mode !== 'manual';
+  elements.gpxPanel.classList.toggle('inactive', mode !== 'gpx');
+  elements.currentLocationPanel.classList.toggle('inactive', mode !== 'current');
+  elements.manualPanel.classList.toggle('inactive', mode !== 'manual');
 }
 
 /** Resets visible and cached result points before a new search. */
@@ -352,6 +357,34 @@ function renderRoute(feature) {
     const goal = new ol.Feature({ geometry: new ol.geom.Point(coordinates[coordinates.length - 1]) });
     goal.set('kind', 'goal');
     endpointSource.addFeatures([start, goal]);
+  }
+}
+
+/** Renders manual-mode endpoints and the connecting straight LineString. */
+function renderManualPoints() {
+  routeSource.clear();
+  endpointSource.clear();
+  currentLocationSource.clear();
+
+  if (manualPoints.length === 0) return;
+
+  const start = new ol.Feature({
+    geometry: new ol.geom.Point(ol.proj.fromLonLat(manualPoints[0]))
+  });
+  start.set('kind', 'start');
+  endpointSource.addFeature(start);
+
+  if (manualPoints.length >= 2) {
+    const goal = new ol.Feature({
+      geometry: new ol.geom.Point(ol.proj.fromLonLat(manualPoints[1]))
+    });
+    goal.set('kind', 'goal');
+    endpointSource.addFeature(goal);
+
+    const line = new ol.Feature({
+      geometry: new ol.geom.LineString(manualPoints.map((coord) => ol.proj.fromLonLat(coord)))
+    });
+    routeSource.addFeature(line);
   }
 }
 
@@ -556,6 +589,7 @@ async function handleGpxFile(event) {
     if (loadToken !== latestRouteLoadToken) return;
     routeFeature = parsedRoute.feature;
     routeCoordinates = parsedRoute.coordinates;
+    manualPoints = [];
     elements.gpxFileName.textContent = file.name;
     renderRoute(routeFeature);
     resetResults();
@@ -568,6 +602,53 @@ async function handleGpxFile(event) {
     elements.gpxFileName.textContent = previousFileName;
     setStatus(error?.message || 'GPX の読み込みに失敗しました');
     console.error(error);
+  }
+}
+
+/** Records a manual map click as start (1st click) or goal (2nd click) and refreshes the map. */
+async function handleManualMapClick(mapCoord) {
+  if (manualPoints.length >= 2) return;
+
+  const lonLat = ol.proj.toLonLat(mapCoord);
+  manualPoints.push([lonLat[0], lonLat[1]]);
+  renderManualPoints();
+
+  const loadToken = ++latestRouteLoadToken;
+  cancelPendingRefreshes();
+
+  if (manualPoints.length === 1) {
+    routeFeature = null;
+    routeCoordinates = [];
+    resetResults();
+    updateRoutePointCount();
+    setStatus('目的地をクリックしてください');
+    return;
+  }
+
+  routeFeature = routeSource.getFeatures()[0] || null;
+  routeCoordinates = manualPoints.map((coord) => [coord[0], coord[1]]);
+  resetResults();
+  updateRoutePointCount();
+  fitToVisibleData();
+  setStatus('手動経路を生成しました');
+  if (loadToken !== latestRouteLoadToken) return;
+  await refreshMap([...routeCoordinates]);
+}
+
+/** Resets manual-mode state so the user can re-pick start and goal. */
+function resetManualState() {
+  manualPoints = [];
+  routeFeature = null;
+  routeCoordinates = [];
+  ++latestRouteLoadToken;
+  cancelPendingRefreshes();
+  routeSource.clear();
+  endpointSource.clear();
+  currentLocationSource.clear();
+  resetResults();
+  updateRoutePointCount();
+  if (selectedSourceMode() === 'manual') {
+    setStatus('地図をクリックして出発地を指定してください');
   }
 }
 
@@ -593,6 +674,7 @@ async function handleCurrentLocation() {
     const coord = [position.coords.longitude, position.coords.latitude];
     routeFeature = null;
     routeCoordinates = [coord];
+    manualPoints = [];
     renderCurrentLocation(coord);
     resetResults();
     updateRoutePointCount();
@@ -628,6 +710,7 @@ function bindEvents() {
   }
   elements.gpxFile.addEventListener('change', handleGpxFile);
   elements.useCurrentLocation.addEventListener('click', handleCurrentLocation);
+  elements.manualReset.addEventListener('click', resetManualState);
   elements.pointList.addEventListener('mouseover', (event) => {
     const item = findPointListItem(event.target);
     if (!item || item === findPointListItem(event.relatedTarget)) return;
@@ -656,11 +739,15 @@ function bindEvents() {
   elements.popupClose.addEventListener('click', clearPopup);
   map.on('singleclick', (event) => {
     const feature = map.forEachFeatureAtPixel(event.pixel, (candidate) => candidate);
-    if (!feature || !feature.get('properties')) {
-      clearPopup();
+    const supplyFeature = feature && feature.get('properties') ? feature : null;
+    if (supplyFeature) {
+      activatePoint(supplyFeature.get('properties').supply_point_id);
       return;
     }
-    activatePoint(feature.get('properties').supply_point_id);
+    clearPopup();
+    if (selectedSourceMode() === 'manual') {
+      handleManualMapClick(event.coordinate);
+    }
   });
 }
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -343,11 +343,16 @@ function updateSummary(visibleCount) {
   elements.matchedCount.textContent = String(visibleCount);
 }
 
-/** Renders the uploaded route and its start/end markers. */
-function renderRoute(feature) {
+/** Clears the three drawing sources used for route and location visuals. */
+function clearRouteVisualSources() {
   routeSource.clear();
   endpointSource.clear();
   currentLocationSource.clear();
+}
+
+/** Renders the uploaded route and its start/end markers. */
+function renderRoute(feature) {
+  clearRouteVisualSources();
   routeSource.addFeature(feature);
 
   const coordinates = feature.getGeometry().getCoordinates();
@@ -362,9 +367,7 @@ function renderRoute(feature) {
 
 /** Renders manual-mode endpoints and the connecting straight LineString. */
 function renderManualPoints() {
-  routeSource.clear();
-  endpointSource.clear();
-  currentLocationSource.clear();
+  clearRouteVisualSources();
 
   if (manualPoints.length === 0) return;
 
@@ -390,9 +393,7 @@ function renderManualPoints() {
 
 /** Renders a single current-location marker instead of a route line. */
 function renderCurrentLocation(coord) {
-  routeSource.clear();
-  endpointSource.clear();
-  currentLocationSource.clear();
+  clearRouteVisualSources();
   currentLocationSource.addFeature(
     new ol.Feature({
       geometry: new ol.geom.Point(ol.proj.fromLonLat(coord))
@@ -642,9 +643,7 @@ function resetManualState() {
   routeCoordinates = [];
   ++latestRouteLoadToken;
   cancelPendingRefreshes();
-  routeSource.clear();
-  endpointSource.clear();
-  currentLocationSource.clear();
+  clearRouteVisualSources();
   resetResults();
   updateRoutePointCount();
   if (selectedSourceMode() === 'manual') {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,7 +17,7 @@
           <h1>RideOasis Map</h1>
           <p class="subtitle">位置と近傍距離だけ決めて、結果をあとから絞り込む</p>
         </div>
-        <div class="status" id="status">GPX か現在地を指定してください</div>
+        <div class="status" id="status">経路を指定してください</div>
       </header>
 
       <section class="panel controls">
@@ -25,6 +25,7 @@
           <legend>ルートの指定</legend>
           <label><input type="radio" name="source-mode" value="gpx" checked />GPX ファイル</label>
           <label><input type="radio" name="source-mode" value="current" />現在地</label>
+          <label><input type="radio" name="source-mode" value="manual" />手動2点指定</label>
         </fieldset>
 
         <div class="source-panel" id="gpx-panel">
@@ -40,6 +41,11 @@
 
         <div class="source-panel" id="current-location-panel">
           <button id="use-current-location" type="button" class="secondary-action">現在地を使う</button>
+        </div>
+
+        <div class="source-panel" id="manual-panel">
+          <p class="manual-instructions" id="manual-instructions">地図をクリックして出発地と目的地を順に指定してください</p>
+          <button id="manual-reset" type="button" class="secondary-action">手動指定をリセット</button>
         </div>
 
         <fieldset class="distance-ladder">


### PR DESCRIPTION
Closes #39

## Summary
- \`source-mode\` に \`manual\` (手動2点指定) を追加し、地図クリックで 出発地 → 目的地 の 2 点を順に置けるようにする
- 2 点が揃ったら直線 LineString を仮想ルートとして既存の近傍検索パイプラインに乗せる (新しい検索経路は作らない)
- リセットボタンで両端点と仮想ルートを消して再指定可能
- GPX / 現在地モードで新しい経路を確定するときは \`manualPoints\` をクリアし、モード間で状態が混ざらないようにする

スコープ外 (将来課題):
- 3 点以上の通過点
- 道なりルート (OSRM 等)

## Test plan
- [x] \`npm test\` (46/46 pass)
- [x] \`node --check frontend/app.js\` / \`route_math.js\` / \`gpx.js\`
- [x] Playwright スモーク (\`./.local/smoketest.mjs\`):
  - manual モード切替で \`#manual-panel\` が active、\`#gpx-panel\` が inactive
  - 1 点目クリックで status が \"目的地をクリックしてください\" に変化
  - 2 点目クリックで route + 535 件マッチ、\`経路点数: 2\` 表示
  - リセットで初期ガイダンスに戻る
  - JS / page エラー無し