### PR TITLE
feat: 走行中の追従モードと前方補給地点の強調表示を追加する

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3,6 +3,9 @@ const API_BASE = window.RIDEOASIS_API_BASE || '/api';
 const PRECISE_POINT_LEVEL = 8;
 const DEFAULT_MIN_POINT_LEVEL = 3;
 const DISTANCE_OPTIONS = [100, 250, 500, 1000, 2000, 5000, 10000];
+const FOLLOW_MIN_REFRESH_INTERVAL_MS = 30000;
+const FOLLOW_FORWARD_HALF_CONE_DEG = 90;
+const FOLLOW_BEARING_MIN_MOVEMENT_M = 5;
 
 const elements = {
   status: document.getElementById('status'),
@@ -18,7 +21,8 @@ const elements = {
   matchedCount: document.getElementById('matched-count'),
   popup: document.getElementById('popup'),
   popupBody: document.getElementById('popup-body'),
-  popupClose: document.getElementById('popup-close')
+  popupClose: document.getElementById('popup-close'),
+  followToggle: document.getElementById('follow-toggle')
 };
 
 const routeGeoJsonFormat = new ol.format.GeoJSON({ featureProjection: 'EPSG:3857' });
@@ -42,11 +46,15 @@ const pointLayer = new ol.layer.Vector({
   source: pointSource,
   style(feature) {
     const active = feature.get('active') === true;
+    const forward = feature.get('forward') === true;
+    const radius = active ? 8 : forward ? 7 : 6;
+    const fillColor = active ? '#9e3d22' : forward ? '#1f4f95' : '#12836b';
+    const strokeWidth = active || forward ? 2 : 1.5;
     return new ol.style.Style({
       image: new ol.style.Circle({
-        radius: active ? 8 : 6,
-        fill: new ol.style.Fill({ color: active ? '#9e3d22' : '#12836b' }),
-        stroke: new ol.style.Stroke({ color: '#ffffff', width: 1.5 })
+        radius,
+        fill: new ol.style.Fill({ color: fillColor }),
+        stroke: new ol.style.Stroke({ color: '#ffffff', width: strokeWidth })
       })
     });
   }
@@ -115,6 +123,10 @@ const API_PAGE_LIMIT = 10000;
 const featureIndex = new Map();
 let latestRouteLoadToken = 0;
 let latestRefreshToken = 0;
+let followWatchId = null;
+let followLastCoord = null;
+let followBearingDeg = null;
+let followLastRefreshAt = 0;
 
 /** Returns the currently selected route source mode. */
 function selectedSourceMode() {
@@ -611,10 +623,118 @@ async function handleCurrentLocation() {
   }
 }
 
+/** Marks rendered point features that fall in the forward cone of the follow heading. */
+function applyForwardEmphasis() {
+  if (followBearingDeg === null || !followLastCoord) {
+    for (const feature of pointSource.getFeatures()) {
+      feature.set('forward', false);
+    }
+    return;
+  }
+  for (const feature of pointSource.getFeatures()) {
+    const lonLat = ol.proj.toLonLat(feature.getGeometry().getCoordinates());
+    const target = window.RouteMath.bearingDegrees(followLastCoord, lonLat);
+    const inFront = target !== null
+      ? window.RouteMath.isWithinHeadingDeg(followBearingDeg, target, FOLLOW_FORWARD_HALF_CONE_DEG)
+      : false;
+    feature.set('forward', inFront);
+  }
+}
+
+/** Handles a single follow-mode position update. */
+async function handleFollowPosition(position) {
+  const coord = [position.coords.longitude, position.coords.latitude];
+  if (followLastCoord) {
+    const distance = window.RouteMath.pointToPointDistanceMeters(followLastCoord, coord);
+    if (distance >= FOLLOW_BEARING_MIN_MOVEMENT_M) {
+      const bearing = window.RouteMath.bearingDegrees(followLastCoord, coord);
+      if (bearing !== null) followBearingDeg = bearing;
+    }
+  }
+  followLastCoord = coord;
+
+  routeFeature = null;
+  routeCoordinates = [coord];
+  renderCurrentLocation(coord);
+  updateRoutePointCount();
+
+  const now = Date.now();
+  const stale = now - followLastRefreshAt >= FOLLOW_MIN_REFRESH_INTERVAL_MS;
+  const noPriorResults = allMatchedPoints.length === 0;
+  if (stale || noPriorResults) {
+    followLastRefreshAt = now;
+    await refreshMap([...routeCoordinates]);
+  }
+  applyForwardEmphasis();
+  const bearingLabel = followBearingDeg !== null ? `${Math.round(followBearingDeg)}°` : '方位推定中';
+  setStatus(`追従中 (${bearingLabel})`);
+}
+
+/** Handles a follow-mode geolocation error and stops the watch. */
+function handleFollowError(error) {
+  console.error('follow position error', error);
+  setStatus('追従モード: 位置情報の取得に失敗しました');
+  if (elements.followToggle.checked) {
+    elements.followToggle.checked = false;
+  }
+  stopFollowMode();
+}
+
+/** Starts watching the device position and switches to current-location mode. */
+async function startFollowMode() {
+  if (!navigator.geolocation) {
+    setStatus('このブラウザは現在地取得に対応していません');
+    elements.followToggle.checked = false;
+    return;
+  }
+  if (followWatchId !== null) return;
+
+  const currentRadio = document.querySelector('input[name="source-mode"][value="current"]');
+  if (currentRadio && !currentRadio.checked) {
+    currentRadio.checked = true;
+    syncSourceModeUi();
+  }
+  followLastRefreshAt = 0;
+  setStatus('追従モード: 現在地を取得中...');
+  followWatchId = navigator.geolocation.watchPosition(
+    handleFollowPosition,
+    handleFollowError,
+    { enableHighAccuracy: false, timeout: 15000, maximumAge: 30000 }
+  );
+}
+
+/** Stops watching the device position and clears forward emphasis. */
+function stopFollowMode() {
+  if (followWatchId !== null) {
+    navigator.geolocation.clearWatch(followWatchId);
+    followWatchId = null;
+  }
+  followBearingDeg = null;
+  followLastCoord = null;
+  followLastRefreshAt = 0;
+  applyForwardEmphasis();
+}
+
+/** Toggle handler for the follow checkbox. */
+async function handleFollowToggle() {
+  if (elements.followToggle.checked) {
+    await startFollowMode();
+  } else {
+    stopFollowMode();
+    setStatus('追従モードを停止しました');
+  }
+}
+
 /** Wires DOM and map click events for the static frontend. */
 function bindEvents() {
   for (const input of document.querySelectorAll('input[name="source-mode"]')) {
-    input.addEventListener('change', syncSourceModeUi);
+    input.addEventListener('change', () => {
+      if (selectedSourceMode() !== 'current' && elements.followToggle.checked) {
+        elements.followToggle.checked = false;
+        stopFollowMode();
+      }
+      syncSourceModeUi();
+    });
   }
   elements.distanceThreshold.addEventListener('input', syncDistanceUi);
   elements.distanceThreshold.addEventListener('change', () => {
@@ -628,6 +748,7 @@ function bindEvents() {
   }
   elements.gpxFile.addEventListener('change', handleGpxFile);
   elements.useCurrentLocation.addEventListener('click', handleCurrentLocation);
+  elements.followToggle.addEventListener('change', handleFollowToggle);
   elements.pointList.addEventListener('mouseover', (event) => {
     const item = findPointListItem(event.target);
     if (!item || item === findPointListItem(event.relatedTarget)) return;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -777,6 +777,7 @@ async function startFollowMode() {
   }
   if (followWatchId !== null) return;
 
+  manualPoints = [];
   const currentRadio = document.querySelector('input[name="source-mode"][value="current"]');
   if (currentRadio && !currentRadio.checked) {
     currentRadio.checked = true;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -746,8 +746,15 @@ function handleFollowPosition(position) {
   });
 }
 
+/** Returns true when follow mode is currently active (watch running and toggle on). */
+function isFollowActive() {
+  return followWatchId !== null && elements.followToggle.checked;
+}
+
 /** Async core for follow-mode position updates; called via the sync wrapper above. */
 async function handleFollowPositionAsync(position) {
+  if (!isFollowActive()) return;
+
   const coord = [position.coords.longitude, position.coords.latitude];
   if (followLastCoord) {
     const distance = window.RouteMath.pointToPointDistanceMeters(followLastCoord, coord);
@@ -765,10 +772,11 @@ async function handleFollowPositionAsync(position) {
 
   const now = Date.now();
   const stale = now - followLastRefreshAt >= FOLLOW_MIN_REFRESH_INTERVAL_MS;
-  const noPriorResults = allMatchedPoints.length === 0;
-  if (stale || noPriorResults) {
+  const firstFollowRefresh = followLastRefreshAt === 0;
+  if (stale || firstFollowRefresh) {
     followLastRefreshAt = now;
     await refreshMap([...routeCoordinates]);
+    if (!isFollowActive()) return;
   }
   applyForwardEmphasis();
   const bearingLabel = followBearingDeg !== null ? `${Math.round(followBearingDeg)}°` : '方位推定中';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,7 +39,13 @@
         </div>
 
         <div class="source-panel" id="current-location-panel">
-          <button id="use-current-location" type="button" class="secondary-action">現在地を使う</button>
+          <div class="current-location-controls">
+            <button id="use-current-location" type="button" class="secondary-action">現在地を使う</button>
+            <label class="follow-toggle">
+              <input id="follow-toggle" type="checkbox" />
+              <span>追従モード (走行中の自動更新)</span>
+            </label>
+          </div>
         </div>
 
         <fieldset class="distance-ladder">

--- a/frontend/route_math.js
+++ b/frontend/route_math.js
@@ -124,10 +124,38 @@
     ];
   }
 
+  /** Computes the initial bearing in degrees [0, 360) from one lon/lat point to another. */
+  function bearingDegrees(from, to) {
+    if (
+      !Array.isArray(from) || from.length < 2 || !Number.isFinite(from[0]) || !Number.isFinite(from[1]) ||
+      !Array.isArray(to) || to.length < 2 || !Number.isFinite(to[0]) || !Number.isFinite(to[1])
+    ) {
+      return null;
+    }
+    const φ1 = toRadians(from[1]);
+    const φ2 = toRadians(to[1]);
+    const Δλ = toRadians(to[0] - from[0]);
+    const x = Math.sin(Δλ) * Math.cos(φ2);
+    const y = Math.cos(φ1) * Math.sin(φ2) - Math.sin(φ1) * Math.cos(φ2) * Math.cos(Δλ);
+    const θ = Math.atan2(x, y);
+    return ((θ * 180) / Math.PI + 360) % 360;
+  }
+
+  /** Returns true if `target` bearing is within ±halfConeDeg of `heading` bearing. */
+  function isWithinHeadingDeg(heading, target, halfConeDeg) {
+    if (!Number.isFinite(heading) || !Number.isFinite(target) || !Number.isFinite(halfConeDeg)) {
+      return false;
+    }
+    const diff = (((target - heading) + 540) % 360) - 180;
+    return Math.abs(diff) <= halfConeDeg;
+  }
+
   return {
     computeBbox,
     expandBbox,
     pointToPointDistanceMeters,
-    pointToRouteDistanceMeters
+    pointToRouteDistanceMeters,
+    bearingDegrees,
+    isWithinHeadingDeg
   };
 });

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -141,6 +141,26 @@ body {
   justify-content: center;
 }
 
+.current-location-controls {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.follow-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--ink);
+}
+
+.follow-toggle input[type="checkbox"] {
+  accent-color: var(--accent);
+}
+
 .source-panel.inactive {
   opacity: 0.5;
 }

--- a/tests/route_math.test.js
+++ b/tests/route_math.test.js
@@ -5,7 +5,9 @@ const {
   computeBbox,
   expandBbox,
   pointToPointDistanceMeters,
-  pointToRouteDistanceMeters
+  pointToRouteDistanceMeters,
+  bearingDegrees,
+  isWithinHeadingDeg
 } = require('../frontend/route_math');
 const { parseCoordinateTokens, parseGpxText } = require('../frontend/gpx');
 
@@ -89,4 +91,46 @@ test('Route Math: 単一点どうしの距離をメートル換算できる', ()
 test('Route Math: 非数値の座標は無限距離として扱う', () => {
   const distance = pointToPointDistanceMeters([139.0, Number.NaN], [139.001, 35.0]);
   assert.equal(distance, Number.POSITIVE_INFINITY);
+});
+
+test('Route Math: 真北は方位 0 度になる', () => {
+  const bearing = bearingDegrees([139.0, 35.0], [139.0, 35.1]);
+  assert.ok(bearing >= 359 || bearing <= 1, `expected ~0, got ${bearing}`);
+});
+
+test('Route Math: 真東は方位 90 度になる', () => {
+  const bearing = bearingDegrees([139.0, 35.0], [139.1, 35.0]);
+  assert.ok(bearing > 89 && bearing < 91, `expected ~90, got ${bearing}`);
+});
+
+test('Route Math: 真南は方位 180 度になる', () => {
+  const bearing = bearingDegrees([139.0, 35.1], [139.0, 35.0]);
+  assert.ok(bearing > 179 && bearing < 181, `expected ~180, got ${bearing}`);
+});
+
+test('Route Math: 真西は方位 270 度になる', () => {
+  const bearing = bearingDegrees([139.1, 35.0], [139.0, 35.0]);
+  assert.ok(bearing > 269 && bearing < 271, `expected ~270, got ${bearing}`);
+});
+
+test('Route Math: 不正な座標の方位は null を返す', () => {
+  assert.equal(bearingDegrees(null, [139.0, 35.0]), null);
+  assert.equal(bearingDegrees([Number.NaN, 35.0], [139.0, 35.0]), null);
+});
+
+test('Route Math: ヘディング許容範囲内なら true', () => {
+  assert.equal(isWithinHeadingDeg(0, 45, 90), true);
+  assert.equal(isWithinHeadingDeg(0, 90, 90), true);
+  assert.equal(isWithinHeadingDeg(0, 91, 90), false);
+});
+
+test('Route Math: ヘディングは 360 度ラップを正しく扱う', () => {
+  assert.equal(isWithinHeadingDeg(350, 10, 30), true);
+  assert.equal(isWithinHeadingDeg(10, 350, 30), true);
+  assert.equal(isWithinHeadingDeg(0, 180, 90), false);
+});
+
+test('Route Math: 不正なヘディング入力は false を返す', () => {
+  assert.equal(isWithinHeadingDeg(Number.NaN, 90, 90), false);
+  assert.equal(isWithinHeadingDeg(0, Number.NaN, 90), false);
 });


### PR DESCRIPTION
Closes #41

## Summary
- 現在地モードに **追従モード** チェックボックスを追加
- ON で \`navigator.geolocation.watchPosition\` を起動 (低電力設定: \`enableHighAccuracy: false\`, \`maximumAge: 30000\`)
- 位置更新ごとに現在地マーカーを更新し、API への近傍検索は **30 秒間隔** で再実行 (走行中の連続更新で API を叩きすぎない)
- 連続2点 (>=5m移動) から進行方向を推定し、status バーに方位表示
- 補給地点のうち **方位 ±90 度内** にあるものを \`forward\` フラグで強調 (青、半径+1)
- 追従中にソースモードを変更すると自動 OFF + watch 解除、checkbox 手動解除でも同様

## バッテリ配慮
- \`enableHighAccuracy: false\` で GPS 高精度モードを使わない
- API 再検索は 30 秒に制限
- 進行方向の推定は 5m 以上移動した時だけ更新 (停止時のノイズを抑える)

## Test plan
- [x] \`npm test\` (54/54 pass: 既存46 + 新規 \`bearingDegrees\` / \`isWithinHeadingDeg\` 8件)
  - 真北/真東/真南/真西の方位が 0/90/180/270 ±1°
  - ヘディング 360 度ラップ (350° から 10° は 30° 以内に true)
  - 不正入力で \`null\` / \`false\` を返す
- [x] \`node --check frontend/app.js\` / \`route_math.js\`
- [x] Playwright スモーク (\`./.local/follow_mode_smoketest.mjs\`):
  - \`watchPosition\` を init script でモック、初期位置 (35.683, 139.769) で 45 件マッチ
  - 東進する2回の位置イベントで status が \"追従中 (90°)\" になる
  - source-mode を \`gpx\` に切り替えると追従 OFF + \`clearWatch\` 実行 (\`watchCount: 0\`)
  - チェック ON / OFF で watch ハンドルが正しく増減
  - JS / page エラー無し

## 補足
PR #42 (manual mode) と PR #43 (geo search) の差分とは独立 (\`current-location-panel\` 内の追加と \`pointLayer\` style 拡張のみ)。マージ順は問わないが、複数同時マージで簡易な競合は \`elements\` / \`bindEvents\` の追記行で発生する可能性あり (リベースで吸収可能)。