### PR TITLE
chore: oasis.ochanu.co をカスタムドメインとして wrangler.toml に明示

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,14 @@ main = "worker.mjs"
 compatibility_date = "2026-04-01"
 compatibility_flags = ["nodejs_compat"]
 
+# Custom domain. The DNS record + worker route are managed in the Cloudflare
+# Dashboard (Workers & Pages → ride-oasis → Settings → Domains & Routes); this
+# entry mirrors that binding so `wrangler deploy` does not warn about an
+# unknown route, and so reviewers can see where the Worker is actually served.
+[[routes]]
+pattern = "oasis.ochanu.co"
+custom_domain = true
+
 # Static frontend served straight from frontend/. The Worker only intercepts
 # the supply-point API; everything else falls through to the asset bundle.
 [assets]


### PR DESCRIPTION
Cloudflare Dashboard 側ではすでに \`oasis.ochanu.co\` を \`ride-oasis\` Worker のカスタムドメインとして bind 済 (DNS + route 設定済)。\`wrangler.toml\` にも対応する \`[[routes]]\` エントリを追加して、\`wrangler deploy\` 時の route 自動 reconcile と PR レビュー時の配信先可視化を揃える。

\`\`\`toml
[[routes]]
pattern = "oasis.ochanu.co"
custom_domain = true
\`\`\`

## 実機確認
- https://oasis.ochanu.co/ → 200, 8768 bytes (index.html)
- https://oasis.ochanu.co/api/supply-points?bbox=... → 200, GeoJSON
- \`npx wrangler deploy --dry-run\` → bundle ビルド成功、binding 認識