### PR TITLE
feat: RideWithGPS ルートを URL/ID から取り込む

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -43,7 +43,10 @@ const elements = {
   resultsToggle: document.getElementById('results-toggle'),
   cueSheetButton: document.getElementById('cue-sheet-button'),
   gpxExportButton: document.getElementById('gpx-export-button'),
-  showCoursePoints: document.getElementById('show-course-points')
+  showCoursePoints: document.getElementById('show-course-points'),
+  rwgForm: document.getElementById('rwg-form'),
+  rwgUrl: document.getElementById('rwg-url'),
+  rwgFetch: document.getElementById('rwg-fetch')
 };
 
 const CUE_SHEET_STORAGE_KEY = 'rideoasis-cue-sheet';
@@ -370,9 +373,13 @@ function activateCoursePoint(feature) {
       projLine = `<div class="popup-distance">累計 ${cumKm} km / ${sideLabel}側 / 離れ ${Math.round(proj.perpMeters)} m</div>`;
     }
   }
+  const descLine = cp.description
+    ? `<div class="popup-description">${escapeHtml(cp.description)}</div>`
+    : '';
   elements.popupBody.innerHTML = [
     `<div class="popup-chain">${escapeHtml(cp.type || 'course point')}</div>`,
     `<div class="popup-title">${escapeHtml(cp.name || '(無名)')}</div>`,
+    descLine,
     projLine
   ].filter(Boolean).join('');
   elements.popup.hidden = false;
@@ -828,6 +835,55 @@ async function handleRouteFile(event) {
   }
 }
 
