### PR TITLE
feat: 印刷用キューシート (距離・左右・補給地点) を追加

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -223,7 +223,7 @@ function resetResults() {
   pointSource.clear();
   buildPointList([]);
   updateSummary(0);
-  if (elements.cueSheetButton) elements.cueSheetButton.disabled = true;
+  syncCueSheetButton();
   clearPopup();
 }
 
@@ -384,6 +384,7 @@ function updateSummary(visibleCount) {
 
 /** Enables the cue-sheet button only when a route and matched results exist. */
 function syncCueSheetButton() {
+  if (!elements.cueSheetButton) return;
   const ready = routeCoordinates.length >= 2 && filteredPoints.length > 0;
   elements.cueSheetButton.disabled = !ready;
 }
@@ -1123,7 +1124,9 @@ function bindEvents() {
     activatePoint(item.dataset.supplyPointId);
   });
   elements.popupClose.addEventListener('click', clearPopup);
-  elements.cueSheetButton.addEventListener('click', openCueSheet);
+  if (elements.cueSheetButton) {
+    elements.cueSheetButton.addEventListener('click', openCueSheet);
+  }
   elements.resultsToggle.addEventListener('click', () => {
     if (desktopMediaQuery && desktopMediaQuery.matches) return;
     const expanded = elements.resultsSheet.classList.toggle('expanded');
@@ -1155,4 +1158,5 @@ updateRoutePointCount();
 syncDistanceUi();
 buildPointList([]);
 updateSummary(0);
+syncCueSheetButton();
 bindEvents();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -40,8 +40,11 @@ const elements = {
   geoSearchClear: document.getElementById('geo-search-clear'),
   geoSearchResults: document.getElementById('geo-search-results'),
   resultsSheet: document.getElementById('results-sheet'),
-  resultsToggle: document.getElementById('results-toggle')
+  resultsToggle: document.getElementById('results-toggle'),
+  cueSheetButton: document.getElementById('cue-sheet-button')
 };
+
+const CUE_SHEET_STORAGE_KEY = 'rideoasis-cue-sheet';
 
 const desktopMediaQuery = typeof window.matchMedia === 'function'
   ? window.matchMedia('(min-width: 821px)')
@@ -220,6 +223,7 @@ function resetResults() {
   pointSource.clear();
   buildPointList([]);
   updateSummary(0);
+  if (elements.cueSheetButton) elements.cueSheetButton.disabled = true;
   clearPopup();
 }
 
@@ -376,6 +380,28 @@ function clearPopup() {
 /** Updates summary card for visible results. */
 function updateSummary(visibleCount) {
   elements.matchedCount.textContent = String(visibleCount);
+}
+
+/** Enables the cue-sheet button only when a route and matched results exist. */
+function syncCueSheetButton() {
+  const ready = routeCoordinates.length >= 2 && filteredPoints.length > 0;
+  elements.cueSheetButton.disabled = !ready;
+}
+
+/** Serializes the current cue-sheet input and opens the printable page. */
+function openCueSheet() {
+  if (routeCoordinates.length < 2 || filteredPoints.length === 0) return;
+  try {
+    localStorage.setItem(CUE_SHEET_STORAGE_KEY, JSON.stringify({
+      routeCoordinates,
+      filteredPoints,
+      distanceMeters: selectedDistanceMeters(),
+      generatedAt: new Date().toISOString()
+    }));
+  } catch (error) {
+    console.error('Failed to serialize cue-sheet input', error);
+  }
+  window.open('./print.html', '_blank', 'noopener');
 }
 
 /** Clears the three drawing sources used for route and location visuals. */
@@ -582,6 +608,7 @@ function applyResultFilters() {
     popupOverlay.setPosition(undefined);
   }
   updateSummary(filteredPoints.length);
+  syncCueSheetButton();
   fitToVisibleData();
   setStatus(`${filteredPoints.length} 件を表示中`);
 }
@@ -1094,6 +1121,7 @@ function bindEvents() {
     activatePoint(item.dataset.supplyPointId);
   });
   elements.popupClose.addEventListener('click', clearPopup);
+  elements.cueSheetButton.addEventListener('click', openCueSheet);
   elements.resultsToggle.addEventListener('click', () => {
     if (desktopMediaQuery && desktopMediaQuery.matches) return;
     const expanded = elements.resultsSheet.classList.toggle('expanded');

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -400,6 +400,8 @@ function openCueSheet() {
     }));
   } catch (error) {
     console.error('Failed to serialize cue-sheet input', error);
+    setStatus('キューシートデータの保存に失敗しました');
+    return;
   }
   window.open('./print.html', '_blank', 'noopener');
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -128,15 +128,21 @@
       </main>
 
       <aside class="results-sheet" id="results-sheet" aria-label="検索結果">
