### PR TITLE
feat: URL クエリでフィルタと RWG ID を永続化する

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -172,6 +172,8 @@ let routeCoordinates = [];
 let manualPoints = [];
 let cachedCoursePoints = [];
 let disabledCoursePointTypes = new Set();
+let currentRwgId = null;
+let pendingCptypesFilter = null;
 let allMatchedPoints = [];
 let filteredPoints = [];
 let activeSupplyPointId = null;
@@ -530,6 +532,7 @@ function clearRouteVisualSources() {
   currentLocationSource.clear();
   coursePointSource.clear();
   cachedCoursePoints = [];
+  currentRwgId = null;
 }
 
 /** Renders FIT course-point waypoints (PCs / aid stations / etc.) on the map. */
@@ -571,12 +574,23 @@ function rebuildCoursePointTypeChips() {
     return;
   }
   container.hidden = false;
+  // If init parsed `cptypes` from the URL, only those types stay enabled.
+  // The pending filter is one-shot so user toggles after this don't get
+  // overridden the next time chips rebuild.
+  const enabledFromUrl = Array.isArray(pendingCptypesFilter)
+    ? new Set(pendingCptypesFilter)
+    : null;
   for (const type of [...types].sort()) {
     const label = document.createElement('label');
     const input = document.createElement('input');
     input.type = 'checkbox';
     input.value = type;
-    input.checked = true;
+    if (enabledFromUrl && !enabledFromUrl.has(type)) {
+      input.checked = false;
+      disabledCoursePointTypes.add(type);
+    } else {
+      input.checked = true;
+    }
     input.addEventListener('change', () => {
       if (input.checked) disabledCoursePointTypes.delete(type);
       else disabledCoursePointTypes.add(type);
@@ -584,11 +598,16 @@ function rebuildCoursePointTypeChips() {
       if (!input.checked && activePopupKind === 'course-point' && activeCoursePointType === type) {
         clearPopup();
       }
+      syncUrlState();
     });
     const span = document.createElement('span');
     span.textContent = type;
     label.append(input, span);
     container.appendChild(label);
+  }
+  if (enabledFromUrl) {
+    pendingCptypesFilter = null;
+    coursePointLayer.changed();
   }
 }
 
