### PR TITLE
feat: コース点をタイプ別チェックボックスでフィルタする

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -44,6 +44,7 @@ const elements = {
   cueSheetButton: document.getElementById('cue-sheet-button'),
   gpxExportButton: document.getElementById('gpx-export-button'),
   showCoursePoints: document.getElementById('show-course-points'),
+  coursePointTypes: document.getElementById('course-point-types'),
   rwgForm: document.getElementById('rwg-form'),
   rwgUrl: document.getElementById('rwg-url'),
   rwgFetch: document.getElementById('rwg-fetch')
@@ -121,18 +122,25 @@ const currentLocationLayer = new ol.layer.Vector({
   })
 });
 
+const coursePointBaseStyle = new ol.style.Style({
+  image: new ol.style.RegularShape({
+    points: 5,
+    radius: 9,
+    radius2: 4,
+    angle: 0,
+    fill: new ol.style.Fill({ color: '#c62f2f' }),
+    stroke: new ol.style.Stroke({ color: '#ffffff', width: 1.5 })
+  })
+});
+
 const coursePointLayer = new ol.layer.Vector({
   source: coursePointSource,
-  style: new ol.style.Style({
-    image: new ol.style.RegularShape({
-      points: 5,
-      radius: 9,
-      radius2: 4,
-      angle: 0,
-      fill: new ol.style.Fill({ color: '#c62f2f' }),
-      stroke: new ol.style.Stroke({ color: '#ffffff', width: 1.5 })
-    })
-  })
+  style(feature) {
+    const cp = feature && feature.get('coursePoint');
+    if (!cp) return null;
+    if (disabledCoursePointTypes.has(cp.type)) return null;
+    return coursePointBaseStyle;
+  }
 });
 
 const map = new ol.Map({
@@ -163,6 +171,7 @@ let routeFeature = null;
 let routeCoordinates = [];
 let manualPoints = [];
 let cachedCoursePoints = [];
+let disabledCoursePointTypes = new Set();
 let allMatchedPoints = [];
 let filteredPoints = [];
 let activeSupplyPointId = null;
@@ -524,6 +533,7 @@ function clearRouteVisualSources() {
 function renderCoursePoints(points) {
   coursePointSource.clear();
   cachedCoursePoints = Array.isArray(points) ? points.slice() : [];
+  disabledCoursePointTypes = new Set();
   for (const cp of cachedCoursePoints) {
     if (!Number.isFinite(cp?.lat) || !Number.isFinite(cp?.lon)) continue;
     const feature = new ol.Feature({
@@ -535,12 +545,48 @@ function renderCoursePoints(points) {
   if (elements.showCoursePoints) {
     coursePointLayer.setVisible(elements.showCoursePoints.checked);
   }
+  rebuildCoursePointTypeChips();
 }
 
-/** Returns the cached course points filtered by the show-course-points toggle. */
+/** Returns the cached course points filtered by both the master toggle and per-type filters. */
 function visibleCoursePoints() {
   if (elements.showCoursePoints && !elements.showCoursePoints.checked) return [];
-  return cachedCoursePoints.slice();
+  return cachedCoursePoints.filter((cp) => !disabledCoursePointTypes.has(cp.type));
+}
+
+/** Rebuilds the per-type chip filters from the unique types in cachedCoursePoints. */
+function rebuildCoursePointTypeChips() {
+  const container = elements.coursePointTypes;
+  if (!container) return;
+  container.innerHTML = '';
+  const types = new Set();
+  for (const cp of cachedCoursePoints) {
+    if (typeof cp?.type === 'string' && cp.type) types.add(cp.type);
+  }
+  if (types.size === 0) {
+    container.hidden = true;
+    return;
+  }
+  container.hidden = false;
+  for (const type of [...types].sort()) {
+    const label = document.createElement('label');
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.value = type;
+    input.checked = true;
+    input.addEventListener('change', () => {
+      if (input.checked) disabledCoursePointTypes.delete(type);
+      else disabledCoursePointTypes.add(type);
+      coursePointLayer.changed();
+      if (!input.checked && activePopupKind === 'course-point') {
+        clearPopup();
+      }
+    });
+    const span = document.createElement('span');
+    span.textContent = type;
+    label.append(input, span);
+    container.appendChild(label);
+  }
 }
 
 /** Renders the uploaded route and its start/end markers. */
@@ -1380,7 +1426,12 @@ function bindEvents() {
     }
     const cpFeature = map.forEachFeatureAtPixel(
       event.pixel,
-      (candidate) => (candidate && candidate.get('coursePoint') ? candidate : undefined)
+      (candidate) => {
+        const cp = candidate && candidate.get('coursePoint');
+        if (!cp) return undefined;
+        if (disabledCoursePointTypes.has(cp.type)) return undefined;
+        return candidate;
+      }
     );
     if (cpFeature) {
       activateCoursePoint(cpFeature);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -176,6 +176,7 @@ let allMatchedPoints = [];
 let filteredPoints = [];
 let activeSupplyPointId = null;
 let activePopupKind = null;
+let activeCoursePointType = null;
 let previewSupplyPointId = null;
 const API_PAGE_LIMIT = 10000;
 const featureIndex = new Map();
@@ -393,6 +394,7 @@ function activateCoursePoint(feature) {
   ].filter(Boolean).join('');
   elements.popup.hidden = false;
   activePopupKind = 'course-point';
+  activeCoursePointType = cp.type || null;
   // Course points are not part of the supply-point selection flow, so we
   // explicitly clear any prior supply selection without closing this popup.
   activeSupplyPointId = null;
@@ -440,6 +442,7 @@ function clearPopup() {
   elements.popup.hidden = true;
   popupOverlay.setPosition(undefined);
   activePopupKind = null;
+  activeCoursePointType = null;
   syncPointHighlight();
   syncPointListSelection();
 }
@@ -578,7 +581,7 @@ function rebuildCoursePointTypeChips() {
       if (input.checked) disabledCoursePointTypes.delete(type);
       else disabledCoursePointTypes.add(type);
       coursePointLayer.changed();
-      if (!input.checked && activePopupKind === 'course-point') {
+      if (!input.checked && activePopupKind === 'course-point' && activeCoursePointType === type) {
         clearPopup();
       }
     });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -168,8 +168,9 @@
               <label><input type="checkbox" name="precision-filter" value="rough" checked /><span>あいまい</span></label>
             </fieldset>
             <fieldset class="chains course-point-filters">
-              <legend>コース点 (FIT)</legend>
+              <legend>コース点 (FIT/RWG)</legend>
               <label><input type="checkbox" id="show-course-points" checked /><span>★ を表示</span></label>
+              <div id="course-point-types" class="course-point-types" hidden></div>
             </fieldset>
           </div>
           <div class="point-list" id="point-list"></div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -825,6 +825,17 @@ input[type="search"]::-webkit-search-cancel-button {
   color: var(--c-accent-strong);
 }
 
+.course-point-types {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.course-point-types[hidden] {
+  display: none;
+}
+
 .results-filters .chains input[type="checkbox"] {
   width: 14px;
   height: 14px;


### PR DESCRIPTION
ルートに含まれるコース点タイプ (generic / left / right / straight / caution / finish / start_event 等) ごとに表示 ON/OFF を切り替えられるようにする。FIT / RWG どちらの取り込みでも動作する。

## UX
- 既存「★ を表示」(master) の下に **動的に生成される type チップ列** を追加
- ルート読み込み時に \`cachedCoursePoints\` のユニーク type をソート、各 type に checkbox を生成
- 各 chip の OFF でその type のマーカーが非表示、キューシート印刷からも除外
- Master OFF だと chip の状態に関わらず全部非表示
- ルート再読み込みで disabled set はクリア → 全 type 初期表示

## 実装
- \`disabledCoursePointTypes\` (Set<string>): OFF にされた type を保持
- \`coursePointLayer\` の \`style\` を function 化: feature の type が disabled なら \`null\` を返してマーカー描画スキップ
- \`forEachFeatureAtPixel\` callback でも disabled type を除外 → 非表示の PC を誤クリックして popup が開く事故を防ぐ
- \`rebuildCoursePointTypeChips()\`: ルート読み込み毎にチップを再構築
- \`visibleCoursePoints()\` を master と per-type 両方適用するよう更新
- type OFF の瞬間にその PC の popup が開いていれば \`clearPopup()\` で閉じる (kind 判定済)

## Test plan
- [x] \`npm test\` (90 件 pass)
- [x] \`node --check frontend/app.js\`
- [x] Playwright スモーク (\`.local/cp_type_filter_smoketest.mjs\`):
  - course_points 3 種 (right/left/straight) + POI 2 種 (generic/caution) を持つ RWG fixture
  - チップ 5 件生成 (ソート済み: caution/generic/left/right/straight)
  - キューシート初期表示 5 行
  - right と caution を OFF → キューシート 3 行 (left/straight/generic)
  - JS / page エラー無し