-        <button class="results-toggle" id="results-toggle" type="button" aria-expanded="false" aria-controls="results-body">
-          <span class="results-handle" aria-hidden="true"></span>
-          <span class="results-summary">
-            <span>結果</span>
-            <strong id="matched-count">-</strong>
-            <span class="results-summary-unit">件</span>
-          </span>
-          <span class="results-toggle-icon" aria-hidden="true">⌃</span>
-        </button>
+        <div class="results-header">
+          <button class="results-toggle" id="results-toggle" type="button" aria-expanded="false" aria-controls="results-body">
+            <span class="results-handle" aria-hidden="true"></span>
+            <span class="results-summary">
+              <span>結果</span>
+              <strong id="matched-count">-</strong>
+              <span class="results-summary-unit">件</span>
+            </span>
+            <span class="results-toggle-icon" aria-hidden="true">⌃</span>
+          </button>
+          <button id="cue-sheet-button" class="cue-sheet-button" type="button" disabled aria-label="キューシートを印刷">
+            <span aria-hidden="true">🖨</span>
+            <span>キューシート</span>
+          </button>
+        </div>
         <div class="results-body" id="results-body">
           <div class="results-filters">
             <fieldset class="chains result-filters chain-filters">

--- a/frontend/print.css
+++ b/frontend/print.css
@@ -342,7 +342,9 @@ td.side-c {
   }
 
   .col-perp,
-  .col-addr {
+  .col-addr,
+  tbody td:nth-child(5),
+  tbody td:nth-child(7) {
     display: none;
   }
 }