@@ -867,12 +886,14 @@ async function handleRouteFile(event) {
     routeFeature = parsedRoute.feature;
     routeCoordinates = parsedRoute.coordinates;
     manualPoints = [];
+    currentRwgId = null;
     elements.gpxFileName.textContent = file.name;
     renderRoute(routeFeature);
     renderCoursePoints(coursePoints);
     resetResults();
     updateRoutePointCount();
     fitToVisibleData();
+    syncUrlState();
     const cpInfo = coursePoints.length > 0 ? ` (PC ${coursePoints.length} 件)` : '';
     setStatus(`${isFit ? 'FIT' : 'GPX'} を読み込みました: ${file.name}${cpInfo}`);
     await refreshMap([...routeCoordinates]);
@@ -922,6 +943,8 @@ async function handleRwgFetch(event) {
     fitToVisibleData();
     const cpInfo = (rwg.coursePoints || []).length > 0 ? ` (PC ${rwg.coursePoints.length} 件)` : '';
     setStatus(`RWG ルートを読み込みました: ${displayName}${cpInfo}`);
+    currentRwgId = id;
+    syncUrlState();
     await refreshMap([...routeCoordinates]);
   } catch (error) {
     if (loadToken !== latestRouteLoadToken) return;
@@ -959,6 +982,7 @@ async function handleManualMapClick(mapCoord) {
   updateRoutePointCount();
   fitToVisibleData();
   setStatus('手動経路を生成しました');
+  syncUrlState();
   if (loadToken !== latestRouteLoadToken) return;
   await refreshMap([...routeCoordinates]);
 }
@@ -1006,6 +1030,7 @@ async function handleCurrentLocation() {
     updateRoutePointCount();
     fitToVisibleData();
     setStatus('現在地を取得しました');
+    syncUrlState();
     await refreshMap([...routeCoordinates]);
   } catch (error) {
     if (loadToken !== latestRouteLoadToken) return;
@@ -1313,6 +1338,76 @@ function handleGeoSearchClear() {
   elements.geoSearchInput.focus();
 }
 
+/** Reads the currently checked filter inputs into the {chains, precision, cptypes} state shape. */
+function readFilterStateForUrl() {
+  const allChainInputs = Array.from(document.querySelectorAll('.chain-filters input[type="checkbox"]'));
+  const checkedChains = allChainInputs.filter((input) => input.checked).map((input) => input.value);
+  const allPrecisionInputs = Array.from(document.querySelectorAll('input[name="precision-filter"]'));
+  const checkedPrecisions = allPrecisionInputs.filter((input) => input.checked).map((input) => input.value);
+  const cptypesInputs = elements.coursePointTypes
+    ? Array.from(elements.coursePointTypes.querySelectorAll('input[type="checkbox"]'))
+    : [];
+  const checkedCptypes = cptypesInputs.filter((input) => input.checked).map((input) => input.value);
+
+  const chainsAllOn = checkedChains.length === allChainInputs.length;
+  const precisionAllOn = checkedPrecisions.length === allPrecisionInputs.length;
+  const cptypesAllOn = cptypesInputs.length === 0 || checkedCptypes.length === cptypesInputs.length;
+  const cpMaster = elements.showCoursePoints ? elements.showCoursePoints.checked : true;
+
+  return {
+    chains: chainsAllOn ? null : checkedChains,
+    precision: precisionAllOn ? null : checkedPrecisions,
+    cp: cpMaster ? null : false,
+    cptypes: cptypesInputs.length === 0 || cptypesAllOn ? null : checkedCptypes
+  };
+}
+
+/** Replaces the URL query string with the current filter state + active RWG id. */
+function syncUrlState() {
+  if (!window.UrlState) return;
+  const existing = window.UrlState.parseUrlState(window.location.search);
+  const filterState = readFilterStateForUrl();
+  const next = {
+    rwg: Number.isFinite(currentRwgId) ? currentRwgId : null,
+    ...filterState,
+    extra: existing.extra
+  };
+  const search = window.UrlState.formatUrlState(next);
+  const url = `${window.location.pathname}${search}${window.location.hash}`;
+  window.history.replaceState({}, '', url);
+}
+
+/** Applies the parsed URL state to checkbox inputs and queues async work (RWG fetch + cptypes). */
+function applyUrlStateOnInit() {
+  if (!window.UrlState) return;
+  const state = window.UrlState.parseUrlState(window.location.search);
+
+  if (Array.isArray(state.chains)) {
+    const allow = new Set(state.chains);
+    for (const input of document.querySelectorAll('.chain-filters input[type="checkbox"]')) {
+      input.checked = allow.has(input.value);
+    }
+  }
+  if (Array.isArray(state.precision)) {
+    const allow = new Set(state.precision);
+    for (const input of document.querySelectorAll('input[name="precision-filter"]')) {
+      input.checked = allow.has(input.value);
+    }
+  }
+  if (state.cp === false && elements.showCoursePoints) {
+    elements.showCoursePoints.checked = false;
+    coursePointLayer.setVisible(false);
+  }
+  if (Array.isArray(state.cptypes)) {
+    pendingCptypesFilter = state.cptypes;
+  }
+
+  if (Number.isFinite(state.rwg) && state.rwg > 0 && elements.rwgUrl) {
+    elements.rwgUrl.value = String(state.rwg);
+    handleRwgFetch();
+  }
+}
+
 /** Wires DOM and map click events for the static frontend. */
 function bindEvents() {
   for (const input of document.querySelectorAll('input[name="source-mode"]')) {
@@ -1339,7 +1434,10 @@ function bindEvents() {
     }
   });
   for (const input of document.querySelectorAll('.result-filters input[type="checkbox"]')) {
-    input.addEventListener('change', applyResultFilters);
+    input.addEventListener('change', () => {
+      applyResultFilters();
+      syncUrlState();
+    });
   }
   elements.gpxFile.addEventListener('change', handleRouteFile);
   if (elements.rwgForm) {
@@ -1401,6 +1499,7 @@ function bindEvents() {
       if (!elements.showCoursePoints.checked && activePopupKind === 'course-point') {
         clearPopup();
       }
+      syncUrlState();
     });
   }
   elements.resultsToggle.addEventListener('click', () => {
@@ -1454,3 +1553,4 @@ buildPointList([]);
 updateSummary(0);
 syncCueSheetButton();
 bindEvents();
+applyUrlStateOnInit();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -186,6 +186,7 @@
     <script src="./gpx.js"></script>
     <script src="./fit.js"></script>
     <script src="./rwg.js"></script>
+    <script src="./url_state.js"></script>
     <script src="./app.js"></script>
   </body>
 </html>

--- a/frontend/url_state.js
+++ b/frontend/url_state.js
@@ -1,0 +1,106 @@
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+    return;
+  }
+  root.UrlState = factory();
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+
+  // Keys we know how to round-trip in the URL. Everything else is left as-is so
+  // we don't clobber unrelated query strings (e.g., ?utm_source=...).
+  const KEYS = ['rwg', 'chains', 'precision', 'cp', 'cptypes'];
+  const VALID_PRECISION = new Set(['precise', 'rough']);
+
+  /** Splits a comma-separated string into a deduplicated, trimmed array. */
+  function splitList(value) {
+    if (typeof value !== 'string' || value === '') return [];
+    const out = [];
+    const seen = new Set();
+    for (const raw of value.split(',')) {
+      const item = raw.trim();
+      if (!item || seen.has(item)) continue;
+      seen.add(item);
+      out.push(item);
+    }
+    return out;
+  }
+
+  /**
+   * Parses a URL search string (or URLSearchParams) into our app state shape.
+   * Unknown keys are kept in `extra` so they can be re-emitted untouched.
+   * `rwg` is `null` when absent or not a positive integer.
+   * The list-typed fields (`chains`, `precision`, `cptypes`) are `null` when
+   * the param is absent (= default = all enabled), or an array (possibly empty)
+   * when the param is present.
+   */
+  function parseUrlState(input) {
+    const params = input instanceof URLSearchParams
+      ? input
+      : new URLSearchParams(typeof input === 'string' ? input.replace(/^\?/, '') : '');
+
+    const rwgRaw = params.get('rwg');
+    let rwg = null;
+    if (rwgRaw != null) {
+      const parsed = Number.parseInt(rwgRaw, 10);
+      if (Number.isFinite(parsed) && parsed > 0) rwg = parsed;
+    }
+
+    const chains = params.has('chains') ? splitList(params.get('chains')) : null;
+    const precision = params.has('precision')
+      ? splitList(params.get('precision')).filter((p) => VALID_PRECISION.has(p))
+      : null;
+    const cp = params.has('cp') ? params.get('cp') !== '0' : null;
+    const cptypes = params.has('cptypes') ? splitList(params.get('cptypes')) : null;
+
+    const extra = new URLSearchParams();
+    for (const [key, value] of params.entries()) {
+      if (!KEYS.includes(key)) extra.append(key, value);
+    }
+
+    return { rwg, chains, precision, cp, cptypes, extra };
+  }
+
+  /**
+   * Builds a URL search string from a state object. Defaults (e.g.,
+   * chains == null) are omitted so the URL stays clean for first-time visits.
+   * `extra` is preserved at the end of the string in stable order.
+   */
+  function formatUrlState(state) {
+    const params = new URLSearchParams();
+    if (state) {
+      if (Number.isFinite(state.rwg) && state.rwg > 0) {
+        params.set('rwg', String(state.rwg));
+      }
+      if (Array.isArray(state.chains)) {
+        params.set('chains', state.chains.join(','));
+      }
+      if (Array.isArray(state.precision)) {
+        params.set('precision', state.precision.join(','));
+      }
+      if (state.cp === false) {
+        // The default (cp = on) is omitted; only the off case is encoded.
+        params.set('cp', '0');
+      } else if (state.cp === true) {
+        // `cp=1` is redundant with the default but lets URLs round-trip.
+        // Treat it as a no-op for compactness.
+      }
+      if (Array.isArray(state.cptypes)) {
+        params.set('cptypes', state.cptypes.join(','));
+      }
+    }
+    if (state && state.extra instanceof URLSearchParams) {
+      for (const [key, value] of state.extra.entries()) {
+        params.append(key, value);
+      }
+    }
+    const search = params.toString();
+    return search ? `?${search}` : '';
+  }
+
+  return {
+    KEYS,
+    parseUrlState,
+    formatUrlState
+  };
+});

--- a/tests/url_state.test.js
+++ b/tests/url_state.test.js
@@ -1,0 +1,88 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseUrlState, formatUrlState } = require('../frontend/url_state');
+
+test('UrlState: 空入力は全て null / undefined と既定の extra を返す', () => {
+  const out = parseUrlState('');
+  assert.equal(out.rwg, null);
+  assert.equal(out.chains, null);
+  assert.equal(out.precision, null);
+  assert.equal(out.cp, null);
+  assert.equal(out.cptypes, null);
+  assert.equal(out.extra.toString(), '');
+});
+
+test('UrlState: rwg は正の整数だけ受け付ける', () => {
+  assert.equal(parseUrlState('?rwg=12345').rwg, 12345);
+  assert.equal(parseUrlState('?rwg=0').rwg, null);
+  assert.equal(parseUrlState('?rwg=-1').rwg, null);
+  assert.equal(parseUrlState('?rwg=abc').rwg, null);
+});
+
+test('UrlState: chains は trim + 重複除去された配列にする', () => {
+  assert.deepEqual(parseUrlState('?chains=lawson,7eleven, lawson').chains, ['lawson', '7eleven']);
+  assert.deepEqual(parseUrlState('?chains=').chains, []);
+  assert.equal(parseUrlState('').chains, null);
+});
+
+test('UrlState: precision は precise / rough のみ通す', () => {
+  assert.deepEqual(parseUrlState('?precision=precise,rough,unknown').precision, ['precise', 'rough']);
+  assert.deepEqual(parseUrlState('?precision=').precision, []);
+});
+
+test('UrlState: cp は 0 で false、それ以外で true', () => {
+  assert.equal(parseUrlState('?cp=1').cp, true);
+  assert.equal(parseUrlState('?cp=0').cp, false);
+  assert.equal(parseUrlState('?cp=true').cp, true);
+  assert.equal(parseUrlState('').cp, null);
+});
+
+test('UrlState: 未知のキーは extra に残す', () => {
+  const out = parseUrlState('?utm_source=x&rwg=42&random=1');
+  assert.equal(out.rwg, 42);
+  assert.equal(out.extra.get('utm_source'), 'x');
+  assert.equal(out.extra.get('random'), '1');
+  assert.equal(out.extra.has('rwg'), false);
+});
+
+test('UrlState: format は default を省略してクリーンな URL を返す', () => {
+  assert.equal(formatUrlState({}), '');
+  assert.equal(formatUrlState({ rwg: 12345 }), '?rwg=12345');
+  assert.equal(formatUrlState({ rwg: null, chains: null, cp: null }), '');
+});
+
+test('UrlState: format は cp=false だけ書き出す (true は省略)', () => {
+  assert.equal(formatUrlState({ cp: false }), '?cp=0');
+  assert.equal(formatUrlState({ cp: true }), '');
+});
+
+test('UrlState: format はリスト型を comma 区切りで書き出す', () => {
+  assert.equal(
+    formatUrlState({ chains: ['lawson', '7eleven'], precision: ['precise'] }),
+    '?chains=lawson%2C7eleven&precision=precise'
+  );
+});
+
+test('UrlState: format は extra を末尾に保持する', () => {
+  const extra = new URLSearchParams('utm_source=tw&id=99');
+  assert.equal(
+    formatUrlState({ rwg: 42, extra }),
+    '?rwg=42&utm_source=tw&id=99'
+  );
+});
+
+test('UrlState: parse → format は extra を含めて round-trip する', () => {
+  const original = '?rwg=999&chains=lawson%2Cfamilymart&precision=precise&cp=0&cptypes=left%2Cright&utm_source=tw';
+  const parsed = parseUrlState(original);
+  const formatted = formatUrlState(parsed);
+  // Re-parse the formatted result to verify semantic equivalence regardless of
+  // key ordering or comma encoding.
+  const reparsed = parseUrlState(formatted);
+  assert.equal(reparsed.rwg, 999);
+  assert.deepEqual(reparsed.chains, ['lawson', 'familymart']);
+  assert.deepEqual(reparsed.precision, ['precise']);
+  assert.equal(reparsed.cp, false);
+  assert.deepEqual(reparsed.cptypes, ['left', 'right']);
+  assert.equal(reparsed.extra.get('utm_source'), 'tw');
+});


