### PR TITLE
fix: workers.dev + version preview URL をカスタムドメインと並存させる

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,13 @@ main = "worker.mjs"
 compatibility_date = "2026-04-01"
 compatibility_flags = ["nodejs_compat"]
 
+# Custom domain と併用しても workers.dev / version preview URL を残す。
+# false にすると `<version-id>-ride-oasis.teacatus.workers.dev` も同時に
+# 無効化され Workers Builds の per-branch preview が機能しなくなるため、
+# 意図的に true で固定する。
+workers_dev = true
+preview_urls = true
+
 # Custom domain. The DNS record + worker route are managed in the Cloudflare
 # Dashboard (Workers & Pages → ride-oasis → Settings → Domains & Routes); this
 # entry mirrors that binding so `wrangler deploy` does not warn about an


### PR DESCRIPTION
\`oasis.ochanu.co\` をカスタムドメインに追加した後、CF 側で workers.dev サブドメインが自動 off になり \`*.workers.dev\` 系の URL がすべて 404 になっていた。これだと Workers Builds の per-branch プレビュー (\`<version-id>-ride-oasis.teacatus.workers.dev\`) も死んでしまうため、\`wrangler.toml\` に明示的に有効化フラグを足して固定する。

\`\`\`toml
workers_dev = true
preview_urls = true
\`\`\`

## 確認 (\`wrangler deploy\` 適用後)
- https://oasis.ochanu.co/ → 200 (custom domain)
- https://ride-oasis.teacatus.workers.dev/ → 200 (workers.dev)
- https://aae40d3c-ride-oasis.teacatus.workers.dev/ → 200 (version preview)
- \`npx wrangler versions upload\` の出力に \`Version Preview URL: ...\` 行が復活

## 補足
カスタムドメインと workers.dev は独立した route なので、preview を社外に晒したくないケースでは将来 \`workers_dev = false\` に戻せばよい (その場合 Workers Builds のブランチプレビューは利用不可)。