### PR TITLE
feat: コース点 (FIT★) をクリック・キューシート表示・フィルタ対応

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -42,7 +42,8 @@ const elements = {
   resultsSheet: document.getElementById('results-sheet'),
   resultsToggle: document.getElementById('results-toggle'),
   cueSheetButton: document.getElementById('cue-sheet-button'),
-  gpxExportButton: document.getElementById('gpx-export-button')
+  gpxExportButton: document.getElementById('gpx-export-button'),
+  showCoursePoints: document.getElementById('show-course-points')
 };
 
 const CUE_SHEET_STORAGE_KEY = 'rideoasis-cue-sheet';
@@ -158,6 +159,7 @@ map.addOverlay(popupOverlay);
 let routeFeature = null;
 let routeCoordinates = [];
 let manualPoints = [];
+let cachedCoursePoints = [];
 let allMatchedPoints = [];
 let filteredPoints = [];
 let activeSupplyPointId = null;
@@ -352,6 +354,34 @@ function openPopupForFeature(feature) {
   elements.popup.hidden = false;
 }
 
+/** Opens the popup for a clicked FIT course point with route projection info. */
+function activateCoursePoint(feature) {
+  const cp = feature.get('coursePoint');
+  if (!cp) return;
+  popupOverlay.setPosition(feature.getGeometry().getCoordinates());
+  let projLine = '';
+  if (routeCoordinates.length >= 2) {
+    const proj = window.RouteMath.routeProjection([cp.lon, cp.lat], routeCoordinates);
+    if (proj) {
+      const cumKm = (proj.alongMeters / 1000).toFixed(1);
+      const sideLabel = proj.side === 'L' ? '左' : proj.side === 'R' ? '右' : '・';
+      projLine = `<div class="popup-distance">累計 ${cumKm} km / ${sideLabel}側 / 離れ ${Math.round(proj.perpMeters)} m</div>`;
+    }
+  }
+  elements.popupBody.innerHTML = [
+    `<div class="popup-chain">${escapeHtml(cp.type || 'course point')}</div>`,
+    `<div class="popup-title">${escapeHtml(cp.name || '(無名)')}</div>`,
+    projLine
+  ].filter(Boolean).join('');
+  elements.popup.hidden = false;
+  // Course points are not part of the supply-point selection flow, so we
+  // explicitly clear any prior supply selection without closing this popup.
+  activeSupplyPointId = null;
+  previewSupplyPointId = null;
+  syncPointHighlight();
+  syncPointListSelection();
+}
+
 /** Marks one supply point active and opens its popup. */
 function activatePoint(supplyPointId) {
   activeSupplyPointId = supplyPointKey(supplyPointId);
@@ -458,6 +488,7 @@ function openCueSheet() {
     localStorage.setItem(CUE_SHEET_STORAGE_KEY, JSON.stringify({
       routeCoordinates,
       filteredPoints,
+      coursePoints: visibleCoursePoints(),
       distanceMeters: selectedDistanceMeters(),
       generatedAt: new Date().toISOString()
     }));
@@ -475,13 +506,14 @@ function clearRouteVisualSources() {
   endpointSource.clear();
   currentLocationSource.clear();
   coursePointSource.clear();
+  cachedCoursePoints = [];
 }
 
 /** Renders FIT course-point waypoints (PCs / aid stations / etc.) on the map. */
 function renderCoursePoints(points) {
   coursePointSource.clear();
-  if (!Array.isArray(points)) return;
-  for (const cp of points) {
+  cachedCoursePoints = Array.isArray(points) ? points.slice() : [];
+  for (const cp of cachedCoursePoints) {
     if (!Number.isFinite(cp?.lat) || !Number.isFinite(cp?.lon)) continue;
     const feature = new ol.Feature({
       geometry: new ol.geom.Point(ol.proj.fromLonLat([cp.lon, cp.lat]))
@@ -489,6 +521,15 @@ function renderCoursePoints(points) {
     feature.set('coursePoint', cp);
     coursePointSource.addFeature(feature);
   }
+  if (elements.showCoursePoints) {
+    coursePointLayer.setVisible(elements.showCoursePoints.checked);
+  }
+}
+
+/** Returns the cached course points filtered by the show-course-points toggle. */
+function visibleCoursePoints() {
+  if (elements.showCoursePoints && !elements.showCoursePoints.checked) return [];
+  return cachedCoursePoints.slice();
 }
 
 /** Renders the uploaded route and its start/end markers. */
@@ -1242,6 +1283,14 @@ function bindEvents() {
   if (elements.gpxExportButton) {
     elements.gpxExportButton.addEventListener('click', exportGpx);
   }
+  if (elements.showCoursePoints) {
+    elements.showCoursePoints.addEventListener('change', () => {
+      coursePointLayer.setVisible(elements.showCoursePoints.checked);
+      if (!elements.showCoursePoints.checked) {
+        clearPopup();
+      }
+    });
+  }
   elements.resultsToggle.addEventListener('click', () => {
     if (desktopMediaQuery && desktopMediaQuery.matches) return;
     const expanded = elements.resultsSheet.classList.toggle('expanded');
@@ -1264,6 +1313,14 @@ function bindEvents() {
     );
     if (supplyFeature) {
       activatePoint(supplyFeature.get('properties').supply_point_id);
+      return;
+    }
+    const cpFeature = map.forEachFeatureAtPixel(
+      event.pixel,
+      (candidate) => (candidate && candidate.get('coursePoint') ? candidate : undefined)
+    );
+    if (cpFeature) {
+      activateCoursePoint(cpFeature);
       return;
     }
     clearPopup();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -163,6 +163,7 @@ let cachedCoursePoints = [];
 let allMatchedPoints = [];
 let filteredPoints = [];
 let activeSupplyPointId = null;
+let activePopupKind = null;
 let previewSupplyPointId = null;
 const API_PAGE_LIMIT = 10000;
 const featureIndex = new Map();
@@ -352,6 +353,7 @@ function openPopupForFeature(feature) {
   popupOverlay.setPosition(feature.getGeometry().getCoordinates());
   elements.popupBody.innerHTML = buildPopupHtml(feature.get('properties'));
   elements.popup.hidden = false;
+  activePopupKind = 'supply';
 }
 
 /** Opens the popup for a clicked FIT course point with route projection info. */
@@ -374,6 +376,7 @@ function activateCoursePoint(feature) {
     projLine
   ].filter(Boolean).join('');
   elements.popup.hidden = false;
+  activePopupKind = 'course-point';
   // Course points are not part of the supply-point selection flow, so we
   // explicitly clear any prior supply selection without closing this popup.
   activeSupplyPointId = null;
@@ -420,6 +423,7 @@ function clearPopup() {
   previewSupplyPointId = null;
   elements.popup.hidden = true;
   popupOverlay.setPosition(undefined);
+  activePopupKind = null;
   syncPointHighlight();
   syncPointListSelection();
 }
@@ -1286,7 +1290,7 @@ function bindEvents() {
   if (elements.showCoursePoints) {
     elements.showCoursePoints.addEventListener('change', () => {
       coursePointLayer.setVisible(elements.showCoursePoints.checked);
-      if (!elements.showCoursePoints.checked) {
+      if (!elements.showCoursePoints.checked && activePopupKind === 'course-point') {
         clearPopup();
       }
     });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -163,6 +163,10 @@
               <label><input type="checkbox" name="precision-filter" value="precise" checked /><span>正確</span></label>
               <label><input type="checkbox" name="precision-filter" value="rough" checked /><span>あいまい</span></label>
             </fieldset>
+            <fieldset class="chains course-point-filters">
+              <legend>コース点 (FIT)</legend>
+              <label><input type="checkbox" id="show-course-points" checked /><span>★ を表示</span></label>
+            </fieldset>
           </div>
           <div class="point-list" id="point-list"></div>
         </div>

--- a/frontend/print.css
+++ b/frontend/print.css
@@ -200,6 +200,21 @@ td.side-c {
   vertical-align: 1px;
 }
 
+.chain-badge.cp-badge {
+  background: #fbe8d3;
+  color: #8a4a14;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+tr.cue-row-cp td {
+  background: #fdf4e8;
+}
+
+tr.cue-row-cp:nth-child(even) td {
+  background: #fbeed7;
+}
+
 .store-name {
   font-weight: 700;
 }
@@ -305,6 +320,12 @@ td.side-c {
 
   td.side-r {
     background: var(--c-right-soft) !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  tr.cue-row-cp td {
+    background: #fdf4e8 !important;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
   }

--- a/frontend/print.js
+++ b/frontend/print.js
@@ -31,7 +31,59 @@
     return `${Math.round(meters)} m`;
   }
 
-  /** Renders the cue-sheet rows derived from route + matched supply points. */
+  /** Builds a row descriptor (kind + projection) for one supply point feature. */
+  function makeSupplyRow(feature, route, cum) {
+    const coords = feature?.geometry?.coordinates;
+    if (!Array.isArray(coords)) return null;
+    const proj = window.RouteMath.routeProjection(coords, route, cum);
+    return proj ? { kind: 'supply', proj, props: feature.properties || {} } : null;
+  }
+
+  /** Builds a row descriptor for one course point. */
+  function makeCoursePointRow(cp, route, cum) {
+    if (!cp || !Number.isFinite(cp.lat) || !Number.isFinite(cp.lon)) return null;
+    const proj = window.RouteMath.routeProjection([cp.lon, cp.lat], route, cum);
+    return proj ? { kind: 'course-point', proj, cp } : null;
+  }
+
+  /** Renders one row's cells into innerHTML based on its kind. */
+  function renderRow(row, index, intervalKm) {
+    const cumKm = (row.proj.alongMeters / 1000).toFixed(1);
+    const sideLabel = row.proj.side === 'L' ? '左' : row.proj.side === 'R' ? '右' : '・';
+    const sideClass = `side side-${row.proj.side.toLowerCase()}`;
+
+    if (row.kind === 'course-point') {
+      const cp = row.cp;
+      return {
+        className: 'cue-row-cp',
+        html: [
+          `<td class="num">${index + 1}</td>`,
+          `<td class="num">${cumKm}</td>`,
+          `<td class="num">${intervalKm}</td>`,
+          `<td class="${sideClass}">${sideLabel}</td>`,
+          `<td class="num">${Math.round(row.proj.perpMeters)}</td>`,
+          `<td><span class="chain-badge cp-badge">★ ${escapeHtml(cp.type || 'PC')}</span><span class="store-name">${escapeHtml(cp.name || '(無名)')}</span></td>`,
+          `<td>—</td>`
+        ].join('')
+      };
+    }
+
+    const props = row.props;
+    return {
+      className: '',
+      html: [
+        `<td class="num">${index + 1}</td>`,
+        `<td class="num">${cumKm}</td>`,
+        `<td class="num">${intervalKm}</td>`,
+        `<td class="${sideClass}">${sideLabel}</td>`,
+        `<td class="num">${Math.round(row.proj.perpMeters)}</td>`,
+        `<td><span class="chain-badge">${escapeHtml(props.chain || '')}</span><span class="store-name">${escapeHtml(props.name || '-')}</span></td>`,
+        `<td>${escapeHtml(props.address_norm || '-')}</td>`
+      ].join('')
+    };
+  }
+
+  /** Renders the cue-sheet rows derived from route + matched supply points + course points. */
   function render(input) {
     const tbody = document.getElementById('cue-body');
     const metaRouteLength = document.getElementById('meta-route-length');
@@ -44,25 +96,24 @@
       return;
     }
 
-    const points = Array.isArray(input.filteredPoints) ? input.filteredPoints : [];
+    const supplyFeatures = Array.isArray(input.filteredPoints) ? input.filteredPoints : [];
+    const coursePoints = Array.isArray(input.coursePoints) ? input.coursePoints : [];
     const cum = window.RouteMath.cumulativeDistancesMeters(input.routeCoordinates);
     const totalKm = cum[cum.length - 1] / 1000;
 
-    const rows = points
-      .map((feature) => {
-        const proj = window.RouteMath.routeProjection(
-          feature.geometry.coordinates,
-          input.routeCoordinates,
-          cum
-        );
-        return proj ? { feature, proj } : null;
-      })
+    const supplyRows = supplyFeatures.map((f) => makeSupplyRow(f, input.routeCoordinates, cum));
+    const cpRows = coursePoints.map((cp) => makeCoursePointRow(cp, input.routeCoordinates, cum));
+    const rows = [...supplyRows, ...cpRows]
       .filter((row) => row !== null)
       .sort((a, b) => a.proj.alongMeters - b.proj.alongMeters);
 
+    const supplyCount = rows.filter((r) => r.kind === 'supply').length;
+    const cpCount = rows.filter((r) => r.kind === 'course-point').length;
+    const cpSummary = cpCount > 0 ? ` / ★ <strong>${cpCount}</strong> 件` : '';
+
     metaRouteLength.innerHTML = `経路長 <strong>${totalKm.toFixed(1)} km</strong>`;
     metaDistance.innerHTML = `近傍距離 <strong>${formatDistanceMeters(input.distanceMeters)}</strong>`;
-    metaCount.innerHTML = `補給地点 <strong>${rows.length}</strong> 件`;
+    metaCount.innerHTML = `補給地点 <strong>${supplyCount}</strong> 件${cpSummary}`;
     generatedAt.textContent = input.generatedAt
       ? new Date(input.generatedAt).toLocaleString('ja-JP')
       : new Date().toLocaleString('ja-JP');
@@ -75,26 +126,13 @@
     tbody.innerHTML = '';
     let prevAlong = 0;
     rows.forEach((row, index) => {
-      const { feature, proj } = row;
-      const props = feature.properties || {};
-      const intervalMeters = proj.alongMeters - prevAlong;
-      prevAlong = proj.alongMeters;
-
-      const cumKm = (proj.alongMeters / 1000).toFixed(1);
+      const intervalMeters = row.proj.alongMeters - prevAlong;
+      prevAlong = row.proj.alongMeters;
       const intervalKm = (intervalMeters / 1000).toFixed(1);
-      const sideLabel = proj.side === 'L' ? '左' : proj.side === 'R' ? '右' : '・';
-      const sideClass = `side side-${proj.side.toLowerCase()}`;
-
       const tr = document.createElement('tr');
-      tr.innerHTML = [
-        `<td class="num">${index + 1}</td>`,
-        `<td class="num">${cumKm}</td>`,
-        `<td class="num">${intervalKm}</td>`,
-        `<td class="${sideClass}">${sideLabel}</td>`,
-        `<td class="num">${Math.round(proj.perpMeters)}</td>`,
-        `<td><span class="chain-badge">${escapeHtml(props.chain || '')}</span><span class="store-name">${escapeHtml(props.name || '-')}</span></td>`,
-        `<td>${escapeHtml(props.address_norm || '-')}</td>`
-      ].join('');
+      const rendered = renderRow(row, index, intervalKm);
+      if (rendered.className) tr.className = rendered.className;
+      tr.innerHTML = rendered.html;
       tbody.appendChild(tr);
     });
   }


### PR DESCRIPTION
ブルベ用途で FIT に含まれる course point (PC / aid station / 道路指示等) をライド計画上で扱えるように UX を3点拡張。

## 1. ★ クリックで popup
- 地図上の ★ をクリックすると popup に course point の \`type\` / \`name\` / 累計 km・左右・離れ (経路があれば) を表示
- single-click handler は supply-point → course-point → 手動2点 の順に hit-detect
- course point を activate すると既存の supply-point 選択はクリアして整合させる

## 2. キューシートに統合
- 印刷ページが \`coursePoints\` を受け取り、各 PC に \`routeProjection\` を実行して \`alongMeters\` でソート、補給地点と統合表示
- PC 行は \`★ <type>\` バッジ + PC 名を店舗カラムに、行全体を温かみのあるオレンジで強調 (\`@media print\` でも色保持)
- メタ表示が「補給地点 N 件 / ★ M 件」になる

## 3. フィルタチェックボックス
- サイドバーに「★ を表示」 (\`#show-course-points\`、既定 ON) を追加
- OFF で \`coursePointLayer.setVisible(false)\` (hit detection も skip)、PC popup が開いてたら閉じる
- OFF のまま「キューシート」ボタンを押すと localStorage に PC が含まれず、印刷ページにも出ない (= 地図と紙の表示が一致)

## 配管
- \`cachedCoursePoints\` 状態を追加。FIT 読み込み時に \`renderCoursePoints\` が更新、\`clearRouteVisualSources()\` でリセットして他モードに状態が漏れないようにする

## Test plan
- [x] \`npm test\` (78 件 pass)
- [x] \`node --check frontend/{app,print}.js\`
- [x] Playwright スモーク (\`./.local/course_point_ux_smoketest.mjs\`) — FIT (4 trkpt + 1 PC) を投入:
  - キューシート: PC 1 行、\`★ generic\` バッジ、PC 名 \"PC1\", メタ「補給地点 99 件 / ★ 1 件」
  - フィルタ OFF → キューシート PC 0 行、メタ「補給地点 99 件」
  - JS / page エラー無し
- [ ] 実機で ★ クリック popup の見た目確認 (Playwright では canvas 座標→pixel 算出が複雑だったため手動)