### PR TITLE
feat: FIT ファイル取り込み (経路 + course point)

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -568,7 +568,7 @@ function findPointListItem(node) {
 function fitToVisibleData() {
   const extent = ol.extent.createEmpty();
   let hasData = false;
-  for (const source of [routeSource, pointSource, endpointSource, currentLocationSource]) {
+  for (const source of [routeSource, pointSource, endpointSource, currentLocationSource, coursePointSource]) {
     const sourceExtent = source.getExtent();
     if (sourceExtent && !ol.extent.isEmpty(sourceExtent)) {
       ol.extent.extend(extent, sourceExtent);
@@ -1255,11 +1255,13 @@ function bindEvents() {
   }
   window.addEventListener('resize', () => map.updateSize());
   map.on('singleclick', (event) => {
-    const feature = map.forEachFeatureAtPixel(
+    const supplyFeature = map.forEachFeatureAtPixel(
       event.pixel,
-      (candidate) => (candidate && candidate.get('properties') ? candidate : undefined)
+      (candidate) => {
+        const props = candidate && candidate.get('properties');
+        return props && props.supply_point_id != null ? candidate : undefined;
+      }
     );
-    const supplyFeature = feature && feature.get('properties') ? feature : null;
     if (supplyFeature) {
       activatePoint(supplyFeature.get('properties').supply_point_id);
       return;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -743,6 +743,9 @@ async function handleRouteFile(event) {
     let parsedRoute;
     let coursePoints = [];
     if (isFit) {
+      if (!window.FitParser || typeof window.FitParser.parseFitArrayBuffer !== 'function') {
+        throw new Error('FIT パーサーの初期化に失敗しました。ページを再読み込みしてください');
+      }
       setStatus('FIT を読み込み中...');
       const buffer = await file.arrayBuffer();
       if (loadToken !== latestRouteLoadToken) return;
@@ -1252,7 +1255,10 @@ function bindEvents() {
   }
   window.addEventListener('resize', () => map.updateSize());
   map.on('singleclick', (event) => {
-    const feature = map.forEachFeatureAtPixel(event.pixel, (candidate) => candidate);
+    const feature = map.forEachFeatureAtPixel(
+      event.pixel,
+      (candidate) => (candidate && candidate.get('properties') ? candidate : undefined)
+    );
     const supplyFeature = feature && feature.get('properties') ? feature : null;
     if (supplyFeature) {
       activatePoint(supplyFeature.get('properties').supply_point_id);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -57,6 +57,7 @@ const routeSource = new ol.source.Vector();
 const pointSource = new ol.source.Vector();
 const endpointSource = new ol.source.Vector();
 const currentLocationSource = new ol.source.Vector();
+const coursePointSource = new ol.source.Vector();
 
 const routeLayer = new ol.layer.Vector({
   source: routeSource,
@@ -116,6 +117,20 @@ const currentLocationLayer = new ol.layer.Vector({
   })
 });
 
+const coursePointLayer = new ol.layer.Vector({
+  source: coursePointSource,
+  style: new ol.style.Style({
+    image: new ol.style.RegularShape({
+      points: 5,
+      radius: 9,
+      radius2: 4,
+      angle: 0,
+      fill: new ol.style.Fill({ color: '#c62f2f' }),
+      stroke: new ol.style.Stroke({ color: '#ffffff', width: 1.5 })
+    })
+  })
+});
+
 const map = new ol.Map({
   target: 'map',
   layers: [
@@ -123,7 +138,8 @@ const map = new ol.Map({
     routeLayer,
     pointLayer,
     endpointLayer,
-    currentLocationLayer
+    currentLocationLayer,
+    coursePointLayer
   ],
   view: new ol.View({
     center: ol.proj.fromLonLat([139.767, 35.681]),
@@ -453,11 +469,26 @@ function openCueSheet() {
   window.open('./print.html', '_blank', 'noopener');
 }
 
-/** Clears the three drawing sources used for route and location visuals. */
+/** Clears the drawing sources used for route, endpoints, current location, and FIT course points. */
 function clearRouteVisualSources() {
   routeSource.clear();
   endpointSource.clear();
   currentLocationSource.clear();
+  coursePointSource.clear();
+}
+
+/** Renders FIT course-point waypoints (PCs / aid stations / etc.) on the map. */
+function renderCoursePoints(points) {
+  coursePointSource.clear();
+  if (!Array.isArray(points)) return;
+  for (const cp of points) {
+    if (!Number.isFinite(cp?.lat) || !Number.isFinite(cp?.lon)) continue;
+    const feature = new ol.Feature({
+      geometry: new ol.geom.Point(ol.proj.fromLonLat([cp.lon, cp.lat]))
+    });
+    feature.set('coursePoint', cp);
+    coursePointSource.addFeature(feature);
+  }
 }
 
 /** Renders the uploaded route and its start/end markers. */
@@ -555,6 +586,19 @@ function createRouteFeatureFromGpx(gpxText) {
   return {
     coordinates: parsed.geometry.coordinates,
     feature: routeGeoJsonFormat.readFeature(parsed)
+  };
+}
+
+/** Builds an OpenLayers route feature from an ordered [lon, lat] coordinate array. */
+function createRouteFeatureFromCoords(coordinates) {
+  const geojson = {
+    type: 'Feature',
+    geometry: { type: 'LineString', coordinates },
+    properties: { point_count: coordinates.length }
+  };
+  return {
+    coordinates,
+    feature: routeGeoJsonFormat.readFeature(geojson)
   };
 }
 
@@ -687,32 +731,51 @@ async function refreshMap(routeSnapshot = [...routeCoordinates]) {
   }
 }
 
-/** Reads the selected GPX file and refreshes the map candidates. */
-async function handleGpxFile(event) {
+/** Reads the selected route file (GPX or FIT) and refreshes the map candidates. */
+async function handleRouteFile(event) {
   const file = event.target.files?.[0];
   if (!file) return;
+  const isFit = /\.fit$/i.test(file.name);
   const loadToken = ++latestRouteLoadToken;
   cancelPendingRefreshes();
   const previousFileName = elements.gpxFileName.textContent;
   try {
-    const gpxText = await file.text();
-    if (loadToken !== latestRouteLoadToken) return;
-    const parsedRoute = createRouteFeatureFromGpx(gpxText);
+    let parsedRoute;
+    let coursePoints = [];
+    if (isFit) {
+      setStatus('FIT を読み込み中...');
+      const buffer = await file.arrayBuffer();
+      if (loadToken !== latestRouteLoadToken) return;
+      const fit = await window.FitParser.parseFitArrayBuffer(buffer);
+      if (loadToken !== latestRouteLoadToken) return;
+      if (fit.records.length < 2) {
+        throw new Error('FIT から 2 点以上の経路座標を抽出できませんでした');
+      }
+      const coords = fit.records.map((r) => [r.lon, r.lat]);
+      parsedRoute = createRouteFeatureFromCoords(coords);
+      coursePoints = fit.coursePoints;
+    } else {
+      const gpxText = await file.text();
+      if (loadToken !== latestRouteLoadToken) return;
+      parsedRoute = createRouteFeatureFromGpx(gpxText);
+    }
     if (loadToken !== latestRouteLoadToken) return;
     routeFeature = parsedRoute.feature;
     routeCoordinates = parsedRoute.coordinates;
     manualPoints = [];
     elements.gpxFileName.textContent = file.name;
     renderRoute(routeFeature);
+    renderCoursePoints(coursePoints);
     resetResults();
     updateRoutePointCount();
     fitToVisibleData();
-    setStatus(`GPX を読み込みました: ${file.name}`);
+    const cpInfo = coursePoints.length > 0 ? ` (PC ${coursePoints.length} 件)` : '';
+    setStatus(`${isFit ? 'FIT' : 'GPX'} を読み込みました: ${file.name}${cpInfo}`);
     await refreshMap([...routeCoordinates]);
   } catch (error) {
     if (loadToken !== latestRouteLoadToken) return;
     elements.gpxFileName.textContent = previousFileName;
-    setStatus(error?.message || 'GPX の読み込みに失敗しました');
+    setStatus(error?.message || 'ルートファイルの読み込みに失敗しました');
     console.error(error);
   }
 }
@@ -1125,7 +1188,7 @@ function bindEvents() {
   for (const input of document.querySelectorAll('.result-filters input[type="checkbox"]')) {
     input.addEventListener('change', applyResultFilters);
   }
-  elements.gpxFile.addEventListener('change', handleGpxFile);
+  elements.gpxFile.addEventListener('change', handleRouteFile);
   elements.useCurrentLocation.addEventListener('click', handleCurrentLocation);
   elements.followToggle.addEventListener('change', handleFollowToggle);
   elements.manualReset.addEventListener('click', resetManualState);

--- a/frontend/fit.js
+++ b/frontend/fit.js
@@ -1,0 +1,109 @@
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+    return;
+  }
+  root.FitParser = factory();
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+
+  // Pinned CDN URL for the fit-file-parser ESM bundle. Loaded on demand so
+  // ride-oasis pages without a route file (or all-GPX users) do not pay for
+  // the extra network fetch on initial render.
+  const FIT_PARSER_CDN = 'https://cdn.jsdelivr.net/npm/fit-file-parser@1.21.0/+esm';
+
+  let cachedParserClass = null;
+
+  /**
+   * Dynamically imports fit-file-parser via the pinned CDN URL.
+   *
+   * jsdelivr's `+esm` bundle returns a nested CJS-default shape
+   * (`mod.default.default` is the class), while a real ESM build can return
+   * the class directly. Walk through up to three levels of `default` until
+   * we find the constructor function.
+   */
+  async function loadFitParserClass(importFn) {
+    if (cachedParserClass) return cachedParserClass;
+    const dynamicImport = importFn || ((url) => import(/* @vite-ignore */ url));
+    const mod = await dynamicImport(FIT_PARSER_CDN);
+    let candidate = mod;
+    for (let i = 0; i < 3; i += 1) {
+      if (typeof candidate === 'function') break;
+      if (candidate && typeof candidate === 'object' && 'default' in candidate) {
+        candidate = candidate.default;
+      } else if (candidate && typeof candidate === 'object' && 'FitParser' in candidate) {
+        candidate = candidate.FitParser;
+        break;
+      } else {
+        break;
+      }
+    }
+    if (typeof candidate !== 'function') {
+      throw new Error('FIT parser ライブラリの読み込みに失敗しました');
+    }
+    cachedParserClass = candidate;
+    return cachedParserClass;
+  }
+
+  /**
+   * Normalizes the fit-file-parser output into the route + course-points shape
+   * the rest of ride-oasis consumes:
+   *   { records: [{ lat, lon, distanceMeters? }], coursePoints: [{ lat, lon, distanceMeters?, name, type }] }
+   * Records / course points without finite lat+lon are dropped.
+   */
+  function normalizeFitData(data) {
+    const records = (Array.isArray(data?.records) ? data.records : [])
+      .filter((r) => Number.isFinite(r?.position_lat) && Number.isFinite(r?.position_long))
+      .map((r) => ({
+        lat: r.position_lat,
+        lon: r.position_long,
+        distanceMeters: Number.isFinite(r.distance) ? r.distance : null
+      }));
+
+    const coursePoints = (Array.isArray(data?.course_points) ? data.course_points : [])
+      .filter((cp) => Number.isFinite(cp?.position_lat) && Number.isFinite(cp?.position_long))
+      .map((cp) => ({
+        lat: cp.position_lat,
+        lon: cp.position_long,
+        distanceMeters: Number.isFinite(cp.distance) ? cp.distance : null,
+        name: typeof cp.name === 'string' ? cp.name : '',
+        type: typeof cp.type === 'string' ? cp.type : 'generic'
+      }));
+
+    return { records, coursePoints };
+  }
+
+  /**
+   * Parses a FIT byte buffer (e.g. from `File.arrayBuffer()`) and returns the
+   * normalized records + course points. Lazy-loads fit-file-parser the first
+   * time it is called.
+   */
+  async function parseFitArrayBuffer(arrayBuffer, opts = {}) {
+    const ParserClass = await loadFitParserClass(opts.importFn);
+    const parser = new ParserClass({
+      force: true,
+      lengthUnit: 'm',
+      mode: 'list',
+      ...(opts.parserOptions || {})
+    });
+    const buffer = arrayBuffer instanceof ArrayBuffer
+      ? new Uint8Array(arrayBuffer)
+      : arrayBuffer;
+    return new Promise((resolve, reject) => {
+      parser.parse(buffer, (error, data) => {
+        if (error) {
+          reject(new Error(typeof error === 'string' ? error : 'FIT parse failed'));
+          return;
+        }
+        resolve(normalizeFitData(data));
+      });
+    });
+  }
+
+  return {
+    parseFitArrayBuffer,
+    normalizeFitData,
+    /** Exposed for tests: clears the cached fit-file-parser class. */
+    _resetCacheForTests: () => { cachedParserClass = null; }
+  };
+});

--- a/frontend/fit.js
+++ b/frontend/fit.js
@@ -45,15 +45,23 @@
     return cachedParserClass;
   }
 
+  /** Returns true when lat/lon are finite and inside WGS84 valid ranges. */
+  function isValidLatLon(lat, lon) {
+    return Number.isFinite(lat)
+      && Number.isFinite(lon)
+      && lat >= -90 && lat <= 90
+      && lon >= -180 && lon <= 180;
+  }
+
   /**
    * Normalizes the fit-file-parser output into the route + course-points shape
    * the rest of ride-oasis consumes:
    *   { records: [{ lat, lon, distanceMeters? }], coursePoints: [{ lat, lon, distanceMeters?, name, type }] }
-   * Records / course points without finite lat+lon are dropped.
+   * Records / course points outside the valid lat/lon range are dropped.
    */
   function normalizeFitData(data) {
     const records = (Array.isArray(data?.records) ? data.records : [])
-      .filter((r) => Number.isFinite(r?.position_lat) && Number.isFinite(r?.position_long))
+      .filter((r) => isValidLatLon(r?.position_lat, r?.position_long))
       .map((r) => ({
         lat: r.position_lat,
         lon: r.position_long,
@@ -61,7 +69,7 @@
       }));
 
     const coursePoints = (Array.isArray(data?.course_points) ? data.course_points : [])
-      .filter((cp) => Number.isFinite(cp?.position_lat) && Number.isFinite(cp?.position_long))
+      .filter((cp) => isValidLatLon(cp?.position_lat, cp?.position_long))
       .map((cp) => ({
         lat: cp.position_lat,
         lon: cp.position_long,

--- a/frontend/fit.js
+++ b/frontend/fit.js
@@ -100,7 +100,11 @@
     return new Promise((resolve, reject) => {
       parser.parse(buffer, (error, data) => {
         if (error) {
-          reject(new Error(typeof error === 'string' ? error : 'FIT parse failed'));
+          if (error instanceof Error) {
+            reject(error);
+          } else {
+            reject(new Error(typeof error === 'string' && error ? error : String(error || 'FIT parse failed')));
+          }
           return;
         }
         resolve(normalizeFitData(data));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -55,8 +55,8 @@
           <div class="ctx-panel" id="gpx-panel">
             <label class="picker-button" for="gpx-file">
               <span class="picker-icon" aria-hidden="true">📁</span>
-              <span class="picker-label">GPX を選ぶ</span>
-              <input id="gpx-file" type="file" accept=".gpx,application/gpx+xml,text/xml,application/xml" />
+              <span class="picker-label">ルートを選ぶ (GPX / FIT)</span>
+              <input id="gpx-file" type="file" accept=".gpx,.fit,application/gpx+xml,text/xml,application/xml,application/octet-stream" />
             </label>
             <div class="ctx-meta">
               <span class="file-name" id="gpx-file-name">未選択</span>
@@ -175,6 +175,7 @@
     <script src="https://cdn.jsdelivr.net/npm/ol@10.9.0/dist/ol.js"></script>
     <script src="./route_math.js"></script>
     <script src="./gpx.js"></script>
+    <script src="./fit.js"></script>
     <script src="./app.js"></script>
   </body>
 </html>

--- a/tests/fit.test.js
+++ b/tests/fit.test.js
@@ -45,6 +45,26 @@ test('FIT Parser: 不正な lat/lon を持つレコードを除外する', () =>
   assert.equal(out.coursePoints[0].name, 'OK');
 });
 
+test('FIT Parser: WGS84 範囲外の lat/lon を除外する', () => {
+  const out = normalizeFitData({
+    records: [
+      { position_lat: 35.0, position_long: 139.0 },
+      { position_lat: 999, position_long: 139.0 },
+      { position_lat: -91, position_long: 139.0 },
+      { position_lat: 35.0, position_long: 181 },
+      { position_lat: 35.0, position_long: -181 }
+    ],
+    course_points: [
+      { position_lat: 91, position_long: 0, name: 'NorthOfNorth' },
+      { position_lat: 35, position_long: 139, name: 'OK' }
+    ]
+  });
+  assert.equal(out.records.length, 1);
+  assert.equal(out.records[0].lat, 35);
+  assert.equal(out.coursePoints.length, 1);
+  assert.equal(out.coursePoints[0].name, 'OK');
+});
+
 test('FIT Parser: distance が無い record / course_point は distanceMeters: null になる', () => {
   const out = normalizeFitData({
     records: [{ position_lat: 35, position_long: 139 }],

--- a/tests/fit.test.js
+++ b/tests/fit.test.js
@@ -124,3 +124,19 @@ test('FIT Parser: parseFitArrayBuffer はライブラリのエラーを Error �
   const buffer = new ArrayBuffer(16);
   await assert.rejects(parseFitArrayBuffer(buffer, { importFn }), /boom/);
 });
+
+test('FIT Parser: parseFitArrayBuffer は Error インスタンスをそのまま reject する', async () => {
+  _resetCacheForTests();
+  const original = new Error('detail message');
+  original.code = 'XYZ';
+  class FailingParser {
+    parse(_buffer, cb) { cb(original); }
+  }
+  const importFn = async () => ({ default: FailingParser });
+  const buffer = new ArrayBuffer(16);
+  await assert.rejects(parseFitArrayBuffer(buffer, { importFn }), (received) => {
+    assert.equal(received, original);
+    assert.equal(received.code, 'XYZ');
+    return true;
+  });
+});

--- a/tests/fit.test.js
+++ b/tests/fit.test.js
@@ -1,0 +1,106 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { normalizeFitData, parseFitArrayBuffer, _resetCacheForTests } = require('../frontend/fit');
+
+test('FIT Parser: records と course_points を内部形式に正規化する', () => {
+  const data = {
+    records: [
+      { position_lat: 35.0, position_long: 139.0, distance: 0 },
+      { position_lat: 35.1, position_long: 139.1, distance: 1234.5 }
+    ],
+    course_points: [
+      { position_lat: 35.5, position_long: 139.5, name: 'PC1', type: 'checkpoint', distance: 50000 }
+    ]
+  };
+  const out = normalizeFitData(data);
+  assert.equal(out.records.length, 2);
+  assert.deepEqual(out.records[0], { lat: 35.0, lon: 139.0, distanceMeters: 0 });
+  assert.deepEqual(out.records[1], { lat: 35.1, lon: 139.1, distanceMeters: 1234.5 });
+  assert.equal(out.coursePoints.length, 1);
+  assert.deepEqual(out.coursePoints[0], {
+    lat: 35.5,
+    lon: 139.5,
+    distanceMeters: 50000,
+    name: 'PC1',
+    type: 'checkpoint'
+  });
+});
+
+test('FIT Parser: 不正な lat/lon を持つレコードを除外する', () => {
+  const out = normalizeFitData({
+    records: [
+      { position_lat: 35.0, position_long: 139.0 },
+      { position_lat: null, position_long: 139.0 },
+      { position_lat: 35.0, position_long: null },
+      { position_lat: Number.NaN, position_long: 139.0 }
+    ],
+    course_points: [
+      { position_lat: 35.5, position_long: 139.5, name: 'OK' },
+      { position_lat: null, position_long: 139.0, name: 'Bad' }
+    ]
+  });
+  assert.equal(out.records.length, 1);
+  assert.equal(out.coursePoints.length, 1);
+  assert.equal(out.coursePoints[0].name, 'OK');
+});
+
+test('FIT Parser: distance が無い record / course_point は distanceMeters: null になる', () => {
+  const out = normalizeFitData({
+    records: [{ position_lat: 35, position_long: 139 }],
+    course_points: [{ position_lat: 35.5, position_long: 139.5 }]
+  });
+  assert.equal(out.records[0].distanceMeters, null);
+  assert.equal(out.coursePoints[0].distanceMeters, null);
+});
+
+test('FIT Parser: name / type が文字列でない場合は default 値で正規化する', () => {
+  const out = normalizeFitData({
+    course_points: [
+      { position_lat: 35.5, position_long: 139.5, name: undefined, type: 5 }
+    ]
+  });
+  assert.equal(out.coursePoints[0].name, '');
+  assert.equal(out.coursePoints[0].type, 'generic');
+});
+
+test('FIT Parser: 入力が空 / 不正でも例外を投げず空配列を返す', () => {
+  assert.deepEqual(normalizeFitData({}), { records: [], coursePoints: [] });
+  assert.deepEqual(normalizeFitData(null), { records: [], coursePoints: [] });
+  assert.deepEqual(normalizeFitData({ records: 'not-array' }), { records: [], coursePoints: [] });
+});
+
+test('FIT Parser: parseFitArrayBuffer は注入された importFn 経由で正規化結果を返す', async () => {
+  _resetCacheForTests();
+  // Stub fit-file-parser so the test runs offline.
+  class StubParser {
+    constructor(opts) { this.opts = opts; }
+    parse(buffer, cb) {
+      cb(null, {
+        records: [
+          { position_lat: 35, position_long: 139, distance: 0 },
+          { position_lat: 35.01, position_long: 139.01, distance: 1500 }
+        ],
+        course_points: [
+          { position_lat: 35.005, position_long: 139.005, name: 'PC', type: 'checkpoint', distance: 750 }
+        ]
+      });
+    }
+  }
+  const importFn = async () => ({ default: StubParser });
+  const buffer = new ArrayBuffer(16);
+  const result = await parseFitArrayBuffer(buffer, { importFn });
+  assert.equal(result.records.length, 2);
+  assert.equal(result.coursePoints.length, 1);
+  assert.equal(result.coursePoints[0].name, 'PC');
+});
+
+test('FIT Parser: parseFitArrayBuffer はライブラリのエラーを Error として reject する', async () => {
+  _resetCacheForTests();
+  class FailingParser {
+    parse(_buffer, cb) { cb('boom'); }
+  }
+  const importFn = async () => ({ default: FailingParser });
+  const buffer = new ArrayBuffer(16);
+  await assert.rejects(parseFitArrayBuffer(buffer, { importFn }), /boom/);
+});


### PR DESCRIPTION
ブルベ等で RWG / Garmin Connect から download した FIT course をそのまま食わせられるようにする。GPX だと course point (PC / aid station 等) が抜けるため、FIT を読めると waypoint まで含めて取り込める。

## 実装方針
- パース本体は **fit-file-parser** (npm 一番ポピュラー、~30KB) を **jsdelivr の +esm bundle** から動的 import
- FIT が必要になったとき (ユーザが .fit ファイルを picker で選んだ瞬間) に初めて download → 通常の GPX ユーザはペイロード増えない

## frontend/fit.js (新規)
- \`loadFitParserClass()\` が \`mod.default.default\` の CJS-default ネストを解いて constructor を取り出す
- \`normalizeFitData(data)\` がライブラリ出力 (\`position_lat\`/\`position_long\` 度、\`distance\` メートル) を ride-oasis 内部形式 (\`{ lat, lon, distanceMeters }\`) に整形、不正 lat/lon は除外
- \`parseFitArrayBuffer(arrayBuffer)\` を提供。テスト用に \`opts.importFn\` 注入可

## ファイル picker
- \`accept=".gpx,.fit,..."\`、ラベル「ルートを選ぶ (GPX / FIT)」に更新
- \`handleRouteFile\` で拡張子 \`.fit\` を判定、FitParser に分岐
- 2 点未満なら明示エラー
- ステータスに \`(PC N 件)\` を表示

## 描画
- 新しい \`coursePointSource\` / \`coursePointLayer\` (赤い5角の星型) を追加
- \`clearRouteVisualSources()\` に含めて、他モード切替で PC も消える
- GPX / FIT / 手動2点で共通の pipeline (\`createRouteFeatureFromCoords\`)

## 範囲外 (将来)
- PC をキューシート印刷に統合
- PC を GPX 出力 (#48) に転記

## Test plan
- [x] \`npm test\` (78 件 pass、新規 fit.test.js 7 件含む)
- [x] \`node --check frontend/{app,fit}.js\`
- [x] Playwright スモーク (\`./.local/fit_import_smoketest.mjs\`)
  - 4 trkpt + 1 PC の inline 構築 FIT を \`setInputFiles\` で投入
  - 経路点数: 4、99 件の近傍補給地点マッチ、JS/page エラー 0
- [ ] 実際の RWG export FIT (ブルベコース) でロード確認
- [ ] PC マーカーの見た目 (赤5角星) 確認