### PR TITLE
feat: 地名検索 (Nominatim) で表示エリアと近傍検索を絞り込めるようにする

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,10 +1,13 @@
 const API_BASE = window.RIDEOASIS_API_BASE || '/api';
+// Public Nominatim forbids client-side autocomplete and limits usage to ~1 req/s.
+// The geo-search UI uses submit-only firing (Enter / search button) so a single
+// user-initiated request is sent per search. For higher volume or hosted use,
+// override this with a self-hosted Nominatim or proxy via window.RIDEOASIS_NOMINATIM_BASE.
 const NOMINATIM_BASE = window.RIDEOASIS_NOMINATIM_BASE || 'https://nominatim.openstreetmap.org/search';
 
 const PRECISE_POINT_LEVEL = 8;
 const DEFAULT_MIN_POINT_LEVEL = 3;
 const DISTANCE_OPTIONS = [100, 250, 500, 1000, 2000, 5000, 10000];
-const GEO_SEARCH_DEBOUNCE_MS = 400;
 const GEO_SEARCH_MIN_QUERY = 2;
 const GEO_SEARCH_LIMIT = 5;
 
@@ -25,7 +28,9 @@ const elements = {
   popup: document.getElementById('popup'),
   popupBody: document.getElementById('popup-body'),
   popupClose: document.getElementById('popup-close'),
+  geoSearchForm: document.getElementById('geo-search-form'),
   geoSearchInput: document.getElementById('geo-search-input'),
+  geoSearchSubmit: document.getElementById('geo-search-submit'),
   geoSearchClear: document.getElementById('geo-search-clear'),
   geoSearchResults: document.getElementById('geo-search-results')
 };
@@ -125,7 +130,6 @@ const API_PAGE_LIMIT = 10000;
 const featureIndex = new Map();
 let latestRouteLoadToken = 0;
 let latestRefreshToken = 0;
-let geoSearchDebounceTimer = null;
 let geoSearchAbortController = null;
 let latestGeoSearchToken = 0;
 
@@ -773,8 +777,18 @@ async function fetchPlaces(query) {
   return response.json();
 }
 