### PR DESCRIPTION
\`?rwg=12345&chains=lawson,7eleven&precision=precise&cp=0&cptypes=left,right\` 形式で UI 状態を URL に同期。コピー/シェアで同じビューに直接到達できる。プレビュー URL とも組み合わせて 「特定 RWG ルート + 自分の絞り込み」をリンクで共有できる。

## 永続化対象
- \`rwg\`: RideWithGPS ルート ID (整数)
- \`chains\`: チェーンフィルタの ON 集合 (default: 全 ON は省略)
- \`precision\`: 精度フィルタ (precise/rough)
- \`cp\`: ★ master トグル (default ON は省略、OFF のときだけ \`cp=0\`)
- \`cptypes\`: コース点タイプ chip の ON 集合 (default: 全 ON は省略)

## frontend/url_state.js (新規)
- \`parseUrlState(input)\`: 既知キーを型付き shape に正規化、未知キーは \`extra\` に保持
- \`formatUrlState(state)\`: default を省略しつつ \`extra\` を末尾に保持

## frontend/app.js 配線
- 起動末尾の \`applyUrlStateOnInit()\` で chain/precision/cp master を checkbox に復元、cptypes は \`pendingCptypesFilter\` に保存して \`rebuildCoursePointTypeChips\` が次に走るとき one-shot で適用
- \`syncUrlState()\` を chain/precision/cp master/cp chip の change と RWG/manual/current/file の各成功パスに紐付け、\`history.replaceState\` で常時 URL を同期
- \`clearRouteVisualSources()\` で \`currentRwgId = null\` を保証 (GPX/FIT/manual/current で route が差し替わると rwg= が URL から自動消去)

## Test plan
- [x] \`npm test\` 110 件 pass (新規 url_state.test.js 11 件)
- [x] \`node --check frontend/{app,url_state}.js\`
- [x] Playwright スモーク (\`./.local/url_state_smoketest.mjs\`):
  - chain 1 件 OFF → \`?chains=...(lawson 抜き)\`
  - + precision (rough OFF) + cp master OFF → \`?chains=...&precision=precise&cp=0\`
  - 全て戻す → URL の search が空に戻る
  - RWG fetch → \`?rwg=12345\`
  - right chip OFF → \`?rwg=12345&cptypes=finish,left\`
  - そのままの URL を別タブで開く → RWG input に \"12345\" 復元、right chip OFF / left chip ON が再現
  - JS / page エラー無し