+/** Fetches a RideWithGPS public route by URL/id, applies it as the active route. */
+async function handleRwgFetch(event) {
+  if (event && typeof event.preventDefault === 'function') event.preventDefault();
+  if (!window.RwgImport || typeof window.RwgImport.fetchRoute !== 'function') {
+    setStatus('RWG インポータの初期化に失敗しました。ページを再読み込みしてください');
+    return;
+  }
+  const value = elements.rwgUrl ? elements.rwgUrl.value : '';
+  const id = window.RwgImport.parseRouteId(value);
+  if (id == null) {
+    setStatus('RWG の URL / ID が認識できません');
+    return;
+  }
+  const loadToken = ++latestRouteLoadToken;
+  cancelPendingRefreshes();
+  const previousFileName = elements.gpxFileName.textContent;
+  if (elements.rwgFetch) elements.rwgFetch.disabled = true;
+  try {
+    setStatus(`RWG #${id} を取得中...`);
+    const rwg = await window.RwgImport.fetchRoute(id);
+    if (loadToken !== latestRouteLoadToken) return;
+    if (!rwg.records || rwg.records.length < 2) {
+      throw new Error('RWG ルートから 2 点以上の経路座標を取得できませんでした');
+    }
+    const coords = rwg.records.map((r) => [r.lon, r.lat]);
+    const parsedRoute = createRouteFeatureFromCoords(coords);
+    routeFeature = parsedRoute.feature;
+    routeCoordinates = parsedRoute.coordinates;
+    manualPoints = [];
+    const displayName = rwg.name || `RWG #${id}`;
+    elements.gpxFileName.textContent = displayName;
+    renderRoute(routeFeature);
+    renderCoursePoints(rwg.coursePoints || []);
+    resetResults();
+    updateRoutePointCount();
+    fitToVisibleData();
+    const cpInfo = (rwg.coursePoints || []).length > 0 ? ` (PC ${rwg.coursePoints.length} 件)` : '';
+    setStatus(`RWG ルートを読み込みました: ${displayName}${cpInfo}`);
+    await refreshMap([...routeCoordinates]);
+  } catch (error) {
+    if (loadToken !== latestRouteLoadToken) return;
+    elements.gpxFileName.textContent = previousFileName;
+    setStatus(error?.message || 'RWG ルートの取得に失敗しました');
+    console.error(error);
+  } finally {
+    if (elements.rwgFetch) elements.rwgFetch.disabled = false;
+  }
+}
+
 /** Records a manual map click as start (1st click) or goal (2nd click) and refreshes the map. */
 async function handleManualMapClick(mapCoord) {
   if (manualPoints.length >= 2) return;
@@ -1237,6 +1293,9 @@ function bindEvents() {
     input.addEventListener('change', applyResultFilters);
   }
   elements.gpxFile.addEventListener('change', handleRouteFile);
+  if (elements.rwgForm) {
+    elements.rwgForm.addEventListener('submit', handleRwgFetch);
+  }
   elements.useCurrentLocation.addEventListener('click', handleCurrentLocation);
   elements.followToggle.addEventListener('change', handleFollowToggle);
   elements.manualReset.addEventListener('click', resetManualState);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -58,6 +58,10 @@
               <span class="picker-label">ルートを選ぶ (GPX / FIT)</span>
               <input id="gpx-file" type="file" accept=".gpx,.fit,application/gpx+xml,text/xml,application/xml,application/octet-stream" />
             </label>
+            <form class="rwg-form" id="rwg-form" autocomplete="off">
+              <input id="rwg-url" type="text" placeholder="または RWG URL / ID" inputmode="url" autocomplete="off" />
+              <button type="submit" id="rwg-fetch" class="rwg-fetch">取得</button>
+            </form>
             <div class="ctx-meta">
               <span class="file-name" id="gpx-file-name">未選択</span>
               <span class="route-meta" id="route-point-count">経路点数: -</span>
@@ -180,6 +184,7 @@
     <script src="./route_math.js"></script>
     <script src="./gpx.js"></script>
     <script src="./fit.js"></script>
+    <script src="./rwg.js"></script>
     <script src="./app.js"></script>
   </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -59,7 +59,7 @@
               <input id="gpx-file" type="file" accept=".gpx,.fit,application/gpx+xml,text/xml,application/xml,application/octet-stream" />
             </label>
             <form class="rwg-form" id="rwg-form" autocomplete="off">
-              <input id="rwg-url" type="text" placeholder="または RWG URL / ID" inputmode="url" autocomplete="off" />
+              <input id="rwg-url" type="text" placeholder="または RWG URL / ID" inputmode="url" autocomplete="off" aria-label="RideWithGPS URL または ID" />
               <button type="submit" id="rwg-fetch" class="rwg-fetch">取得</button>
             </form>
             <div class="ctx-meta">

--- a/frontend/print.css
+++ b/frontend/print.css
@@ -219,6 +219,16 @@ tr.cue-row-cp:nth-child(even) td {
   font-weight: 700;
 }
 
+.cp-description {
+  margin-top: 3px;
+  font-size: 11px;
+  font-weight: 400;
+  color: #6c5a3a;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .empty {
   text-align: center;
   color: var(--c-muted);

--- a/frontend/print.js
+++ b/frontend/print.js
@@ -54,6 +54,9 @@
 
     if (row.kind === 'course-point') {
       const cp = row.cp;
+      const desc = cp.description
+        ? `<div class="cp-description">${escapeHtml(cp.description)}</div>`
+        : '';
       return {
         className: 'cue-row-cp',
         html: [
@@ -62,7 +65,7 @@
           `<td class="num">${intervalKm}</td>`,
           `<td class="${sideClass}">${sideLabel}</td>`,
           `<td class="num">${Math.round(row.proj.perpMeters)}</td>`,
-          `<td><span class="chain-badge cp-badge">★ ${escapeHtml(cp.type || 'PC')}</span><span class="store-name">${escapeHtml(cp.name || '(無名)')}</span></td>`,
+          `<td><span class="chain-badge cp-badge">★ ${escapeHtml(cp.type || 'PC')}</span><span class="store-name">${escapeHtml(cp.name || '(無名)')}</span>${desc}</td>`,
           `<td>—</td>`
         ].join('')
       };

--- a/frontend/rwg.js
+++ b/frontend/rwg.js
@@ -1,0 +1,110 @@
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+    return;
+  }
+  root.RwgImport = factory();
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+
+  const ROUTE_URL_RE = /ridewithgps\.com\/routes\/(\d+)/i;
+
+  /** Returns the numeric RWG route id from a URL or bare numeric string, or null. */
+  function parseRouteId(input) {
+    if (typeof input !== 'string') return null;
+    const trimmed = input.trim();
+    if (/^\d+$/.test(trimmed)) return Number(trimmed);
+    const match = trimmed.match(ROUTE_URL_RE);
+    return match ? Number(match[1]) : null;
+  }
+
+  /** Returns true when lat/lon are finite and inside WGS84 valid ranges. */
+  function isValidLatLon(lat, lon) {
+    return Number.isFinite(lat)
+      && Number.isFinite(lon)
+      && lat >= -90 && lat <= 90
+      && lon >= -180 && lon <= 180;
+  }
+
+  /**
+   * Normalizes a RideWithGPS routes/<id>.json response into the shape the rest
+   * of ride-oasis consumes.
+   *
+   * - records: 1 entry per `track_points` element (`x` lon, `y` lat, `d` dist m)
+   * - coursePoints: union of `course_points` (turn instructions) and
+   *   `points_of_interest` (PCs / cautions / finish / generic), each with
+   *   `{ lat, lon, distanceMeters, name, type, description }`. RWG's POIs are
+   *   the only place the long brevet PC text lives, so the description field
+   *   is preserved here for the popup and cue-sheet.
+   * - name: the route's own display name (used as a substitute filename).
+   */
+  function normalizeRwgData(data) {
+    const records = (Array.isArray(data?.track_points) ? data.track_points : [])
+      .filter((p) => isValidLatLon(p?.y, p?.x))
+      .map((p) => ({
+        lat: p.y,
+        lon: p.x,
+        distanceMeters: Number.isFinite(p.d) ? p.d : null
+      }));
+
+    const cuePoints = (Array.isArray(data?.course_points) ? data.course_points : [])
+      .filter((p) => isValidLatLon(p?.y, p?.x))
+      .map((p) => ({
+        lat: p.y,
+        lon: p.x,
+        distanceMeters: Number.isFinite(p.d) ? p.d : null,
+        name: typeof p.n === 'string' ? p.n : '',
+        type: typeof p.t === 'string' && p.t ? p.t.toLowerCase() : 'generic',
+        description: ''
+      }));
+
+    const poiPoints = (Array.isArray(data?.points_of_interest) ? data.points_of_interest : [])
+      .filter((p) => isValidLatLon(p?.lat, p?.lng))
+      .map((p) => ({
+        lat: p.lat,
+        lon: p.lng,
+        distanceMeters: null,
+        name: typeof p.name === 'string' ? p.name : '',
+        type: typeof p.poi_type_name === 'string' && p.poi_type_name ? p.poi_type_name : 'generic',
+        description: typeof p.description === 'string' ? p.description : ''
+      }));
+
+    return {
+      records,
+      coursePoints: [...cuePoints, ...poiPoints],
+      name: typeof data?.name === 'string' ? data.name : ''
+    };
+  }
+
+  /** Builds a public RideWithGPS JSON URL for the given numeric route id. */
+  function buildRouteUrl(id) {
+    return `https://ridewithgps.com/routes/${id}.json`;
+  }
+
+  /**
+   * Fetches a public RWG route by numeric id and returns the normalized shape.
+   * The route must be public (anonymous access); routes shared only with a
+   * link will fail at the server side.
+   */
+  async function fetchRoute(id, opts = {}) {
+    if (!Number.isFinite(id)) {
+      throw new Error('RWG ルート ID が不正です');
+    }
+    const fetchFn = opts.fetchFn || fetch;
+    const response = await fetchFn(buildRouteUrl(id), {
+      headers: { Accept: 'application/json' }
+    });
+    if (!response.ok) {
+      throw new Error(`RWG fetch failed (HTTP ${response.status})`);
+    }
+    const data = await response.json();
+    return normalizeRwgData(data);
+  }
+
+  return {
+    parseRouteId,
+    normalizeRwgData,
+    fetchRoute,
+    buildRouteUrl
+  };
+});

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -389,6 +389,55 @@ input[type="search"]::-webkit-search-cancel-button {
   display: none;
 }
 