--- a/frontend/print.css
+++ b/frontend/print.css
@@ -1,0 +1,348 @@
+:root {
+  --c-ink: #1f1f1c;
+  --c-muted: #6c6a63;
+  --c-line: #d6d2c5;
+  --c-line-strong: #b3ae9f;
+  --c-bg: #ffffff;
+  --c-stripe: #faf8f3;
+  --c-accent: #225ea8;
+  --c-accent-strong: #18467a;
+  --c-left: #1f7a67;
+  --c-left-soft: #e3f2ec;
+  --c-right: #b1431f;
+  --c-right-soft: #fae8de;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--c-bg);
+  color: var(--c-ink);
+  font-family: "Hiragino Sans", "Yu Gothic UI", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  font-size: 13px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  padding: 16px 24px 24px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  align-items: end;
+  gap: 8px 16px;
+  padding-bottom: 12px;
+  border-bottom: 2px solid var(--c-ink);
+  margin-bottom: 14px;
+}
+
+.page-title h1 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 0.02em;
+}
+
+.page-subtitle {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--c-muted);
+}
+
+.page-meta {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 12px;
+  color: var(--c-muted);
+}
+
+.page-meta strong {
+  color: var(--c-ink);
+  font-weight: 700;
+  margin-left: 4px;
+}
+
+.page-actions {
+  grid-column: 2;
+  grid-row: 1;
+  display: flex;
+  gap: 8px;
+}
+
+.page-actions button {
+  padding: 6px 12px;
+  border: 1px solid var(--c-line-strong);
+  background: #fff;
+  font: inherit;
+  cursor: pointer;
+  border-radius: 6px;
+}
+
+.page-actions button:hover,
+.page-actions button:focus-visible {
+  border-color: var(--c-accent);
+  background: #f0f5fb;
+}
+
+.page-actions button.primary {
+  background: var(--c-accent);
+  border-color: var(--c-accent);
+  color: #fff;
+  font-weight: 700;
+}
+
+.page-actions button.primary:hover,
+.page-actions button.primary:focus-visible {
+  background: var(--c-accent-strong);
+  border-color: var(--c-accent-strong);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+th,
+td {
+  padding: 6px 8px;
+  border: 1px solid var(--c-line);
+  text-align: left;
+  vertical-align: top;
+}
+
+thead th {
+  background: #f1ebdc;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--c-muted);
+}
+
+tbody tr:nth-child(even) td {
+  background: var(--c-stripe);
+}
+
+.col-no {
+  width: 40px;
+  text-align: right;
+}
+
+.col-cum,
+.col-int,
+.col-perp {
+  width: 64px;
+  text-align: right;
+}
+
+.col-side {
+  width: 56px;
+  text-align: center;
+}
+
+.col-store {
+  width: 28%;
+}
+
+.col-addr {
+  width: auto;
+}
+
+td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+td.side {
+  text-align: center;
+  font-weight: 800;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+}
+
+td.side-l {
+  background: var(--c-left-soft);
+  color: var(--c-left);
+}
+
+td.side-r {
+  background: var(--c-right-soft);
+  color: var(--c-right);
+}
+
+td.side-c {
+  color: var(--c-muted);
+}
+
+.chain-badge {
+  display: inline-block;
+  margin-right: 6px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: #eef4fb;
+  color: var(--c-accent);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  vertical-align: 1px;
+}
+
+.store-name {
+  font-weight: 700;
+}
+
+.empty {
+  text-align: center;
+  color: var(--c-muted);
+  padding: 24px;
+}
+
+.page-footer {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  margin-top: 16px;
+  padding-top: 8px;
+  border-top: 1px solid var(--c-line);
+  font-size: 10px;
+  color: var(--c-muted);
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.side-mark {
+  display: inline-block;
+  min-width: 22px;
+  padding: 1px 4px;
+  border-radius: 4px;
+  text-align: center;
+  font-weight: 700;
+  font-size: 10px;
+}
+
+.side-mark.side-l {
+  background: var(--c-left-soft);
+  color: var(--c-left);
+}
+
+.side-mark.side-r {
+  background: var(--c-right-soft);
+  color: var(--c-right);
+}
+
+@media print {
+  @page {
+    size: A4 portrait;
+    margin: 12mm;
+  }
+
+  body {
+    padding: 0;
+    max-width: none;
+  }
+
+  .no-print {
+    display: none !important;
+  }
+
+  .page-header {
+    grid-template-columns: 1fr;
+    border-bottom: 1px solid #000;
+    padding-bottom: 6px;
+    margin-bottom: 8px;
+  }
+
+  .page-title h1 {
+    font-size: 14pt;
+  }
+
+  table {
+    font-size: 9pt;
+  }
+
+  thead {
+    display: table-header-group;
+  }
+
+  tr {
+    page-break-inside: avoid;
+  }
+
+  .page-footer {
+    margin-top: 8px;
+    font-size: 8pt;
+  }
+
+  td.side-l {
+    background: var(--c-left-soft) !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  td.side-r {
+    background: var(--c-right-soft) !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 12px;
+  }
+
+  .page-header {
+    grid-template-columns: 1fr;
+  }
+
+  .page-actions {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  table {
+    font-size: 11px;
+  }
+
+  th,
+  td {
+    padding: 4px 6px;
+  }
+
+  .col-no,
+  .col-cum,
+  .col-int,
+  .col-perp,
+  .col-side {
+    width: auto;
+  }
+
+  .col-perp,
+  .col-addr {
+    display: none;
+  }
+}

--- a/frontend/print.css
+++ b/frontend/print.css
@@ -256,7 +256,7 @@ td.side-c {
 
 @media print {
   @page {
-    size: A4 portrait;
+    size: a4 portrait;
     margin: 12mm;
   }
 
@@ -289,7 +289,7 @@ td.side-c {
   }
 
   tr {
-    page-break-inside: avoid;
+    break-inside: avoid;
   }
 
   .page-footer {

--- a/frontend/print.html
+++ b/frontend/print.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RideOasis キューシート (補給地点)</title>
+    <link rel="stylesheet" href="./print.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <div class="page-title">
+        <h1>RideOasis キューシート</h1>
+        <p class="page-subtitle">補給地点リスト</p>
+      </div>
+      <div class="page-meta">
+        <span id="meta-route-length">経路長: -</span>
+        <span id="meta-distance">近傍距離: -</span>
+        <span id="meta-count">補給地点: -</span>
+      </div>
+      <div class="page-actions no-print">
+        <button id="print-btn" type="button" class="primary">印刷 / PDF 保存</button>
+        <button id="close-btn" type="button">閉じる</button>
+      </div>
+    </header>
+
+    <main>
+      <table id="cue-table">
+        <thead>
+          <tr>
+            <th class="col-no">No</th>
+            <th class="col-cum">累計 km</th>
+            <th class="col-int">区間 km</th>
+            <th class="col-side">左/右</th>
+            <th class="col-perp">離れ m</th>
+            <th class="col-store">店舗</th>
+            <th class="col-addr">住所</th>
+          </tr>
+        </thead>
+        <tbody id="cue-body">
+          <tr>
+            <td colspan="7" class="empty">補給地点データがありません。元のページで GPX または手動2点指定を行い、検索結果が表示された状態で「キューシート」ボタンを押してください。</td>
+          </tr>
+        </tbody>
+      </table>
+    </main>
+
+    <footer class="page-footer">
+      <span>RideOasis - <span id="generated-at"></span></span>
+      <span class="legend">
+        <span class="legend-item"><span class="side-mark side-l">左</span> = 進行方向左 (停車しやすい)</span>
+        <span class="legend-item"><span class="side-mark side-r">右</span> = 進行方向右 (横断が必要な場合あり)</span>
+      </span>
+    </footer>
+
+    <script src="./route_math.js"></script>
+    <script src="./print.js"></script>
+  </body>
+</html>

--- a/frontend/print.js
+++ b/frontend/print.js
@@ -1,0 +1,111 @@
+(function () {
+  'use strict';
+
+  const STORAGE_KEY = 'rideoasis-cue-sheet';
+
+  /** Reads serialized cue-sheet input from localStorage. */
+  function loadInput() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  /** Escapes text before inserting into innerHTML. */
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
+  }
+
+  /** Formats a meter distance as "12.3 km" or "850 m". */
+  function formatDistanceMeters(meters) {
+    if (!Number.isFinite(meters)) return '-';
+    if (meters >= 1000) return `${(meters / 1000).toFixed(meters >= 10000 ? 0 : 1)} km`;
+    return `${Math.round(meters)} m`;
+  }
+
+  /** Renders the cue-sheet rows derived from route + matched supply points. */
+  function render(input) {
+    const tbody = document.getElementById('cue-body');
+    const metaRouteLength = document.getElementById('meta-route-length');
+    const metaDistance = document.getElementById('meta-distance');
+    const metaCount = document.getElementById('meta-count');
+    const generatedAt = document.getElementById('generated-at');
+
+    if (!input || !Array.isArray(input.routeCoordinates) || input.routeCoordinates.length < 2) {
+      generatedAt.textContent = new Date().toLocaleString('ja-JP');
+      return;
+    }
+
+    const points = Array.isArray(input.filteredPoints) ? input.filteredPoints : [];
+    const cum = window.RouteMath.cumulativeDistancesMeters(input.routeCoordinates);
+    const totalKm = cum[cum.length - 1] / 1000;
+
+    const rows = points
+      .map((feature) => {
+        const proj = window.RouteMath.routeProjection(
+          feature.geometry.coordinates,
+          input.routeCoordinates,
+          cum
+        );
+        return proj ? { feature, proj } : null;
+      })
+      .filter((row) => row !== null)
+      .sort((a, b) => a.proj.alongMeters - b.proj.alongMeters);
+
+    metaRouteLength.innerHTML = `経路長 <strong>${totalKm.toFixed(1)} km</strong>`;
+    metaDistance.innerHTML = `近傍距離 <strong>${formatDistanceMeters(input.distanceMeters)}</strong>`;
+    metaCount.innerHTML = `補給地点 <strong>${rows.length}</strong> 件`;
+    generatedAt.textContent = input.generatedAt
+      ? new Date(input.generatedAt).toLocaleString('ja-JP')
+      : new Date().toLocaleString('ja-JP');
+
+    if (rows.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="7" class="empty">条件に一致する補給地点はありません。</td></tr>';
+      return;
+    }
+
+    tbody.innerHTML = '';
+    let prevAlong = 0;
+    rows.forEach((row, index) => {
+      const { feature, proj } = row;
+      const props = feature.properties || {};
+      const intervalMeters = proj.alongMeters - prevAlong;
+      prevAlong = proj.alongMeters;
+
+      const cumKm = (proj.alongMeters / 1000).toFixed(1);
+      const intervalKm = (intervalMeters / 1000).toFixed(1);
+      const sideLabel = proj.side === 'L' ? '左' : proj.side === 'R' ? '右' : '・';
+      const sideClass = `side side-${proj.side.toLowerCase()}`;
+
+      const tr = document.createElement('tr');
+      tr.innerHTML = [
+        `<td class="num">${index + 1}</td>`,
+        `<td class="num">${cumKm}</td>`,
+        `<td class="num">${intervalKm}</td>`,
+        `<td class="${sideClass}">${sideLabel}</td>`,
+        `<td class="num">${Math.round(proj.perpMeters)}</td>`,
+        `<td><span class="chain-badge">${escapeHtml(props.chain || '')}</span><span class="store-name">${escapeHtml(props.name || '-')}</span></td>`,
+        `<td>${escapeHtml(props.address_norm || '-')}</td>`
+      ].join('');
+      tbody.appendChild(tr);
+    });
+  }
+
+  function bindControls() {
+    const printBtn = document.getElementById('print-btn');
+    const closeBtn = document.getElementById('close-btn');
+    if (printBtn) printBtn.addEventListener('click', () => window.print());
+    if (closeBtn) closeBtn.addEventListener('click', () => window.close());
+  }
+
+  render(loadInput());
+  bindControls();
+})();

--- a/frontend/route_math.js
+++ b/frontend/route_math.js
@@ -150,12 +150,99 @@
     return Math.abs(diff) <= halfConeDeg;
   }
 
+  /** Returns cumulative meters [0, d1, d1+d2, ...] from the start of the route to each vertex. */
+  function cumulativeDistancesMeters(coordinates) {
+    if (!Array.isArray(coordinates) || coordinates.length === 0) return [];
+    const out = [0];
+    for (let i = 1; i < coordinates.length; i += 1) {
+      out.push(out[i - 1] + pointToPointDistanceMeters(coordinates[i - 1], coordinates[i]));
+    }
+    return out;
+  }
+
+  /**
+   * Projects a lon/lat point onto a polyline route and returns the closest segment
+   * along with cumulative meters from the start, perpendicular meters off the route,
+   * and side ('L' / 'R' / 'C') relative to the local direction of travel.
+   *
+   * The route is interpreted as the direction-of-travel order (start -> goal).
+   * `cumulative`, when provided, must match `cumulativeDistancesMeters(coordinates)`
+   * and is reused to avoid recomputing the prefix sum on every call.
+   */
+  function routeProjection(point, coordinates, cumulative) {
+    if (!Array.isArray(coordinates) || coordinates.length < 2) return null;
+    if (
+      !Array.isArray(point) || point.length < 2 ||
+      !Number.isFinite(point[0]) || !Number.isFinite(point[1])
+    ) {
+      return null;
+    }
+
+    const referenceLat = meanLatitude(coordinates);
+    const projected = coordinates.map((coord) => projectLonLatToMeters(coord, referenceLat));
+    const p = projectLonLatToMeters(point, referenceLat);
+
+    let bestIndex = -1;
+    let bestT = 0;
+    let bestPerp = Number.POSITIVE_INFINITY;
+
+    for (let i = 1; i < projected.length; i += 1) {
+      const a = projected[i - 1];
+      const b = projected[i];
+      const abx = b[0] - a[0];
+      const aby = b[1] - a[1];
+      const ab2 = abx * abx + aby * aby;
+      if (ab2 === 0) continue;
+      const apx = p[0] - a[0];
+      const apy = p[1] - a[1];
+      const t = Math.max(0, Math.min(1, (apx * abx + apy * aby) / ab2));
+      const closestX = a[0] + abx * t;
+      const closestY = a[1] + aby * t;
+      const perp = Math.hypot(p[0] - closestX, p[1] - closestY);
+      if (perp < bestPerp) {
+        bestPerp = perp;
+        bestIndex = i - 1;
+        bestT = t;
+      }
+    }
+
+    if (bestIndex < 0) return null;
+
+    const cum = Array.isArray(cumulative) && cumulative.length === coordinates.length
+      ? cumulative
+      : cumulativeDistancesMeters(coordinates);
+    const segLen = cum[bestIndex + 1] - cum[bestIndex];
+    const alongMeters = cum[bestIndex] + segLen * bestT;
+
+    const a = projected[bestIndex];
+    const b = projected[bestIndex + 1];
+    const fx = b[0] - a[0];
+    const fy = b[1] - a[1];
+    const closestX = a[0] + fx * bestT;
+    const closestY = a[1] + fy * bestT;
+    const ox = p[0] - closestX;
+    const oy = p[1] - closestY;
+    const cross = fx * oy - fy * ox;
+    let side = 'C';
+    if (cross > 0) side = 'L';
+    else if (cross < 0) side = 'R';
+
+    return {
+      segmentIndex: bestIndex,
+      alongMeters,
+      perpMeters: bestPerp,
+      side
+    };
+  }
+
   return {
     computeBbox,
     expandBbox,
     pointToPointDistanceMeters,
     pointToRouteDistanceMeters,
     bearingDegrees,
-    isWithinHeadingDeg
+    isWithinHeadingDeg,
+    cumulativeDistancesMeters,
+    routeProjection
   };
 });

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -617,18 +617,55 @@ input[type="search"]::-webkit-search-cancel-button {
   max-height: var(--results-expanded-h);
 }
 
+.results-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  height: var(--results-collapsed-h);
+  padding-right: var(--space-3);
+  flex-shrink: 0;
+}
+
 .results-toggle {
+  flex: 1;
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  height: var(--results-collapsed-h);
-  width: 100%;
+  height: 100%;
   padding: 0 var(--space-4);
   border: 0;
   background: transparent;
   cursor: pointer;
   font-weight: 700;
   text-align: left;
+}
+
+.cue-sheet-button {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 36px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--c-line-strong);
+  border-radius: var(--r-pill);
+  background: var(--c-surface);
+  color: var(--c-ink);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.cue-sheet-button:hover:not(:disabled),
+.cue-sheet-button:focus-visible:not(:disabled) {
+  border-color: var(--c-accent);
+  background: var(--c-accent-soft);
+  color: var(--c-accent-strong);
+}
+
+.cue-sheet-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .results-handle {
@@ -920,6 +957,16 @@ input[type="search"]::-webkit-search-cancel-button {
 
   .results-filters .chains label {
     flex: 1 1 calc(50% - var(--space-2));
+    justify-content: center;
+  }
+
+  .cue-sheet-button span:not([aria-hidden="true"]) {
+    display: none;
+  }
+
+  .cue-sheet-button {
+    width: 36px;
+    padding: 0;
     justify-content: center;
   }
 }

--- a/tests/route_math.test.js
+++ b/tests/route_math.test.js
@@ -7,7 +7,9 @@ const {
   pointToPointDistanceMeters,
   pointToRouteDistanceMeters,
   bearingDegrees,
-  isWithinHeadingDeg
+  isWithinHeadingDeg,
+  cumulativeDistancesMeters,
+  routeProjection
 } = require('../frontend/route_math');
 const { parseCoordinateTokens, parseGpxText } = require('../frontend/gpx');
 
@@ -137,4 +139,70 @@ test('Route Math: ヘディングは 360 度ラップを正しく扱う', () => 
 test('Route Math: 不正なヘディング入力は false を返す', () => {
   assert.equal(isWithinHeadingDeg(Number.NaN, 90, 90), false);
   assert.equal(isWithinHeadingDeg(0, Number.NaN, 90), false);
+});
+
+test('Route Math: 累計距離は各頂点までの合計を返す', () => {
+  const cum = cumulativeDistancesMeters([
+    [139.0, 35.0],
+    [139.001, 35.0],
+    [139.002, 35.0]
+  ]);
+  assert.equal(cum.length, 3);
+  assert.equal(cum[0], 0);
+  assert.ok(cum[1] > 80 && cum[1] < 100);
+  assert.ok(cum[2] > 170 && cum[2] < 200);
+});
+
+test('Route Math: 累計距離は空配列で空配列を返す', () => {
+  assert.deepEqual(cumulativeDistancesMeters([]), []);
+});
+
+test('Route Math: routeProjection は東進ルートで北側の点を L と判定する', () => {
+  const proj = routeProjection([139.001, 35.0001], [
+    [139.0, 35.0],
+    [139.002, 35.0]
+  ]);
+  assert.equal(proj.side, 'L');
+  assert.ok(proj.perpMeters > 0);
+});
+
+test('Route Math: routeProjection は東進ルートで南側の点を R と判定する', () => {
+  const proj = routeProjection([139.001, 34.9999], [
+    [139.0, 35.0],
+    [139.002, 35.0]
+  ]);
+  assert.equal(proj.side, 'R');
+});
+
+test('Route Math: routeProjection は北進ルートで東側の点を R と判定する', () => {
+  const proj = routeProjection([139.0001, 35.001], [
+    [139.0, 35.0],
+    [139.0, 35.002]
+  ]);
+  assert.equal(proj.side, 'R');
+});
+
+test('Route Math: routeProjection は累計距離 (alongMeters) を正しく計算する', () => {
+  const coords = [
+    [139.0, 35.0],
+    [139.002, 35.0],
+    [139.004, 35.0]
+  ];
+  const cum = cumulativeDistancesMeters(coords);
+  // Project to mid of segment 2 -> alongMeters ≈ cum[1] + segment2Length/2 ≈ cum[1] + (cum[2]-cum[1])/2
+  const proj = routeProjection([139.003, 35.0], coords, cum);
+  assert.equal(proj.segmentIndex, 1);
+  const expected = cum[1] + (cum[2] - cum[1]) * 0.5;
+  assert.ok(Math.abs(proj.alongMeters - expected) < 1);
+});
+
+test('Route Math: routeProjection は経路が短すぎると null を返す', () => {
+  assert.equal(routeProjection([139.0, 35.0], [[139.0, 35.0]]), null);
+  assert.equal(routeProjection([139.0, 35.0], []), null);
+});
+
+test('Route Math: routeProjection は不正な点で null を返す', () => {
+  const coords = [[139.0, 35.0], [139.001, 35.0]];
+  assert.equal(routeProjection([Number.NaN, 35.0], coords), null);
+  assert.equal(routeProjection(null, coords), null);
 });


### PR DESCRIPTION
ブルベ等の長距離ライドで使う紙キューシートを補給地点版で生成する機能。経路上の各補給地点について「累計 km / 区間 km / 進行方向の左右 / 経路からの離れ」を表形式で印刷できる。

## Why
ブルベ走行中は GPX が落ちる/バッテリ切れの保険として紙のキューシートを携行するのが定番。RideOasis の補給地点 DB をそのフォーマットで出力すれば、ライド中に「次の補給ポイントまで Nkm」が紙で確認でき、特に「進行方向の左にある店」が分かるとライド中に停車しやすい (横断不要)。

## 計算
\`frontend/route_math.js\` に2つ追加:
- \`cumulativeDistancesMeters(coords)\` — 経路の累計距離プレフィックス和
- \`routeProjection(point, coords, cumulative?)\` — 補給地点を経路に投影して \`{ segmentIndex, alongMeters, perpMeters, side }\` を返す。\`side\` はローカル進行方向ベクトルと補給地点へのオフセットベクトルの外積符号で \`L\` / \`R\` / \`C\` を判定 (経路は start→goal 方向と解釈)。

ユニットテストは 4方位 (E向きで N側=L, S側=R; N向きで E側=R)、累計距離の中点ケース、不正入力の null 返却をカバー。

## UI
- 結果シートのトグル横に **🖨 キューシート** ボタンを追加
- 経路 (>=2点) かつマッチ件数 >0 のときのみ enabled
- クリックで \`localStorage\` に \`{ routeCoordinates, filteredPoints, distanceMeters, generatedAt }\` を保存し、新規タブで \`print.html\` を開く
- 480px 以下ではアイコンのみに圧縮

## 印刷ページ
- \`/print.html\` + \`print.css\` + \`print.js\` を新規追加
- 表は累計距離でソート、左右セルを色分け (左=緑、右=橙)
- \`@media print\`: A4縦、12mm 余白、thead を各ページに繰り返し、行を分割しない、色を保持
- \`@media (max-width: 720px)\` で離れ・住所カラムを畳んでスマホでも見やすい
- 「印刷 / PDF 保存」「閉じる」ボタン (画面のみ表示、印刷時は非表示)

## Test plan
- [x] \`npm test\` (63/63 pass、新規 routeProjection / cumulativeDistancesMeters のテスト 9 件含む)
- [x] \`node --check frontend/{app,route_math,print}.js\`
- [x] Playwright スモーク (\`./.local/cuesheet_smoketest.mjs\`)
  - ボタン初期 disabled、検索後 enabled
  - 新規タブで print.html、535 行レンダリング
  - 1 行目: 左、累計 1.6km
  - メタ表示: 経路長 341 km、近傍距離 1.0 km、補給地点 535 件
  - L=300 / R=235 / C=0 (経路の両側にバランス分布)
  - parent / print 両ページとも JS エラー無し
- [ ] 実機 (iPhone Safari 印刷プレビュー、デスクトップ Chrome PDF 保存) で印刷崩れ確認