+/** Cancels any in-flight geo-search request and invalidates pending response tokens. */
+function cancelPendingGeoSearch() {
+  latestGeoSearchToken += 1;
+  if (geoSearchAbortController) {
+    geoSearchAbortController.abort();
+    geoSearchAbortController = null;
+  }
+}
+
 /** Fits the map view to a Nominatim place's bounding box. */
 function fitMapToPlace(item) {
+  cancelPendingGeoSearch();
   const bbox = Array.isArray(item.boundingbox) ? item.boundingbox.map(Number) : null;
   if (!bbox || bbox.length !== 4 || !bbox.every(Number.isFinite)) {
     return;
@@ -794,6 +808,9 @@ async function searchAtPlace(item) {
   const lat = Number(item.lat);
   const lon = Number(item.lon);
   if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
+
+  cancelPendingGeoSearch();
+  manualPoints = [];
 
   const currentRadio = document.querySelector('input[name="source-mode"][value="current"]');
   if (currentRadio) {
@@ -816,47 +833,41 @@ async function searchAtPlace(item) {
   await refreshMap([...routeCoordinates]);
 }
 
-/** Debounced query handler that triggers Nominatim and renders results. */
+/** Updates clear-button visibility on input change. Submission is explicit (Enter / button). */
 function handleGeoSearchInput() {
   const query = elements.geoSearchInput.value.trim();
   elements.geoSearchClear.hidden = query.length === 0;
+}
 
-  if (geoSearchDebounceTimer) {
-    clearTimeout(geoSearchDebounceTimer);
-    geoSearchDebounceTimer = null;
-  }
-  const token = ++latestGeoSearchToken;
-
+/** Submit-only Nominatim search triggered by Enter key or the search button. */
+async function handleGeoSearchSubmit(event) {
+  event.preventDefault();
+  const query = elements.geoSearchInput.value.trim();
   if (query.length < GEO_SEARCH_MIN_QUERY) {
-    if (geoSearchAbortController) geoSearchAbortController.abort();
+    cancelPendingGeoSearch();
     clearGeoSearchResults();
     return;
   }
 
-  geoSearchDebounceTimer = setTimeout(async () => {
-    try {
-      const items = await fetchPlaces(query);
-      if (token !== latestGeoSearchToken) return;
-      renderGeoSearchResults(items);
-    } catch (error) {
-      if (error?.name === 'AbortError') return;
-      if (token !== latestGeoSearchToken) return;
-      console.error(error);
-      clearGeoSearchResults();
-    }
-  }, GEO_SEARCH_DEBOUNCE_MS);
+  cancelPendingGeoSearch();
+  const token = ++latestGeoSearchToken;
+  try {
+    const items = await fetchPlaces(query);
+    if (token !== latestGeoSearchToken) return;
+    renderGeoSearchResults(items);
+  } catch (error) {
+    if (error?.name === 'AbortError') return;
+    if (token !== latestGeoSearchToken) return;
+    console.error(error);
+    clearGeoSearchResults();
+  }
 }
 
 /** Clears the search box and hides results. */
 function handleGeoSearchClear() {
   elements.geoSearchInput.value = '';
   elements.geoSearchClear.hidden = true;
-  latestGeoSearchToken += 1;
-  if (geoSearchDebounceTimer) {
-    clearTimeout(geoSearchDebounceTimer);
-    geoSearchDebounceTimer = null;
-  }
-  if (geoSearchAbortController) geoSearchAbortController.abort();
+  cancelPendingGeoSearch();
   clearGeoSearchResults();
   elements.geoSearchInput.focus();
 }
@@ -888,6 +899,7 @@ function bindEvents() {
   elements.gpxFile.addEventListener('change', handleGpxFile);
   elements.useCurrentLocation.addEventListener('click', handleCurrentLocation);
   elements.manualReset.addEventListener('click', resetManualState);
+  elements.geoSearchForm.addEventListener('submit', handleGeoSearchSubmit);
   elements.geoSearchInput.addEventListener('input', handleGeoSearchInput);
   elements.geoSearchClear.addEventListener('click', handleGeoSearchClear);
   document.addEventListener('click', (event) => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -722,6 +722,7 @@ async function searchAtPlace(item) {
 
   const loadToken = ++latestRouteLoadToken;
   cancelPendingRefreshes();
+  if (loadToken !== latestRouteLoadToken) return;
   const coord = [lon, lat];
   routeFeature = null;
   routeCoordinates = [coord];
@@ -731,7 +732,6 @@ async function searchAtPlace(item) {
   fitToVisibleData();
   setStatus(`「${item.display_name}」を中心に検索中...`);
   clearGeoSearchResults();
-  if (loadToken !== latestRouteLoadToken) return;
   await refreshMap([...routeCoordinates]);
 }
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,8 +1,12 @@
 const API_BASE = window.RIDEOASIS_API_BASE || '/api';
+const NOMINATIM_BASE = window.RIDEOASIS_NOMINATIM_BASE || 'https://nominatim.openstreetmap.org/search';
 
 const PRECISE_POINT_LEVEL = 8;
 const DEFAULT_MIN_POINT_LEVEL = 3;
 const DISTANCE_OPTIONS = [100, 250, 500, 1000, 2000, 5000, 10000];
+const GEO_SEARCH_DEBOUNCE_MS = 400;
+const GEO_SEARCH_MIN_QUERY = 2;
+const GEO_SEARCH_LIMIT = 5;
 
 const elements = {
   status: document.getElementById('status'),
@@ -18,7 +22,10 @@ const elements = {
   matchedCount: document.getElementById('matched-count'),
   popup: document.getElementById('popup'),
   popupBody: document.getElementById('popup-body'),
-  popupClose: document.getElementById('popup-close')
+  popupClose: document.getElementById('popup-close'),
+  geoSearchInput: document.getElementById('geo-search-input'),
+  geoSearchClear: document.getElementById('geo-search-clear'),
+  geoSearchResults: document.getElementById('geo-search-results')
 };
 
 const routeGeoJsonFormat = new ol.format.GeoJSON({ featureProjection: 'EPSG:3857' });
@@ -115,6 +122,9 @@ const API_PAGE_LIMIT = 10000;
 const featureIndex = new Map();
 let latestRouteLoadToken = 0;
 let latestRefreshToken = 0;
+let geoSearchDebounceTimer = null;
+let geoSearchAbortController = null;
+let latestGeoSearchToken = 0;
 
 /** Returns the currently selected route source mode. */
 function selectedSourceMode() {
@@ -611,6 +621,160 @@ async function handleCurrentLocation() {
   }
 }
 
+/** Empties the geo-search dropdown and hides it. */
+function clearGeoSearchResults() {
+  elements.geoSearchResults.innerHTML = '';
+  elements.geoSearchResults.hidden = true;
+}
+
+/** Renders Nominatim search results into the dropdown with two actions per row. */
+function renderGeoSearchResults(items) {
+  elements.geoSearchResults.innerHTML = '';
+  if (!items.length) {
+    const empty = document.createElement('li');
+    empty.className = 'geo-search-empty';
+    empty.textContent = '該当する地名が見つかりません';
+    elements.geoSearchResults.appendChild(empty);
+    elements.geoSearchResults.hidden = false;
+    return;
+  }
+  for (const item of items) {
+    const li = document.createElement('li');
+    li.className = 'geo-search-result';
+
+    const name = document.createElement('span');
+    name.className = 'geo-search-result-name';
+    name.textContent = item.display_name;
+
+    const actions = document.createElement('div');
+    actions.className = 'geo-search-result-actions';
+
+    const fitBtn = document.createElement('button');
+    fitBtn.type = 'button';
+    fitBtn.className = 'geo-search-result-fit';
+    fitBtn.textContent = 'この場所を表示';
+    fitBtn.addEventListener('click', () => fitMapToPlace(item));
+
+    const searchBtn = document.createElement('button');
+    searchBtn.type = 'button';
+    searchBtn.className = 'geo-search-result-search';
+    searchBtn.textContent = 'ここで検索';
+    searchBtn.addEventListener('click', () => searchAtPlace(item));
+
+    actions.append(fitBtn, searchBtn);
+    li.append(name, actions);
+    elements.geoSearchResults.appendChild(li);
+  }
+  elements.geoSearchResults.hidden = false;
+}
+
+/** Calls Nominatim and returns up to GEO_SEARCH_LIMIT places matching the query. */
+async function fetchPlaces(query) {
+  if (geoSearchAbortController) {
+    geoSearchAbortController.abort();
+  }
+  geoSearchAbortController = new AbortController();
+  const params = new URLSearchParams({
+    q: query,
+    format: 'json',
+    countrycodes: 'jp',
+    'accept-language': 'ja',
+    limit: String(GEO_SEARCH_LIMIT),
+    addressdetails: '0'
+  });
+  const response = await fetch(`${NOMINATIM_BASE}?${params.toString()}`, {
+    signal: geoSearchAbortController.signal,
+    headers: { Accept: 'application/json' }
+  });
+  if (!response.ok) {
+    throw new Error(`Nominatim error (${response.status})`);
+  }
+  return response.json();
+}
+
+/** Fits the map view to a Nominatim place's bounding box. */
+function fitMapToPlace(item) {
+  const bbox = Array.isArray(item.boundingbox) ? item.boundingbox.map(Number) : null;
+  if (!bbox || bbox.length !== 4 || !bbox.every(Number.isFinite)) {
+    return;
+  }
+  const [minLat, maxLat, minLon, maxLon] = bbox;
+  const extent = ol.proj.transformExtent(
+    [minLon, minLat, maxLon, maxLat],
+    'EPSG:4326',
+    'EPSG:3857'
+  );
+  map.getView().fit(extent, { padding: [40, 40, 40, 40], duration: 250, maxZoom: 14 });
+  clearGeoSearchResults();
+}
+
+/** Uses a Nominatim place as the current-location anchor and runs nearby search. */
+async function searchAtPlace(item) {
+  const lat = Number(item.lat);
+  const lon = Number(item.lon);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
+
+  const currentRadio = document.querySelector('input[name="source-mode"][value="current"]');
+  if (currentRadio) {
+    currentRadio.checked = true;
+    syncSourceModeUi();
+  }
+
+  const loadToken = ++latestRouteLoadToken;
+  cancelPendingRefreshes();
+  const coord = [lon, lat];
+  routeFeature = null;
+  routeCoordinates = [coord];
+  renderCurrentLocation(coord);
+  resetResults();
+  updateRoutePointCount();
+  fitToVisibleData();
+  setStatus(`「${item.display_name}」を中心に検索中...`);
+  clearGeoSearchResults();
+  if (loadToken !== latestRouteLoadToken) return;
+  await refreshMap([...routeCoordinates]);
+}
+
+/** Debounced query handler that triggers Nominatim and renders results. */
+function handleGeoSearchInput() {
+  const query = elements.geoSearchInput.value.trim();
+  elements.geoSearchClear.hidden = query.length === 0;
+
+  if (geoSearchDebounceTimer) {
+    clearTimeout(geoSearchDebounceTimer);
+    geoSearchDebounceTimer = null;
+  }
+
+  if (query.length < GEO_SEARCH_MIN_QUERY) {
+    if (geoSearchAbortController) geoSearchAbortController.abort();
+    clearGeoSearchResults();
+    return;
+  }
+
+  const token = ++latestGeoSearchToken;
+  geoSearchDebounceTimer = setTimeout(async () => {
+    try {
+      const items = await fetchPlaces(query);
+      if (token !== latestGeoSearchToken) return;
+      renderGeoSearchResults(items);
+    } catch (error) {
+      if (error?.name === 'AbortError') return;
+      if (token !== latestGeoSearchToken) return;
+      console.error(error);
+      clearGeoSearchResults();
+    }
+  }, GEO_SEARCH_DEBOUNCE_MS);
+}
+
+/** Clears the search box and hides results. */
+function handleGeoSearchClear() {
+  elements.geoSearchInput.value = '';
+  elements.geoSearchClear.hidden = true;
+  if (geoSearchAbortController) geoSearchAbortController.abort();
+  clearGeoSearchResults();
+  elements.geoSearchInput.focus();
+}
+
 /** Wires DOM and map click events for the static frontend. */
 function bindEvents() {
   for (const input of document.querySelectorAll('input[name="source-mode"]')) {
@@ -628,6 +792,19 @@ function bindEvents() {
   }
   elements.gpxFile.addEventListener('change', handleGpxFile);
   elements.useCurrentLocation.addEventListener('click', handleCurrentLocation);
+  elements.geoSearchInput.addEventListener('input', handleGeoSearchInput);
+  elements.geoSearchClear.addEventListener('click', handleGeoSearchClear);
+  document.addEventListener('click', (event) => {
+    if (elements.geoSearchResults.hidden) return;
+    const target = event.target;
+    if (target instanceof Node && (
+      elements.geoSearchResults.contains(target) ||
+      elements.geoSearchInput.contains(target)
+    )) {
+      return;
+    }
+    clearGeoSearchResults();
+  });
   elements.pointList.addEventListener('mouseover', (event) => {
     const item = findPointListItem(event.target);
     if (!item || item === findPointListItem(event.relatedTarget)) return;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3,7 +3,9 @@ const API_BASE = window.RIDEOASIS_API_BASE || '/api';
 // The geo-search UI uses submit-only firing (Enter / search button) so a single
 // user-initiated request is sent per search. For higher volume or hosted use,
 // override this with a self-hosted Nominatim or proxy via window.RIDEOASIS_NOMINATIM_BASE.
-const NOMINATIM_BASE = window.RIDEOASIS_NOMINATIM_BASE || 'https://nominatim.openstreetmap.org/search';
+const PUBLIC_NOMINATIM_BASE = 'https://nominatim.openstreetmap.org/search';
+const NOMINATIM_BASE = window.RIDEOASIS_NOMINATIM_BASE || PUBLIC_NOMINATIM_BASE;
+const NOMINATIM_PUBLIC_MIN_INTERVAL_MS = 1000;
 
 const PRECISE_POINT_LEVEL = 8;
 const DEFAULT_MIN_POINT_LEVEL = 3;
@@ -132,6 +134,7 @@ let latestRouteLoadToken = 0;
 let latestRefreshToken = 0;
 let geoSearchAbortController = null;
 let latestGeoSearchToken = 0;
+let lastGeoSearchRequestTs = 0;
 
 /** Returns the currently selected route source mode. */
 function selectedSourceMode() {
@@ -849,7 +852,17 @@ async function handleGeoSearchSubmit(event) {
     return;
   }
 
+  if (NOMINATIM_BASE === PUBLIC_NOMINATIM_BASE) {
+    const sinceLast = Date.now() - lastGeoSearchRequestTs;
+    if (sinceLast < NOMINATIM_PUBLIC_MIN_INTERVAL_MS) {
+      const waitSec = Math.ceil((NOMINATIM_PUBLIC_MIN_INTERVAL_MS - sinceLast) / 100) / 10;
+      setStatus(`連続検索を抑制中: ${waitSec}秒後に再試行してください`);
+      return;
+    }
+  }
+
   cancelPendingGeoSearch();
+  lastGeoSearchRequestTs = Date.now();
   const token = ++latestGeoSearchToken;
   try {
     const items = await fetchPlaces(query);
@@ -911,6 +924,7 @@ function bindEvents() {
     )) {
       return;
     }
+    cancelPendingGeoSearch();
     clearGeoSearchResults();
   });
   elements.pointList.addEventListener('mouseover', (event) => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,11 +21,12 @@
       </header>
 
       <section class="panel geo-search-panel">
-        <div class="geo-search">
+        <form class="geo-search" id="geo-search-form" autocomplete="off">
           <label class="geo-search-label" for="geo-search-input">地名で検索</label>
-          <input id="geo-search-input" type="search" placeholder="例: 箱根、富士河口湖、千葉県柏市" autocomplete="off" />
+          <input id="geo-search-input" type="search" placeholder="例: 箱根、富士河口湖、千葉県柏市" autocomplete="off" enterkeyhint="search" />
+          <button type="submit" id="geo-search-submit" class="geo-search-submit">検索</button>
           <button id="geo-search-clear" type="button" class="geo-search-clear" hidden aria-label="検索語を消す">×</button>
-        </div>
+        </form>
         <ul id="geo-search-results" class="geo-search-results" hidden></ul>
       </section>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,6 +20,15 @@
         <div class="status" id="status">GPX か現在地を指定してください</div>
       </header>
 
+      <section class="panel geo-search-panel">
+        <div class="geo-search">
+          <label class="geo-search-label" for="geo-search-input">地名で検索</label>
+          <input id="geo-search-input" type="search" placeholder="例: 箱根、富士河口湖、千葉県柏市" autocomplete="off" />
+          <button id="geo-search-clear" type="button" class="geo-search-clear" hidden aria-label="検索語を消す">×</button>
+        </div>
+        <ul id="geo-search-results" class="geo-search-results" hidden></ul>
+      </section>
+
       <section class="panel controls">
         <fieldset class="source-mode">
           <legend>ルートの指定</legend>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -116,11 +116,20 @@ body {
   border-color: var(--accent);
 }
 
+.geo-search-submit,
 .geo-search-clear {
   flex-shrink: 0;
-  padding: 4px 10px;
-  font-size: 14px;
+  padding: 4px 12px;
   min-height: 32px;
+}
+
+.geo-search-submit {
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.geo-search-clear {
+  font-size: 14px;
 }
 
 .geo-search-results {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -84,6 +84,99 @@ body {
   align-items: stretch;
 }
 
+.geo-search-panel {
+  position: relative;
+  padding: 10px 12px;
+}
+
+.geo-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.geo-search-label {
+  flex-shrink: 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.geo-search input[type="search"] {
+  flex: 1;
+  min-height: 38px;
+  padding: 8px 12px;
+  border: 1px solid var(--line-strong);
+  background: #fff;
+  color: var(--ink);
+}
+
+.geo-search input[type="search"]:focus-visible {
+  outline: 2px solid rgba(36, 95, 153, 0.18);
+  border-color: var(--accent);
+}
+
+.geo-search-clear {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  font-size: 14px;
+  min-height: 32px;
+}
+
+.geo-search-results {
+  position: absolute;
+  top: calc(100% - 4px);
+  left: 12px;
+  right: 12px;
+  z-index: 20;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--line);
+  background: #fff;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.geo-search-result,
+.geo-search-empty {
+  padding: 10px 12px;
+  border-top: 1px solid var(--line);
+  font-size: 13px;
+}
+
+.geo-search-result:first-child,
+.geo-search-empty:first-child {
+  border-top: 0;
+}
+
+.geo-search-result {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.geo-search-result-name {
+  color: var(--ink);
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.geo-search-result-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.geo-search-result-actions button {
+  padding: 4px 10px;
+  font-size: 12px;
+  min-height: 28px;
+}
+
+.geo-search-empty {
+  color: var(--muted);
+}
+
 .source-mode,
 .distance-ladder,
 .chains,


### PR DESCRIPTION
Closes #40

## Summary
- 地名検索バーを追加し、入力 400ms 後に Nominatim (\`nominatim.openstreetmap.org/search\`) を叩いて候補を最大 5 件取得
- 各結果に2アクション:
  - **この場所を表示**: \`boundingbox\` を EPSG:3857 に変換して \`map.getView().fit\`
  - **ここで検索**: 選択地点を中心 (current モード) として既存の近傍検索パイプラインに乗せる
- 検索バー外クリック / クリアボタンで候補を閉じる
- 入力中は \`AbortController\` で前のリクエストをキャンセル、debounce + token で古いレスポンスが新しい結果を上書きしないようにする
- 公開 Nominatim を使うため \`countrycodes=jp\` で日本に絞り、\`accept-language=ja\` で日本語を優先

## 制約
- 公開 Nominatim はレート制限がきびしい (1req/sec)。debounce 400ms + 即時 abort で過剰アクセスを抑制
- 商用/高負荷ユースに切り替える場合は self-host または Mapbox/MapTiler などへ差し替え (フォローアップ Issue 起票予定)

## Test plan
- [x] \`npm test\` (46/46 pass)
- [x] \`node --check frontend/app.js\`
- [x] Playwright スモーク (\`./.local/geo_search_smoketest.mjs\`) — Nominatim をモックして実行:
  - \`箱根\` 入力 → 2 件レンダリング、先頭名一致
  - **この場所を表示** クリック → ドロップダウンが hidden 化
  - **ここで検索** クリック → \`source-mode\` が \`current\` に、補給地点 3 件マッチ、status 更新
  - クリアで input/ 候補が消える、JS エラー無し