+.rwg-form {
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-1);
+  flex: 1;
+  min-width: 200px;
+}
+
+.rwg-form input[type="text"] {
+  flex: 1;
+  min-width: 0;
+  height: var(--tap-min);
+  padding: 0 var(--space-3);
+  border: 1px solid var(--c-line-strong);
+  border-radius: var(--r-md);
+  background: var(--c-surface-muted);
+  color: var(--c-ink);
+  font-size: 13px;
+}
+
+.rwg-form input[type="text"]:focus-visible {
+  outline: 2px solid rgba(34, 94, 168, 0.25);
+  border-color: var(--c-accent);
+  background: var(--c-surface);
+}
+
+.rwg-fetch {
+  flex-shrink: 0;
+  height: var(--tap-min);
+  padding: 0 var(--space-3);
+  border: 0;
+  border-radius: var(--r-md);
+  background: var(--c-accent);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.rwg-fetch:hover:not(:disabled),
+.rwg-fetch:focus-visible:not(:disabled) {
+  background: var(--c-accent-strong);
+}
+
+.rwg-fetch:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .ctx-meta {
   display: flex;
   flex-direction: column;
@@ -598,6 +647,15 @@ input[type="search"]::-webkit-search-cancel-button {
 .popup-distance {
   color: var(--c-ink-muted);
   font-size: 13px;
+}
+
+.popup-description {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--c-ink);
+  white-space: pre-wrap;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
 }
 
 /* ========== Results sheet (mobile bottom sheet, desktop sidebar) ========== */

--- a/tests/rwg.test.js
+++ b/tests/rwg.test.js
@@ -1,0 +1,126 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  parseRouteId,
+  normalizeRwgData,
+  fetchRoute,
+  buildRouteUrl
+} = require('../frontend/rwg');
+
+test('RWG: parseRouteId は URL 文字列から数値 id を抽出する', () => {
+  assert.equal(parseRouteId('https://ridewithgps.com/routes/34616079'), 34616079);
+  assert.equal(parseRouteId('https://ridewithgps.com/routes/34616079?foo=bar'), 34616079);
+  assert.equal(parseRouteId('http://ridewithgps.com/routes/12345'), 12345);
+  assert.equal(parseRouteId('  https://ridewithgps.com/routes/777  '), 777);
+});
+
+test('RWG: parseRouteId は数値文字列をそのまま受ける', () => {
+  assert.equal(parseRouteId('34616079'), 34616079);
+  assert.equal(parseRouteId('  34616079  '), 34616079);
+});
+
+test('RWG: parseRouteId は無効入力で null を返す', () => {
+  assert.equal(parseRouteId(''), null);
+  assert.equal(parseRouteId(null), null);
+  assert.equal(parseRouteId('not a url'), null);
+  assert.equal(parseRouteId('https://example.com/routes/123'), null);
+  assert.equal(parseRouteId(34616079), null);
+});
+
+test('RWG: buildRouteUrl は public JSON URL を返す', () => {
+  assert.equal(buildRouteUrl(34616079), 'https://ridewithgps.com/routes/34616079.json');
+});
+
+test('RWG: normalizeRwgData は track_points / course_points / POI を統合する', () => {
+  const data = {
+    name: '神戸-伊勢',
+    track_points: [
+      { x: 139.0, y: 35.0, d: 0 },
+      { x: 139.001, y: 35.001, d: 150 }
+    ],
+    course_points: [
+      { x: 139.0005, y: 35.0005, d: 75, n: '右折', t: 'Right' }
+    ],
+    points_of_interest: [
+      {
+        lat: 34.5392, lng: 136.6027,
+        name: '通過チェック2a　従是外宮三里 石碑',
+        description: '1a 自転車と写真',
+        poi_type_name: 'generic'
+      }
+    ]
+  };
+  const out = normalizeRwgData(data);
+  assert.equal(out.name, '神戸-伊勢');
+  assert.equal(out.records.length, 2);
+  assert.deepEqual(out.records[0], { lat: 35.0, lon: 139.0, distanceMeters: 0 });
+  assert.equal(out.coursePoints.length, 2);
+  assert.equal(out.coursePoints[0].name, '右折');
+  assert.equal(out.coursePoints[0].type, 'right');
+  assert.equal(out.coursePoints[0].description, '');
+  assert.equal(out.coursePoints[1].name, '通過チェック2a　従是外宮三里 石碑');
+  assert.equal(out.coursePoints[1].description, '1a 自転車と写真');
+  assert.equal(out.coursePoints[1].type, 'generic');
+  assert.equal(out.coursePoints[1].lat, 34.5392);
+  assert.equal(out.coursePoints[1].lon, 136.6027);
+});
+
+test('RWG: normalizeRwgData は不正座標を除外する', () => {
+  const out = normalizeRwgData({
+    track_points: [
+      { x: 139, y: 35 },
+      { x: 999, y: 35 }
+    ],
+    course_points: [
+      { x: 139, y: 91, n: 'oob' },
+      { x: 139, y: 35, n: 'ok' }
+    ],
+    points_of_interest: [
+      { lat: 35, lng: -181, name: 'oob' },
+      { lat: 35, lng: 139, name: 'ok' }
+    ]
+  });
+  assert.equal(out.records.length, 1);
+  assert.equal(out.coursePoints.length, 2);
+  assert.equal(out.coursePoints[0].name, 'ok');
+  assert.equal(out.coursePoints[1].name, 'ok');
+});
+
+test('RWG: normalizeRwgData は欠落フィールドを安全に扱う', () => {
+  const out = normalizeRwgData({});
+  assert.deepEqual(out, { records: [], coursePoints: [], name: '' });
+  assert.deepEqual(normalizeRwgData(null), { records: [], coursePoints: [], name: '' });
+});
+
+test('RWG: fetchRoute は fetchFn を経由して normalize した結果を返す', async () => {
+  const fakeJson = {
+    name: 'TestRoute',
+    track_points: [{ x: 139, y: 35, d: 0 }, { x: 139.01, y: 35, d: 800 }],
+    course_points: [],
+    points_of_interest: [{ lat: 35, lng: 139, name: 'PC', description: 'D', poi_type_name: 'finish' }]
+  };
+  const fetchFn = async (url, opts) => {
+    assert.equal(url, 'https://ridewithgps.com/routes/12345.json');
+    assert.equal(opts.headers.Accept, 'application/json');
+    return {
+      ok: true,
+      json: async () => fakeJson
+    };
+  };
+  const result = await fetchRoute(12345, { fetchFn });
+  assert.equal(result.name, 'TestRoute');
+  assert.equal(result.records.length, 2);
+  assert.equal(result.coursePoints.length, 1);
+  assert.equal(result.coursePoints[0].type, 'finish');
+});
+
+test('RWG: fetchRoute は HTTP エラーで Error を投げる', async () => {
+  const fetchFn = async () => ({ ok: false, status: 404 });
+  await assert.rejects(fetchRoute(99999, { fetchFn }), /HTTP 404/);
+});
+
+test('RWG: fetchRoute は不正 id で Error を投げる', async () => {
+  await assert.rejects(fetchRoute(NaN, { fetchFn: async () => ({}) }), /不正/);
+  await assert.rejects(fetchRoute('abc', { fetchFn: async () => ({}) }), /不正/);
+});


### PR DESCRIPTION
## なぜ
ブルベ用途で RWG ルートの「通過チェック2a 従是外宮三里 石碑」のような長文 PC 説明は **FIT では 16byte 制限で必ず切り詰められる** (実機確認済み)。一方 RWG の public JSON は \`points_of_interest\` に full \`name\` + \`description\` を持っていて、CORS も \`access-control-allow-origin: *\`、認証不要で読める。ここから直接 fetch すれば情報量がフルで取れる。

## 何を取れるか (実例: route 34616079)
- track_points 12,959 件
- course_points 91 件 (turn-by-turn、long text OK)
- points_of_interest 16 件 (通過チェック / 注意 / ゴール / 集合場所等、name + description 完全保持)
- 「通過チェック2a 従是外宮三里 石碑」+ description 「通過チェック1は 1a (自転車と写真),1b (レシート)…」が取得できる

## frontend/rwg.js (新規)
- \`parseRouteId(input)\`: URL / 数値 / 空白付き入力を受け付け、不正なら null
- \`normalizeRwgData(data)\`: track_points → records、course_points + POI を統合して coursePoints (POI 側だけ description を保持)
- \`fetchRoute(id, opts)\`: 公開 JSON エンドポイントを fetch、HTTP エラーを Error throw、テスト用に fetchFn 注入可

## UI
- gpx-panel 内に「または RWG URL / ID」入力 + 「取得」ボタン
- 取得中は status「RWG #ID を取得中...」、成功で「RWG ルートを読み込みました: <name> (PC N 件)」
- ★ クリック popup と キューシート印刷の PC 行に description サブテキストを追加 (#50 の流れに乗せる)
- 印刷でも description が出るよう color-adjust ルールを継承

## Test plan
- [x] \`npm test\` (90 件 pass、新規 rwg.test.js 10 件含む)
- [x] \`node --check\` 各 frontend ファイル
- [x] Playwright スモーク (\`./.local/rwg_smoketest.mjs\`):
  - RWG レスポンスを Playwright route で stub (POI に「通過チェック2a 従是外宮三里 石碑」+ description「1a 自転車と写真」)
  - 取得後: file-name に \`BRM Test\` (RWG name)、経路点数 4、補給地点 99 件、PC 2 行、POI 行に description が表示される
  - JS / page エラー無し
- [ ] 実機で公開 RWG ルート (https://ridewithgps.com/routes/34616079) を取得確認