### PR TITLE
feat: 補給地点 waypoint 入り GPX を出力する

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -41,7 +41,8 @@ const elements = {
   geoSearchResults: document.getElementById('geo-search-results'),
   resultsSheet: document.getElementById('results-sheet'),
   resultsToggle: document.getElementById('results-toggle'),
-  cueSheetButton: document.getElementById('cue-sheet-button')
+  cueSheetButton: document.getElementById('cue-sheet-button'),
+  gpxExportButton: document.getElementById('gpx-export-button')
 };
 
 const CUE_SHEET_STORAGE_KEY = 'rideoasis-cue-sheet';
@@ -382,11 +383,56 @@ function updateSummary(visibleCount) {
   elements.matchedCount.textContent = String(visibleCount);
 }
 
-/** Enables the cue-sheet button only when a route and matched results exist. */
+/** Enables the cue-sheet and GPX-export buttons only when a route and matched results exist. */
 function syncCueSheetButton() {
-  if (!elements.cueSheetButton) return;
   const ready = routeCoordinates.length >= 2 && filteredPoints.length > 0;
-  elements.cueSheetButton.disabled = !ready;
+  if (elements.cueSheetButton) elements.cueSheetButton.disabled = !ready;
+  if (elements.gpxExportButton) elements.gpxExportButton.disabled = !ready;
+}
+
+/** Builds and downloads a GPX 1.1 document with the current route and matched supply points. */
+function exportGpx() {
+  if (routeCoordinates.length < 2 || filteredPoints.length === 0) return;
+  const cum = window.RouteMath.cumulativeDistancesMeters(routeCoordinates);
+  const waypoints = filteredPoints.map((feature) => {
+    const [lon, lat] = feature.geometry.coordinates;
+    const props = feature.properties || {};
+    const proj = window.RouteMath.routeProjection(feature.geometry.coordinates, routeCoordinates, cum);
+    const sideLabel = proj?.side === 'L' ? '左' : proj?.side === 'R' ? '右' : '';
+    const cumKm = proj ? (proj.alongMeters / 1000).toFixed(1) : null;
+    const descParts = [];
+    if (cumKm !== null) descParts.push(`累計 ${cumKm}km`);
+    if (sideLabel) descParts.push(`${sideLabel}側`);
+    if (proj) descParts.push(`離れ ${Math.round(proj.perpMeters)}m`);
+    if (props.address_norm) descParts.push(props.address_norm);
+    return {
+      lat,
+      lon,
+      name: `${props.chain || ''}: ${props.name || ''}`.trim().replace(/^:\s*/, ''),
+      desc: descParts.join(' / '),
+      type: props.chain || 'supply'
+    };
+  });
+
+  const xml = window.GpxParser.buildGpxText({
+    name: 'RideOasis Supply Points',
+    creator: 'RideOasis',
+    generatedAt: new Date().toISOString(),
+    route: routeCoordinates,
+    waypoints
+  });
+
+  const blob = new Blob([xml], { type: 'application/gpx+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  anchor.href = url;
+  anchor.download = `rideoasis-${stamp}.gpx`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  setTimeout(() => URL.revokeObjectURL(url), 100);
+  setStatus(`GPX を書き出しました (${waypoints.length} 件)`);
 }
 
 /** Serializes the current cue-sheet input and opens the printable page. */
@@ -1126,6 +1172,9 @@ function bindEvents() {
   elements.popupClose.addEventListener('click', clearPopup);
   if (elements.cueSheetButton) {
     elements.cueSheetButton.addEventListener('click', openCueSheet);
+  }
+  if (elements.gpxExportButton) {
+    elements.gpxExportButton.addEventListener('click', exportGpx);
   }
   elements.resultsToggle.addEventListener('click', () => {
     if (desktopMediaQuery && desktopMediaQuery.matches) return;

--- a/frontend/gpx.js
+++ b/frontend/gpx.js
@@ -81,12 +81,14 @@
       .join('\n');
 
     let trkXml = '';
-    if (Array.isArray(route) && route.length >= 2) {
-      const trkpts = route
-        .filter((c) => Array.isArray(c) && Number.isFinite(c[0]) && Number.isFinite(c[1]))
-        .map(([lon, lat]) => `      <trkpt lat="${lat}" lon="${lon}"></trkpt>`)
-        .join('\n');
-      if (trkpts) {
+    if (Array.isArray(route)) {
+      const validRoute = route.filter(
+        (c) => Array.isArray(c) && Number.isFinite(c[0]) && Number.isFinite(c[1])
+      );
+      if (validRoute.length >= 2) {
+        const trkpts = validRoute
+          .map(([lon, lat]) => `      <trkpt lat="${lat}" lon="${lon}"></trkpt>`)
+          .join('\n');
         trkXml = [
           `  <trk>`,
           `    <name>${safeName}</name>`,

--- a/frontend/gpx.js
+++ b/frontend/gpx.js
@@ -45,8 +45,77 @@
     };
   }
 
+  /** Escapes a string value for safe insertion into XML text and attribute content. */
+  function escapeXml(value) {
+    return String(value ?? '')
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&apos;');
+  }
+
+  /**
+   * Builds a GPX 1.1 document containing an optional `<trk>` for the route and
+   * `<wpt>` entries for each waypoint. The caller supplies preformatted waypoint
+   * fields so this module has no dependency on the route-math projection.
+   *
+   * route: [[lon, lat], ...] (optional, omitted when length < 2)
+   * waypoints: [{ lat, lon, name, desc, type }]
+   */
+  function buildGpxText({ name, creator, generatedAt, route, waypoints } = {}) {
+    const safeName = escapeXml(name || 'RideOasis Supply Points');
+    const safeCreator = escapeXml(creator || 'RideOasis');
+    const time = escapeXml(generatedAt || new Date().toISOString());
+
+    const wptList = Array.isArray(waypoints) ? waypoints : [];
+    const wptXml = wptList
+      .filter((w) => Number.isFinite(w?.lat) && Number.isFinite(w?.lon))
+      .map((w) => [
+        `  <wpt lat="${w.lat}" lon="${w.lon}">`,
+        `    <name>${escapeXml(w.name || '')}</name>`,
+        w.desc ? `    <desc>${escapeXml(w.desc)}</desc>` : null,
+        w.type ? `    <type>${escapeXml(w.type)}</type>` : null,
+        `  </wpt>`
+      ].filter(Boolean).join('\n'))
+      .join('\n');
+
+    let trkXml = '';
+    if (Array.isArray(route) && route.length >= 2) {
+      const trkpts = route
+        .filter((c) => Array.isArray(c) && Number.isFinite(c[0]) && Number.isFinite(c[1]))
+        .map(([lon, lat]) => `      <trkpt lat="${lat}" lon="${lon}"></trkpt>`)
+        .join('\n');
+      if (trkpts) {
+        trkXml = [
+          `  <trk>`,
+          `    <name>${safeName}</name>`,
+          `    <trkseg>`,
+          trkpts,
+          `    </trkseg>`,
+          `  </trk>`
+        ].join('\n');
+      }
+    }
+
+    const sections = [
+      `<?xml version="1.0" encoding="UTF-8"?>`,
+      `<gpx version="1.1" creator="${safeCreator}" xmlns="http://www.topografix.com/GPX/1/1">`,
+      `  <metadata>`,
+      `    <name>${safeName}</name>`,
+      `    <time>${time}</time>`,
+      `  </metadata>`,
+      wptXml,
+      trkXml,
+      `</gpx>`
+    ].filter(Boolean);
+
+    return sections.join('\n') + '\n';
+  }
+
   return {
     parseCoordinateTokens,
-    parseGpxText
+    parseGpxText,
+    buildGpxText
   };
 });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -142,6 +142,10 @@
             <span aria-hidden="true">🖨</span>
             <span>キューシート</span>
           </button>
+          <button id="gpx-export-button" class="cue-sheet-button" type="button" disabled aria-label="補給地点入り GPX を出力">
+            <span aria-hidden="true">📤</span>
+            <span>GPX</span>
+          </button>
         </div>
         <div class="results-body" id="results-body">
           <div class="results-filters">

--- a/tests/gpx_export.test.js
+++ b/tests/gpx_export.test.js
@@ -39,6 +39,20 @@ test('GPX Export: 経路が短いと <trk> を省略する', () => {
   assert.match(xml, /<wpt lat="35" lon="139">/);
 });
 
+test('GPX Export: 無効座標を除いて trkpt が1点しか残らないと <trk> を省略する', () => {
+  const xml = buildGpxText({
+    route: [
+      [139, 35],
+      [Number.NaN, 35]
+    ],
+    waypoints: [{ lat: 35, lon: 139, name: 'Solo' }]
+  });
+  assert.equal(xml.includes('<trk>'), false);
+  const trkptCount = (xml.match(/<trkpt /g) || []).length;
+  assert.equal(trkptCount, 0);
+  assert.match(xml, /<wpt lat="35" lon="139">/);
+});
+
 test('GPX Export: 不正な座標の wpt と trkpt は除外する', () => {
   const xml = buildGpxText({
     route: [

--- a/tests/gpx_export.test.js
+++ b/tests/gpx_export.test.js
@@ -1,0 +1,107 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildGpxText, parseGpxText, parseCoordinateTokens } = require('../frontend/gpx');
+
+test('GPX Export: 経路と補給地点を両方含むドキュメントを生成する', () => {
+  const xml = buildGpxText({
+    name: 'Test Route',
+    creator: 'TestSuite',
+    generatedAt: '2026-05-01T00:00:00Z',
+    route: [
+      [139.0, 35.0],
+      [139.001, 35.0]
+    ],
+    waypoints: [
+      { lat: 35.0001, lon: 139.0005, name: 'Lawson 渋谷', desc: '累計 0.5km / 左側', type: 'lawson' }
+    ]
+  });
+
+  assert.match(xml, /<\?xml version="1\.0"/);
+  assert.match(xml, /creator="TestSuite"/);
+  assert.match(xml, /<name>Test Route<\/name>/);
+  assert.match(xml, /<time>2026-05-01T00:00:00Z<\/time>/);
+  assert.match(xml, /<wpt lat="35\.0001" lon="139\.0005">/);
+  assert.match(xml, /Lawson 渋谷/);
+  assert.match(xml, /累計 0\.5km \/ 左側/);
+  assert.match(xml, /<type>lawson<\/type>/);
+  assert.match(xml, /<trk>/);
+  assert.match(xml, /<trkpt lat="35" lon="139"><\/trkpt>/);
+  assert.match(xml, /<trkpt lat="35" lon="139\.001"><\/trkpt>/);
+});
+
+test('GPX Export: 経路が短いと <trk> を省略する', () => {
+  const xml = buildGpxText({
+    waypoints: [{ lat: 35, lon: 139, name: 'Solo' }],
+    route: [[139, 35]]
+  });
+  assert.equal(xml.includes('<trk>'), false);
+  assert.match(xml, /<wpt lat="35" lon="139">/);
+});
+
+test('GPX Export: 不正な座標の wpt と trkpt は除外する', () => {
+  const xml = buildGpxText({
+    route: [
+      [139, 35],
+      [Number.NaN, 35],
+      [139.1, 35]
+    ],
+    waypoints: [
+      { lat: 35, lon: 139, name: 'OK' },
+      { lat: Number.NaN, lon: 139, name: 'Bad' }
+    ]
+  });
+  assert.match(xml, /<wpt lat="35" lon="139">/);
+  assert.equal(xml.includes('Bad'), false);
+  // route filter drops NaN
+  const trkptCount = (xml.match(/<trkpt /g) || []).length;
+  assert.equal(trkptCount, 2);
+});
+
+test('GPX Export: name や desc 内の特殊文字を XML エスケープする', () => {
+  const xml = buildGpxText({
+    waypoints: [
+      { lat: 35, lon: 139, name: '<&"\'>', desc: 'a & b' }
+    ]
+  });
+  assert.match(xml, /<name>&lt;&amp;&quot;&apos;&gt;<\/name>/);
+  assert.match(xml, /<desc>a &amp; b<\/desc>/);
+  assert.equal(xml.includes('< &'), false);
+});
+
+test('GPX Export: 出力は parseGpxText で再パースできる', () => {
+  const xml = buildGpxText({
+    route: [
+      [139.0, 35.0],
+      [139.1, 35.1]
+    ],
+    waypoints: []
+  });
+  const parsed = parseGpxText(xml);
+  assert.deepEqual(parsed.geometry.coordinates, [
+    [139.0, 35.0],
+    [139.1, 35.1]
+  ]);
+});
+
+test('GPX Export: 既定で creator は RideOasis、name はデフォルト文言になる', () => {
+  const xml = buildGpxText({ waypoints: [{ lat: 35, lon: 139, name: 'A' }] });
+  assert.match(xml, /creator="RideOasis"/);
+  assert.match(xml, /<name>RideOasis Supply Points<\/name>/);
+});
+
+test('GPX Export: parseCoordinateTokens は出力した trkpt を順序通り抽出する', () => {
+  const xml = buildGpxText({
+    route: [
+      [139.5, 35.5],
+      [139.6, 35.5],
+      [139.6, 35.6]
+    ],
+    waypoints: []
+  });
+  assert.deepEqual(parseCoordinateTokens(xml), [
+    [139.5, 35.5],
+    [139.6, 35.5],
+    [139.6, 35.6]
+  ]);
+});


### PR DESCRIPTION
ブルベ等で Garmin / Wahoo / Ride with GPS にロードして使える GPX を生成。元の経路 (\`<trk>\`) + 補給地点 (\`<wpt>\`) を1ファイルに合成する。

## Why
- ライド中にデバイス上で「次の補給地点はこのへん」が確認できる
- POI 表示 / 近接通知をデバイスの機能で活用できる
- 紙のキューシート (#47) とのペアで、紙とデバイスの両方で確認できるブルベ運用に乗せやすい

## 仕様
- \`📤 GPX\` ボタンを結果シート横に配置 (キューシートボタンと並列)
- 経路 (>=2点) かつフィルタ後マッチ件数 >0 で enabled
- クリックで現状の \`routeCoordinates\` + \`filteredPoints\` から GPX 1.1 を生成、Blob でダウンロード
- 各 wpt の中身:
  - \`<name>\`: \`{chain}: {店舗名}\`
  - \`<desc>\`: \`累計 N.Nkm / 左 or 右側 / 離れ Mm / 住所\` (RouteMath.routeProjection の結果から組み立て)
  - \`<type>\`: \`{chain}\` (Garmin Connect 等で chain ごとの分類が可能)
- 経路は \`<trk><trkseg><trkpt/></trkseg></trk>\` で含める
- ファイル名: \`rideoasis-<ISO 日時>.gpx\`

## デバイス上限への配慮
- Garmin Edge は wpt が ~200〜500件程度で頭打ちになる機種あり (機種依存)
- 既存のチェーン / 距離 / 精度 フィルタを使うと簡単に件数を絞れるので、今回は数値上限のチェックは入れない (フィルタ済み件数をそのまま出力)

## 共通化
- \`frontend/gpx.js\` に \`escapeXml()\` と \`buildGpxText({ name, creator, generatedAt, route, waypoints })\` を追加
- 既存の \`parseGpxText\` / \`parseCoordinateTokens\` で round-trip 可能 (テストで検証)

## Test plan
- [x] \`npm test\` (70/70 pass、新規 GPX Export 7件)
- [x] \`node --check frontend/{app,gpx}.js\`
- [x] Playwright スモーク (\`./.local/gpx_export_smoketest.mjs\`)
  - ボタン初期 disabled、検索後 enabled
  - クリックで \`rideoasis-<ISO>.gpx\` (約 95KB) をダウンロード
  - \`<wpt>\` 535件 + \`<trk>\` 1件 + \`<trkpt>\` 2件
  - サンプル wpt: \`<name>7eleven: 江東南砂１丁目</name><desc>累計 175.5km / 右側 / 離れ 2m / 東京都江東区南砂一丁目5-20</desc>\`
  - JS / page エラー無し
- [ ] 実機 (Garmin Connect / Ride with GPS) にロードして wpt 表示確認