### PR TITLE
feat: ルート標高チャートとマップ⇔チャート双方向ホバー

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -202,6 +202,12 @@ let hoverPointerKind = null;
 let lastChartTotalMeters = null;
 let hoverPreviewOasisKey = null;
 let oasisChartDotsCache = { route: null, filtered: null, dots: [] };
+let coursePointChartDotsCache = {
+  route: null,
+  coursePoints: null,
+  disabledTypes: null,
+  dots: []
+};
 let manualPoints = [];
 let cachedCoursePoints = [];
 let disabledCoursePointTypes = new Set();
@@ -574,6 +580,7 @@ function renderCoursePoints(points) {
   coursePointSource.clear();
   cachedCoursePoints = Array.isArray(points) ? points.slice() : [];
   disabledCoursePointTypes = new Set();
+  coursePointChartDotsCache.coursePoints = null;
   for (const cp of cachedCoursePoints) {
     if (!Number.isFinite(cp?.lat) || !Number.isFinite(cp?.lon)) continue;
     const feature = new ol.Feature({
@@ -629,6 +636,8 @@ function rebuildCoursePointTypeChips() {
       if (input.checked) disabledCoursePointTypes.delete(type);
       else disabledCoursePointTypes.add(type);
       coursePointLayer.changed();
+      coursePointChartDotsCache.coursePoints = null;
+      renderElevationChart();
       if (!input.checked && activePopupKind === 'course-point' && activeCoursePointType === type) {
         clearPopup();
       }
@@ -912,39 +921,97 @@ function getOasisChartDots() {
   return dots;
 }
 
-/** Renders the elevation profile in the bottom-of-map overlay (or hides it). */
-function renderElevationChart() {
-  const container = elements.elevationChart;
-  const canvas = elements.elevationCanvas;
-  if (!container || !canvas) return;
+/**
+ * Projects each currently visible course point (FIT/RWG ★) onto the active
+ * route so the chart can plot them alongside the Oasis dots. Cached by
+ * reference so chart redraws during hover stay cheap; the cache invalidates
+ * whenever the route or the visibility filters change.
+ */
+function getCoursePointChartDots() {
+  if (
+    coursePointChartDotsCache.route === routeCoordinates
+    && coursePointChartDotsCache.coursePoints === cachedCoursePoints
+    && coursePointChartDotsCache.disabledTypes === disabledCoursePointTypes
+    && coursePointChartDotsCache.masterVisible === (elements.showCoursePoints?.checked ?? true)
+  ) {
+    return coursePointChartDotsCache.dots;
+  }
+  const dots = [];
+  const visible = visibleCoursePoints();
+  if (
+    visible.length > 0
+    && routeCoordinates.length >= 2
+    && routeElevationSeries
+    && routeCumulativeMeters.length === routeCoordinates.length
+  ) {
+    for (const cp of visible) {
+      if (!Number.isFinite(cp?.lat) || !Number.isFinite(cp?.lon)) continue;
+      const proj = window.RouteMath.routeProjection([cp.lon, cp.lat], routeCoordinates, routeCumulativeMeters);
+      if (!proj) continue;
+      const elevation = elevationAtRouteMeters(proj.alongMeters);
+      if (!Number.isFinite(elevation)) continue;
+      dots.push({ alongMeters: proj.alongMeters, elevation, cp });
+    }
+  }
+  coursePointChartDotsCache = {
+    route: routeCoordinates,
+    coursePoints: cachedCoursePoints,
+    disabledTypes: disabledCoursePointTypes,
+    masterVisible: elements.showCoursePoints?.checked ?? true,
+    dots
+  };
+  return dots;
+}
 
-  if (routeCoordinates.length < 2 || routeElevations.length < 2) {
+/**
+ * Refreshes `routeCumulativeMeters` and `routeElevationSeries` from the
+ * current route. Call this once whenever the route is replaced — the rest of
+ * the chart code (renderElevationChart, hover handlers, projection helpers)
+ * reads the cached values so pointermove never has to redo this O(N) work.
+ *
+ * Also clears the active hover position when the route's total length changes,
+ * since stale cumulative meters from the previous route do not map to the
+ * same point on the new route.
+ */
+function rebuildRouteElevationCache() {
+  if (routeCoordinates.length < 2) {
     routeCumulativeMeters = [];
     routeElevationSeries = null;
+    lastChartTotalMeters = null;
     hoverCumulativeMeters = null;
     hoverPointerKind = null;
     hoverMarkerSource.clear();
-    container.hidden = true;
     return;
   }
   routeCumulativeMeters = window.RouteMath.cumulativeDistancesMeters(routeCoordinates);
-  routeElevationSeries = buildElevationSeries(routeElevations, routeCumulativeMeters);
+  routeElevationSeries = routeElevations.length >= 2
+    ? buildElevationSeries(routeElevations, routeCumulativeMeters)
+    : null;
   if (!routeElevationSeries) {
+    lastChartTotalMeters = null;
     hoverCumulativeMeters = null;
     hoverPointerKind = null;
     hoverMarkerSource.clear();
-    lastChartTotalMeters = null;
-    container.hidden = true;
     return;
   }
-  // Route swap detection: if total length changed, the previous hover position
-  // no longer maps to the same point. Drop it before redraw.
   if (lastChartTotalMeters !== null && lastChartTotalMeters !== routeElevationSeries.totalDistanceMeters) {
     hoverCumulativeMeters = null;
     hoverPointerKind = null;
     hoverMarkerSource.clear();
   }
   lastChartTotalMeters = routeElevationSeries.totalDistanceMeters;
+}
+
+/** Renders the elevation profile in the bottom-of-map overlay (or hides it). */
+function renderElevationChart() {
+  const container = elements.elevationChart;
+  const canvas = elements.elevationCanvas;
+  if (!container || !canvas) return;
+
+  if (!routeElevationSeries || routeCumulativeMeters.length < 2) {
+    container.hidden = true;
+    return;
+  }
   container.hidden = false;
 
   const rect = canvas.getBoundingClientRect();
@@ -1048,6 +1115,27 @@ function renderElevationChart() {
       ctx.fillStyle = isActive ? '#9e3d22' : '#12836b';
       ctx.beginPath();
       ctx.arc(x, y, isActive ? 4 : 2.6, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+    }
+  }
+
+  // Course points (FIT/RWG ★) projected onto the elevation profile. Drawn as
+  // diamond-ish red dots so they read distinctly from the round oasis dots.
+  const cpDots = getCoursePointChartDots();
+  if (cpDots.length > 0) {
+    ctx.strokeStyle = '#ffffff';
+    ctx.lineWidth = 1;
+    ctx.fillStyle = '#c62f2f';
+    for (const dot of cpDots) {
+      const x = xFromMeters(Math.max(0, Math.min(dot.alongMeters, totalMeters)));
+      const y = yFromValue(dot.elevation);
+      ctx.beginPath();
+      ctx.moveTo(x, y - 4);
+      ctx.lineTo(x + 3.5, y);
+      ctx.lineTo(x, y + 4);
+      ctx.lineTo(x - 3.5, y);
+      ctx.closePath();
       ctx.fill();
       ctx.stroke();
     }
@@ -1348,11 +1436,25 @@ function bindRouteHoverLinks() {
         return candidate;
       });
       clearHoverPreview();
-      hideLinkedTip();
       if (cpFeature) {
-        showHoverTip(buildCoursePointHoverHtml(cpFeature.get('coursePoint')), clientX, clientY);
+        const cp = cpFeature.get('coursePoint');
+        const html = buildCoursePointHoverHtml(cp);
+        showHoverTip(html, clientX, clientY);
+        // Linked tooltip near the corresponding chart course-point dot.
+        if (routeElevationSeries && cp && Number.isFinite(cp.lat) && Number.isFinite(cp.lon)) {
+          const proj = window.RouteMath.routeProjection([cp.lon, cp.lat], routeCoordinates, routeCumulativeMeters);
+          if (proj) {
+            const elevation = elevationAtRouteMeters(proj.alongMeters);
+            if (Number.isFinite(elevation)) {
+              const pos = chartDotViewportXY(proj.alongMeters, elevation);
+              if (pos) showLinkedTip(html, pos.x, pos.y);
+              else hideLinkedTip();
+            } else hideLinkedTip();
+          } else hideLinkedTip();
+        } else hideLinkedTip();
       } else {
         hideHoverTip();
+        hideLinkedTip();
       }
     }
 
@@ -1400,18 +1502,18 @@ function bindRouteHoverLinks() {
       if (!(rect.width > 0)) return;
       const x = event.clientX - rect.left;
       const y = event.clientY - rect.top;
-      // Chart x padding mirrors padLeft (32) / padRight (6) in renderElevationChart.
-      const ratio = Math.max(0, Math.min(1, (x - 32) / Math.max(rect.width - 38, 1)));
+      const plotW = Math.max(rect.width - CHART_PAD_LEFT - CHART_PAD_RIGHT, 1);
+      const ratio = Math.max(0, Math.min(1, (x - CHART_PAD_LEFT) / plotW));
       const total = routeCumulativeMeters[routeCumulativeMeters.length - 1] || 0;
       setHoverCumulativeMeters(ratio * total, 'chart');
 
-      const dot = findChartDotNear(rect, x, y);
-      if (dot && dot.id != null) {
-        const feature = findPointFeature(dot.id);
+      const hit = findChartDotNear(rect, x, y);
+      if (hit && hit.kind === 'oasis' && hit.dot.id != null) {
+        const feature = findPointFeature(hit.dot.id);
         if (feature) {
           const html = buildOasisHoverHtml(feature.get('properties'));
           showHoverTip(html, event.clientX, event.clientY);
-          setHoverPreviewOasis(dot.id);
+          setHoverPreviewOasis(hit.dot.id);
           const coord = feature.getGeometry().getCoordinates();
           const lonLat = ol.proj.toLonLat(coord);
           const pos = mapMarkerViewportXY(lonLat[0], lonLat[1]);
@@ -1419,6 +1521,15 @@ function bindRouteHoverLinks() {
           else hideLinkedTip();
           return;
         }
+      } else if (hit && hit.kind === 'course') {
+        const cp = hit.dot.cp;
+        const html = buildCoursePointHoverHtml(cp);
+        showHoverTip(html, event.clientX, event.clientY);
+        clearHoverPreview();
+        const pos = mapMarkerViewportXY(cp.lon, cp.lat);
+        if (pos) showLinkedTip(html, pos.x, pos.y);
+        else hideLinkedTip();
+        return;
       }
       clearHoverPreview();
       hideHoverTip();
@@ -1435,28 +1546,42 @@ function bindRouteHoverLinks() {
 }
 
 /**
- * Returns the chart dot closest to the cursor's X position. The cursor's Y is
- * ignored on purpose — the user only needs to sweep horizontally along the
- * route to surface any Oasis at that distance, regardless of where the dot
- * lands on the elevation curve. `rect` is the canvas bounding rect; (x, _y)
- * are cursor coords relative to that rect.
+ * Returns the chart dot closest to the cursor's X position, tagged with its
+ * kind so the caller can dispatch tooltip + linked-tooltip logic. The cursor's
+ * Y is ignored on purpose — the user only needs to sweep horizontally along
+ * the route to surface any point at that distance, regardless of where the
+ * dot lands on the elevation curve. `rect` is the canvas bounding rect;
+ * (x, _y) are cursor coords relative to that rect.
+ *
+ * Both Oasis dots and course-point dots are eligible; ties on X distance fall
+ * back to course points (they tend to be sparser and more "intentional" — a
+ * brevet PC takes priority over a random convenience store next to it).
  */
 function findChartDotNear(rect, x, _y) {
-  const dots = getOasisChartDots();
-  if (!dots.length || !routeElevationSeries) return null;
-  const padLeft = CHART_PAD_LEFT;
-  const padRight = CHART_PAD_RIGHT;
-  const plotW = Math.max(rect.width - padLeft - padRight, 1);
+  if (!routeElevationSeries) return null;
+  const plotW = Math.max(rect.width - CHART_PAD_LEFT - CHART_PAD_RIGHT, 1);
   const totalMeters = routeElevationSeries.totalDistanceMeters || 1;
-  const toX = (m) => padLeft + (Math.max(0, Math.min(m, totalMeters)) / totalMeters) * plotW;
+  const toX = (m) => CHART_PAD_LEFT + (Math.max(0, Math.min(m, totalMeters)) / totalMeters) * plotW;
 
   const xTolerance = 6;
+  // Course points first — they're sparser and more "intentional" (turn /
+  // PC / finish markers), so if one is within tolerance prefer it even if an
+  // adjacent Oasis is a pixel closer. Only fall back to Oasis when no course
+  // point is in range.
   let best = null;
   let bestDx = Infinity;
-  for (const dot of dots) {
+  for (const dot of getCoursePointChartDots()) {
     const dx = Math.abs(toX(dot.alongMeters) - x);
     if (dx <= xTolerance && dx < bestDx) {
-      best = dot;
+      best = { kind: 'course', dot };
+      bestDx = dx;
+    }
+  }
+  if (best) return best;
+  for (const dot of getOasisChartDots()) {
+    const dx = Math.abs(toX(dot.alongMeters) - x);
+    if (dx <= xTolerance && dx < bestDx) {
+      best = { kind: 'oasis', dot };
       bestDx = dx;
     }
   }
@@ -1663,6 +1788,7 @@ async function handleRouteFile(event) {
     routeFeature = parsedRoute.feature;
     routeCoordinates = parsedRoute.coordinates;
     routeElevations = parsedRoute.elevations || [];
+    rebuildRouteElevationCache();
     manualPoints = [];
     currentRwgId = null;
     elements.gpxFileName.textContent = file.name;
@@ -1715,6 +1841,7 @@ async function handleRwgFetch(event) {
     routeFeature = parsedRoute.feature;
     routeCoordinates = parsedRoute.coordinates;
     routeElevations = parsedRoute.elevations || [];
+    rebuildRouteElevationCache();
     manualPoints = [];
     const displayName = rwg.name || `RWG #${id}`;
     elements.gpxFileName.textContent = displayName;
@@ -1754,6 +1881,7 @@ async function handleManualMapClick(mapCoord) {
     routeFeature = null;
     routeCoordinates = [];
     routeElevations = [];
+    rebuildRouteElevationCache();
     resetResults();
     updateRoutePointCount();
     renderElevationChart();
@@ -1764,6 +1892,7 @@ async function handleManualMapClick(mapCoord) {
   routeFeature = routeSource.getFeatures()[0] || null;
   routeCoordinates = manualPoints.map((coord) => [coord[0], coord[1]]);
   routeElevations = [];
+  rebuildRouteElevationCache();
   resetResults();
   updateRoutePointCount();
   fitToVisibleData();
@@ -1780,6 +1909,7 @@ function resetManualState() {
   routeFeature = null;
   routeCoordinates = [];
   routeElevations = [];
+  rebuildRouteElevationCache();
   ++latestRouteLoadToken;
   cancelPendingRefreshes();
   clearRouteVisualSources();
@@ -1814,6 +1944,7 @@ async function handleCurrentLocation() {
     routeFeature = null;
     routeCoordinates = [coord];
     routeElevations = [];
+    rebuildRouteElevationCache();
     manualPoints = [];
     renderCurrentLocation(coord);
     resetResults();
@@ -1882,6 +2013,7 @@ async function handleFollowPositionAsync(position) {
   routeFeature = null;
   routeCoordinates = [coord];
   routeElevations = [];
+  rebuildRouteElevationCache();
   renderCurrentLocation(coord);
   updateRoutePointCount();
 
@@ -2073,6 +2205,7 @@ async function searchAtPlace(item) {
   routeFeature = null;
   routeCoordinates = [coord];
   routeElevations = [];
+  rebuildRouteElevationCache();
   renderCurrentLocation(coord);
   resetResults();
   updateRoutePointCount();
@@ -2290,6 +2423,8 @@ function bindEvents() {
   if (elements.showCoursePoints) {
     elements.showCoursePoints.addEventListener('change', () => {
       coursePointLayer.setVisible(elements.showCoursePoints.checked);
+      coursePointChartDotsCache.coursePoints = null;
+      renderElevationChart();
       if (!elements.showCoursePoints.checked && activePopupKind === 'course-point') {
         clearPopup();
       }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -47,8 +47,20 @@ const elements = {
   coursePointTypes: document.getElementById('course-point-types'),
   rwgForm: document.getElementById('rwg-form'),
   rwgUrl: document.getElementById('rwg-url'),
-  rwgFetch: document.getElementById('rwg-fetch')
+  rwgFetch: document.getElementById('rwg-fetch'),
+  elevationChart: document.getElementById('elevation-chart'),
+  elevationCanvas: document.getElementById('elevation-canvas'),
+  elevationMeta: document.getElementById('elevation-meta'),
+  hoverTip: document.getElementById('hover-tip'),
+  hoverTipLinked: document.getElementById('hover-tip-linked')
 };
+
+// Padding constants shared between chart drawing and chart hit-testing so the
+// hover dots line up exactly with what's painted on the canvas.
+const CHART_PAD_LEFT = 32;
+const CHART_PAD_RIGHT = 6;
+const CHART_PAD_TOP = 4;
+const CHART_PAD_BOTTOM = 4;
 
 const CUE_SHEET_STORAGE_KEY = 'rideoasis-cue-sheet';
 
@@ -143,6 +155,18 @@ const coursePointLayer = new ol.layer.Vector({
   }
 });
 
+const hoverMarkerSource = new ol.source.Vector();
+const hoverMarkerLayer = new ol.layer.Vector({
+  source: hoverMarkerSource,
+  style: new ol.style.Style({
+    image: new ol.style.Circle({
+      radius: 6,
+      fill: new ol.style.Fill({ color: '#225ea8' }),
+      stroke: new ol.style.Stroke({ color: '#ffffff', width: 2 })
+    })
+  })
+});
+
 const map = new ol.Map({
   target: 'map',
   layers: [
@@ -151,7 +175,8 @@ const map = new ol.Map({
     pointLayer,
     endpointLayer,
     currentLocationLayer,
-    coursePointLayer
+    coursePointLayer,
+    hoverMarkerLayer
   ],
   view: new ol.View({
     center: ol.proj.fromLonLat([139.767, 35.681]),
@@ -169,6 +194,14 @@ map.addOverlay(popupOverlay);
 
 let routeFeature = null;
 let routeCoordinates = [];
+let routeElevations = [];
+let routeCumulativeMeters = [];
+let routeElevationSeries = null;
+let hoverCumulativeMeters = null;
+let hoverPointerKind = null;
+let lastChartTotalMeters = null;
+let hoverPreviewOasisKey = null;
+let oasisChartDotsCache = { route: null, filtered: null, dots: [] };
 let manualPoints = [];
 let cachedCoursePoints = [];
 let disabledCoursePointTypes = new Set();
@@ -354,6 +387,7 @@ function syncPointHighlight() {
   for (const feature of pointSource.getFeatures()) {
     feature.set('active', supplyPointKey(feature.get('properties').supply_point_id) === supplyPointKey(highlightedId));
   }
+  renderElevationChart();
 }
 
 /** Updates active styling in the side list without rebuilding focused elements. */
@@ -700,17 +734,757 @@ function fitToVisibleData() {
   }
 }
 
+/**
+ * Builds a chart-ready elevation series by linearly interpolating across `null`
+ * gaps in `elevations`. Returns null when there is no usable data so callers can
+ * hide the chart. Leading/trailing nulls are extended with the nearest known
+ * value rather than skipped, so the polyline does not start/end mid-air.
+ */
+function buildElevationSeries(elevations, cumulativeMeters) {
+  if (!Array.isArray(elevations) || !Array.isArray(cumulativeMeters)) return null;
+  const n = Math.min(elevations.length, cumulativeMeters.length);
+  if (n < 2) return null;
+
+  const knownIndexes = [];
+  for (let i = 0; i < n; i += 1) {
+    if (Number.isFinite(elevations[i])) knownIndexes.push(i);
+  }
+  if (knownIndexes.length < 2) return null;
+
+  const filled = new Array(n);
+  for (let i = 0; i < n; i += 1) {
+    if (Number.isFinite(elevations[i])) {
+      filled[i] = elevations[i];
+      continue;
+    }
+    let prev = null;
+    let next = null;
+    for (let k = 0; k < knownIndexes.length; k += 1) {
+      const idx = knownIndexes[k];
+      if (idx < i) prev = idx;
+      else if (idx > i) { next = idx; break; }
+    }
+    if (prev !== null && next !== null) {
+      const dx = cumulativeMeters[next] - cumulativeMeters[prev];
+      const t = dx > 0 ? (cumulativeMeters[i] - cumulativeMeters[prev]) / dx : 0;
+      filled[i] = elevations[prev] + (elevations[next] - elevations[prev]) * t;
+    } else if (prev !== null) {
+      filled[i] = elevations[prev];
+    } else if (next !== null) {
+      filled[i] = elevations[next];
+    } else {
+      return null;
+    }
+  }
+
+  let min = Infinity;
+  let max = -Infinity;
+  let gain = 0;
+  let loss = 0;
+  for (let i = 0; i < n; i += 1) {
+    const v = filled[i];
+    if (v < min) min = v;
+    if (v > max) max = v;
+    if (i > 0) {
+      const diff = filled[i] - filled[i - 1];
+      if (diff > 0) gain += diff;
+      else loss += -diff;
+    }
+  }
+  return { values: filled, min, max, gain, loss, totalDistanceMeters: cumulativeMeters[n - 1] };
+}
+
+/** Returns the lon/lat interpolated along the route at `meters` cumulative distance. */
+function lonLatAtRouteMeters(meters) {
+  if (routeCoordinates.length < 2 || routeCumulativeMeters.length !== routeCoordinates.length) {
+    return null;
+  }
+  const total = routeCumulativeMeters[routeCumulativeMeters.length - 1];
+  if (!(total > 0)) return null;
+  const m = Math.max(0, Math.min(meters, total));
+  let lo = 0;
+  let hi = routeCumulativeMeters.length - 1;
+  while (lo + 1 < hi) {
+    const mid = (lo + hi) >> 1;
+    if (routeCumulativeMeters[mid] <= m) lo = mid;
+    else hi = mid;
+  }
+  const segLen = routeCumulativeMeters[lo + 1] - routeCumulativeMeters[lo];
+  const t = segLen > 0 ? (m - routeCumulativeMeters[lo]) / segLen : 0;
+  const a = routeCoordinates[lo];
+  const b = routeCoordinates[lo + 1];
+  return [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t];
+}
+
+/**
+ * Returns the route gradient (rise/run as a ratio, e.g. 0.05 = 5%) averaged
+ * over a ±100 m window around the given cumulative meters. Used to label the
+ * hover crosshair with an instantaneous-ish gradient figure.
+ */
+function gradientAtRouteMeters(meters) {
+  if (!routeElevationSeries || routeCumulativeMeters.length < 2) return null;
+  const total = routeCumulativeMeters[routeCumulativeMeters.length - 1];
+  if (!(total > 0)) return null;
+  const window = 100;
+  const lo = Math.max(0, meters - window);
+  const hi = Math.min(total, meters + window);
+  const dx = hi - lo;
+  if (dx <= 0) return null;
+  const eLo = elevationAtRouteMeters(lo);
+  const eHi = elevationAtRouteMeters(hi);
+  if (!Number.isFinite(eLo) || !Number.isFinite(eHi)) return null;
+  return (eHi - eLo) / dx;
+}
+
+/** Interpolates the (filled) elevation series value at the given cumulative meters. */
+function elevationAtRouteMeters(meters) {
+  if (!routeElevationSeries || routeCumulativeMeters.length < 2) return null;
+  const total = routeCumulativeMeters[routeCumulativeMeters.length - 1];
+  if (!(total > 0)) return null;
+  const m = Math.max(0, Math.min(meters, total));
+  let lo = 0;
+  let hi = routeCumulativeMeters.length - 1;
+  while (lo + 1 < hi) {
+    const mid = (lo + hi) >> 1;
+    if (routeCumulativeMeters[mid] <= m) lo = mid;
+    else hi = mid;
+  }
+  const segLen = routeCumulativeMeters[lo + 1] - routeCumulativeMeters[lo];
+  const t = segLen > 0 ? (m - routeCumulativeMeters[lo]) / segLen : 0;
+  const va = routeElevationSeries.values[lo];
+  const vb = routeElevationSeries.values[lo + 1];
+  return va + (vb - va) * t;
+}
+
+/** Picks a round elevation step (m) that yields roughly 3-5 grid lines for the given range. */
+function pickElevationStep(rangeMeters) {
+  const steps = [10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000];
+  for (const s of steps) {
+    if (rangeMeters / s <= 5) return s;
+  }
+  return 5000;
+}
+
+/** Picks a round distance step (m) for the X axis based on total route length. */
+function pickDistanceStep(totalMeters) {
+  const steps = [500, 1000, 2000, 5000, 10000, 20000, 50000, 100000];
+  for (const s of steps) {
+    if (totalMeters / s <= 6) return s;
+  }
+  return 200000;
+}
+
+/**
+ * Projects each currently filtered oasis point onto the active route so the
+ * chart can plot them on the cumulative-meters axis. Cache by reference so
+ * hover redraws are free; both `routeCoordinates` and `filteredPoints` get
+ * reassigned with fresh arrays on each route/filter change.
+ */
+function getOasisChartDots() {
+  if (
+    oasisChartDotsCache.route === routeCoordinates
+    && oasisChartDotsCache.filtered === filteredPoints
+  ) {
+    return oasisChartDotsCache.dots;
+  }
+  const dots = [];
+  if (
+    routeCoordinates.length >= 2
+    && filteredPoints.length > 0
+    && routeElevationSeries
+    && routeCumulativeMeters.length === routeCoordinates.length
+  ) {
+    for (const feature of filteredPoints) {
+      const coord = feature?.geometry?.coordinates;
+      if (!Array.isArray(coord) || coord.length < 2) continue;
+      const proj = window.RouteMath.routeProjection(coord, routeCoordinates, routeCumulativeMeters);
+      if (!proj) continue;
+      const elevation = elevationAtRouteMeters(proj.alongMeters);
+      if (!Number.isFinite(elevation)) continue;
+      dots.push({
+        alongMeters: proj.alongMeters,
+        elevation,
+        id: feature?.properties?.supply_point_id ?? null
+      });
+    }
+  }
+  oasisChartDotsCache = { route: routeCoordinates, filtered: filteredPoints, dots };
+  return dots;
+}
+
+/** Renders the elevation profile in the bottom-of-map overlay (or hides it). */
+function renderElevationChart() {
+  const container = elements.elevationChart;
+  const canvas = elements.elevationCanvas;
+  if (!container || !canvas) return;
+
+  if (routeCoordinates.length < 2 || routeElevations.length < 2) {
+    routeCumulativeMeters = [];
+    routeElevationSeries = null;
+    hoverCumulativeMeters = null;
+    hoverPointerKind = null;
+    hoverMarkerSource.clear();
+    container.hidden = true;
+    return;
+  }
+  routeCumulativeMeters = window.RouteMath.cumulativeDistancesMeters(routeCoordinates);
+  routeElevationSeries = buildElevationSeries(routeElevations, routeCumulativeMeters);
+  if (!routeElevationSeries) {
+    hoverCumulativeMeters = null;
+    hoverPointerKind = null;
+    hoverMarkerSource.clear();
+    lastChartTotalMeters = null;
+    container.hidden = true;
+    return;
+  }
+  // Route swap detection: if total length changed, the previous hover position
+  // no longer maps to the same point. Drop it before redraw.
+  if (lastChartTotalMeters !== null && lastChartTotalMeters !== routeElevationSeries.totalDistanceMeters) {
+    hoverCumulativeMeters = null;
+    hoverPointerKind = null;
+    hoverMarkerSource.clear();
+  }
+  lastChartTotalMeters = routeElevationSeries.totalDistanceMeters;
+  container.hidden = false;
+
+  const rect = canvas.getBoundingClientRect();
+  const cssWidth = Math.max(rect.width, 1);
+  const cssHeight = Math.max(rect.height, 1);
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = Math.round(cssWidth * dpr);
+  canvas.height = Math.round(cssHeight * dpr);
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, cssWidth, cssHeight);
+
+  const padLeft = CHART_PAD_LEFT;
+  const padRight = CHART_PAD_RIGHT;
+  const padTop = CHART_PAD_TOP;
+  const padBottom = CHART_PAD_BOTTOM;
+  const plotW = cssWidth - padLeft - padRight;
+  const plotH = cssHeight - padTop - padBottom;
+  const series = routeElevationSeries;
+  const totalMeters = series.totalDistanceMeters || 1;
+  // Pad the y range to the nearest grid step so the axis aligns with labels.
+  const rawRange = Math.max(series.max - series.min, 1);
+  const eleStep = pickElevationStep(rawRange);
+  const yMin = Math.floor(series.min / eleStep) * eleStep;
+  const yMax = Math.ceil(series.max / eleStep) * eleStep;
+  const rangeMeters = Math.max(yMax - yMin, 1);
+
+  const xFromMeters = (m) => padLeft + (m / totalMeters) * plotW;
+  const yFromValue = (v) => padTop + (1 - (v - yMin) / rangeMeters) * plotH;
+
+  // Grid lines: horizontal elevation guides + faint vertical distance guides.
+  ctx.lineWidth = 1;
+  ctx.strokeStyle = 'rgba(15, 23, 42, 0.08)';
+  ctx.fillStyle = 'rgba(15, 23, 42, 0.5)';
+  ctx.font = '10px system-ui, sans-serif';
+  ctx.textBaseline = 'middle';
+  ctx.textAlign = 'right';
+  for (let v = yMin; v <= yMax + 1e-6; v += eleStep) {
+    const y = yFromValue(v);
+    ctx.beginPath();
+    ctx.moveTo(padLeft, y);
+    ctx.lineTo(cssWidth - padRight, y);
+    ctx.stroke();
+    ctx.fillText(`${Math.round(v)}m`, padLeft - 4, y);
+  }
+
+  const distStep = pickDistanceStep(totalMeters);
+  ctx.save();
+  ctx.strokeStyle = 'rgba(15, 23, 42, 0.22)';
+  ctx.fillStyle = 'rgba(15, 23, 42, 0.6)';
+  ctx.setLineDash([3, 3]);
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'bottom';
+  for (let d = distStep; d < totalMeters; d += distStep) {
+    const x = xFromMeters(d);
+    ctx.beginPath();
+    ctx.moveTo(x, padTop);
+    ctx.lineTo(x, padTop + plotH);
+    ctx.stroke();
+    const label = distStep >= 1000 ? `${Math.round(d / 1000)}km` : `${d}m`;
+    ctx.fillText(label, x, padTop + plotH - 1);
+  }
+  ctx.restore();
+
+  const accent = '#225ea8';
+  ctx.lineWidth = 1.5;
+  ctx.strokeStyle = accent;
+  ctx.fillStyle = 'rgba(34, 94, 168, 0.18)';
+  ctx.beginPath();
+  for (let i = 0; i < series.values.length; i += 1) {
+    const x = xFromMeters(routeCumulativeMeters[i]);
+    const y = yFromValue(series.values[i]);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.lineTo(xFromMeters(routeCumulativeMeters[series.values.length - 1]), padTop + plotH);
+  ctx.lineTo(xFromMeters(routeCumulativeMeters[0]), padTop + plotH);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.beginPath();
+  for (let i = 0; i < series.values.length; i += 1) {
+    const x = xFromMeters(routeCumulativeMeters[i]);
+    const y = yFromValue(series.values[i]);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+
+  // Oasis points projected onto the elevation profile.
+  const dots = getOasisChartDots();
+  if (dots.length > 0) {
+    ctx.strokeStyle = '#ffffff';
+    ctx.lineWidth = 1;
+    for (const dot of dots) {
+      const isActive = dot.id != null && supplyPointKey(dot.id) === highlightedSupplyPointId();
+      const x = xFromMeters(Math.max(0, Math.min(dot.alongMeters, totalMeters)));
+      const y = yFromValue(dot.elevation);
+      ctx.fillStyle = isActive ? '#9e3d22' : '#12836b';
+      ctx.beginPath();
+      ctx.arc(x, y, isActive ? 4 : 2.6, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+    }
+  }
+
+  // Hover guide: full-height vertical line + horizontal line at the elevation
+  // value, plus boxed distance / elevation labels at the axes (Google-Maps
+  // style crosshair).
+  if (Number.isFinite(hoverCumulativeMeters)) {
+    const clampedMeters = Math.max(0, Math.min(hoverCumulativeMeters, totalMeters));
+    const hx = xFromMeters(clampedMeters);
+    const hv = elevationAtRouteMeters(hoverCumulativeMeters);
+    ctx.save();
+    ctx.strokeStyle = 'rgba(60, 70, 90, 0.85)';
+    ctx.lineWidth = 1;
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    ctx.moveTo(hx, padTop);
+    ctx.lineTo(hx, padTop + plotH);
+    ctx.stroke();
+
+    if (Number.isFinite(hv)) {
+      const hy = yFromValue(hv);
+      ctx.beginPath();
+      ctx.moveTo(padLeft, hy);
+      ctx.lineTo(cssWidth - padRight, hy);
+      ctx.stroke();
+      ctx.fillStyle = '#c62f2f';
+      ctx.beginPath();
+      ctx.arc(hx, hy, 3.5, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    // Boxed distance label at the bottom axis, centered on hx.
+    const kmText = (clampedMeters / 1000).toFixed(2);
+    ctx.font = '11px system-ui, sans-serif';
+    ctx.textBaseline = 'middle';
+    ctx.textAlign = 'left';
+    const distPad = 6;
+    const distW = ctx.measureText(kmText).width + distPad * 2;
+    const distH = 16;
+    const distX = Math.max(padLeft, Math.min(hx - distW / 2, cssWidth - padRight - distW));
+    const distY = padTop + plotH - distH;
+    ctx.fillStyle = 'rgba(255, 248, 220, 0.96)';
+    ctx.strokeStyle = 'rgba(120, 30, 30, 0.7)';
+    ctx.lineWidth = 1;
+    ctx.fillRect(distX, distY, distW, distH);
+    ctx.strokeRect(distX + 0.5, distY + 0.5, distW - 1, distH - 1);
+    ctx.fillStyle = '#3a2a16';
+    ctx.fillText(kmText, distX + distPad, distY + distH / 2);
+
+    // Boxed elevation / gradient label near the horizontal line, offset from hx.
+    if (Number.isFinite(hv)) {
+      const hy = yFromValue(hv);
+      const gradient = gradientAtRouteMeters(clampedMeters);
+      const gradientText = Number.isFinite(gradient)
+        ? ` (${gradient >= 0 ? '+' : ''}${(gradient * 100).toFixed(1)}%)`
+        : '';
+      const eleText = `${Math.round(hv)} m${gradientText}`;
+      const elePad = 6;
+      const eleW = ctx.measureText(eleText).width + elePad * 2;
+      const eleH = 16;
+      // Position the label opposite the cursor side so it doesn't overlap the marker.
+      const placeRight = hx < cssWidth / 2;
+      let eleX = placeRight ? hx + 10 : hx - eleW - 10;
+      eleX = Math.max(padLeft + 2, Math.min(eleX, cssWidth - padRight - eleW - 2));
+      let eleY = hy - eleH - 4;
+      if (eleY < padTop) eleY = hy + 4;
+      ctx.fillStyle = 'rgba(255, 248, 220, 0.96)';
+      ctx.strokeStyle = 'rgba(120, 30, 30, 0.7)';
+      ctx.fillRect(eleX, eleY, eleW, eleH);
+      ctx.strokeRect(eleX + 0.5, eleY + 0.5, eleW - 1, eleH - 1);
+      ctx.fillStyle = '#3a2a16';
+      ctx.fillText(eleText, eleX + elePad, eleY + eleH / 2);
+    }
+    ctx.restore();
+  }
+
+  if (elements.elevationMeta) {
+    const km = (totalMeters / 1000).toFixed(totalMeters >= 10000 ? 0 : 1);
+    if (Number.isFinite(hoverCumulativeMeters)) {
+      const hv = elevationAtRouteMeters(hoverCumulativeMeters);
+      const hovKm = (hoverCumulativeMeters / 1000).toFixed(hoverCumulativeMeters >= 10000 ? 0 : 1);
+      elements.elevationMeta.innerHTML = `
+        <span>${hovKm} km / 全 ${km} km</span>
+        <span>標高 ${Number.isFinite(hv) ? Math.round(hv) : '-'} m</span>
+        <span>↑ ${Math.round(series.gain)} m / ↓ ${Math.round(series.loss)} m</span>
+      `;
+    } else {
+      elements.elevationMeta.innerHTML = `
+        <span>距離 ${km} km</span>
+        <span>標高 ${Math.round(series.min)}–${Math.round(series.max)} m</span>
+        <span>↑ ${Math.round(series.gain)} m / ↓ ${Math.round(series.loss)} m</span>
+      `;
+    }
+  }
+}
+
+/** Updates the shared hover state (cumulative meters along the route). */
+function setHoverCumulativeMeters(meters, sourceKind) {
+  if (meters === hoverCumulativeMeters && sourceKind === hoverPointerKind) return;
+  hoverCumulativeMeters = Number.isFinite(meters) ? meters : null;
+  hoverPointerKind = hoverCumulativeMeters === null ? null : sourceKind;
+  syncHoverMarker();
+  renderElevationChart();
+}
+
+/** Builds the hover tooltip HTML for a supply point GeoJSON feature. */
+function buildOasisHoverHtml(props) {
+  if (!props) return '';
+  const distance = Number.isFinite(props.route_distance_m)
+    ? `<div class="hover-tip-meta">${Math.round(props.route_distance_m)}m ・ ${escapeHtml(precisionLabel(props.geocode_point_level))}</div>`
+    : '';
+  return [
+    `<div class="hover-tip-chain">${escapeHtml(props.chain || '')}</div>`,
+    `<div class="hover-tip-title">${escapeHtml(props.name || '')}</div>`,
+    distance
+  ].filter(Boolean).join('');
+}
+
+/** Builds the hover tooltip HTML for a FIT/RWG course point object. */
+function buildCoursePointHoverHtml(cp) {
+  if (!cp) return '';
+  let meta = '';
+  if (routeCoordinates.length >= 2) {
+    const proj = window.RouteMath.routeProjection([cp.lon, cp.lat], routeCoordinates, routeCumulativeMeters);
+    if (proj) {
+      const cumKm = (proj.alongMeters / 1000).toFixed(1);
+      const sideLabel = proj.side === 'L' ? '左' : proj.side === 'R' ? '右' : '・';
+      meta = `<div class="hover-tip-meta">累計 ${cumKm} km / ${sideLabel}側</div>`;
+    }
+  }
+  return [
+    `<div class="hover-tip-chain">${escapeHtml(cp.type || 'course point')}</div>`,
+    `<div class="hover-tip-title">${escapeHtml(cp.name || '(無名)')}</div>`,
+    meta
+  ].filter(Boolean).join('');
+}
+
+/** Positions the fixed tooltip near the cursor, clamped to the viewport. */
+function showHoverTip(html, clientX, clientY) {
+  const tip = elements.hoverTip;
+  if (!tip || !html) return;
+  tip.innerHTML = html;
+  tip.hidden = false;
+  const padding = 12;
+  const rect = tip.getBoundingClientRect();
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  let left = clientX + padding;
+  let top = clientY + padding;
+  if (left + rect.width > vw - 4) left = clientX - padding - rect.width;
+  if (top + rect.height > vh - 4) top = clientY - padding - rect.height;
+  tip.style.left = `${Math.max(4, left)}px`;
+  tip.style.top = `${Math.max(4, top)}px`;
+}
+
+/** Hides the floating tooltip. */
+function hideHoverTip() {
+  const tip = elements.hoverTip;
+  if (tip && !tip.hidden) tip.hidden = true;
+}
+
+/** Returns viewport pixel coords for an oasis dot on the elevation chart, or null. */
+function chartDotViewportXY(alongMeters, elevation) {
+  if (!routeElevationSeries) return null;
+  const canvas = elements.elevationCanvas;
+  if (!canvas) return null;
+  const rect = canvas.getBoundingClientRect();
+  if (!(rect.width > 0)) return null;
+  const plotW = Math.max(rect.width - CHART_PAD_LEFT - CHART_PAD_RIGHT, 1);
+  const plotH = Math.max(rect.height - CHART_PAD_TOP - CHART_PAD_BOTTOM, 1);
+  const series = routeElevationSeries;
+  const totalMeters = series.totalDistanceMeters || 1;
+  const eleStep = pickElevationStep(Math.max(series.max - series.min, 1));
+  const yMin = Math.floor(series.min / eleStep) * eleStep;
+  const yMax = Math.ceil(series.max / eleStep) * eleStep;
+  const rangeMeters = Math.max(yMax - yMin, 1);
+  const canvasX = CHART_PAD_LEFT + (Math.max(0, Math.min(alongMeters, totalMeters)) / totalMeters) * plotW;
+  const canvasY = CHART_PAD_TOP + (1 - (elevation - yMin) / rangeMeters) * plotH;
+  return { x: rect.left + canvasX, y: rect.top + canvasY };
+}
+
+/** Returns viewport pixel coords for a lon/lat on the map, or null when off-screen. */
+function mapMarkerViewportXY(lon, lat) {
+  if (!Number.isFinite(lon) || !Number.isFinite(lat)) return null;
+  const coord = ol.proj.fromLonLat([lon, lat]);
+  const pixel = map.getPixelFromCoordinate(coord);
+  if (!pixel) return null;
+  const rect = map.getViewport().getBoundingClientRect();
+  return { x: rect.left + pixel[0], y: rect.top + pixel[1] };
+}
+
+/** Shows the secondary (linked-surface) tooltip near the given viewport coords. */
+function showLinkedTip(html, viewportX, viewportY) {
+  const tip = elements.hoverTipLinked;
+  if (!tip || !html) return;
+  tip.innerHTML = html;
+  tip.hidden = false;
+  const padding = 10;
+  const rect = tip.getBoundingClientRect();
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  let left = viewportX + padding;
+  let top = viewportY - rect.height - padding;
+  if (left + rect.width > vw - 4) left = viewportX - padding - rect.width;
+  if (top < 4) top = viewportY + padding;
+  tip.style.left = `${Math.max(4, left)}px`;
+  tip.style.top = `${Math.max(4, Math.min(top, vh - rect.height - 4))}px`;
+}
+
+/** Hides the secondary tooltip. */
+function hideLinkedTip() {
+  const tip = elements.hoverTipLinked;
+  if (tip && !tip.hidden) tip.hidden = true;
+}
+
+/**
+ * Marks the given supply point as the hover preview so the chart dot and the
+ * map marker both render in the active color. Intentionally does NOT open the
+ * click-popup — `previewPoint` (used by the side list) does that, but here we
+ * only want the small floating tooltip plus the highlight.
+ */
+function setHoverPreviewOasis(supplyPointId) {
+  const key = supplyPointKey(supplyPointId);
+  if (!key || key === hoverPreviewOasisKey) return;
+  hoverPreviewOasisKey = key;
+  if (key === supplyPointKey(activeSupplyPointId)) {
+    syncPointHighlight();
+    return;
+  }
+  previewSupplyPointId = key;
+  syncPointHighlight();
+}
+
+/** Clears any hover-driven Oasis preview from both the map and the chart. */
+function clearHoverPreview() {
+  if (!hoverPreviewOasisKey) return;
+  const key = hoverPreviewOasisKey;
+  hoverPreviewOasisKey = null;
+  if (previewSupplyPointId === key) {
+    previewSupplyPointId = null;
+    syncPointHighlight();
+  }
+}
+
+/**
+ * Wires bidirectional hover linking between the map route and the elevation
+ * chart. Pointer events on either surface project the cursor onto the route's
+ * cumulative-meter axis and call `setHoverCumulativeMeters`, which redraws the
+ * chart guide and updates the on-map marker in one place.
+ *
+ * Map hover uses `routeProjection`; we bail when the perpendicular distance to
+ * the route exceeds a screen-resolution-scaled tolerance so wildly off-route
+ * cursors don't drag the marker to the route end.
+ */
+function bindRouteHoverLinks() {
+  // Map → chart + tooltip: project the cursor onto the active route and show a
+  // tooltip when the cursor is over an Oasis / course-point marker. Hovering an
+  // Oasis also previews it on the map and chart (highlighted dot) without
+  // toggling its active selection state.
+  map.on('pointermove', (event) => {
+    if (event.dragging) {
+      hideHoverTip();
+      clearHoverPreview();
+      return;
+    }
+    const oeEvent = event.originalEvent;
+    const clientX = oeEvent ? oeEvent.clientX : 0;
+    const clientY = oeEvent ? oeEvent.clientY : 0;
+
+    const supplyFeature = map.forEachFeatureAtPixel(event.pixel, (candidate) => {
+      const props = candidate && candidate.get('properties');
+      return props && props.supply_point_id != null ? candidate : undefined;
+    });
+    if (supplyFeature) {
+      const props = supplyFeature.get('properties');
+      const html = buildOasisHoverHtml(props);
+      showHoverTip(html, clientX, clientY);
+      setHoverPreviewOasis(props.supply_point_id);
+      // Also surface the same info next to the corresponding chart dot.
+      const coord = supplyFeature.getGeometry().getCoordinates();
+      const lonLat = ol.proj.toLonLat(coord);
+      const proj = window.RouteMath.routeProjection(lonLat, routeCoordinates, routeCumulativeMeters);
+      if (proj && routeElevationSeries) {
+        const elevation = elevationAtRouteMeters(proj.alongMeters);
+        if (Number.isFinite(elevation)) {
+          const pos = chartDotViewportXY(proj.alongMeters, elevation);
+          if (pos) showLinkedTip(html, pos.x, pos.y);
+          else hideLinkedTip();
+        } else hideLinkedTip();
+      } else hideLinkedTip();
+    } else {
+      const cpFeature = map.forEachFeatureAtPixel(event.pixel, (candidate) => {
+        const cp = candidate && candidate.get('coursePoint');
+        if (!cp) return undefined;
+        if (disabledCoursePointTypes.has(cp.type)) return undefined;
+        return candidate;
+      });
+      clearHoverPreview();
+      hideLinkedTip();
+      if (cpFeature) {
+        showHoverTip(buildCoursePointHoverHtml(cpFeature.get('coursePoint')), clientX, clientY);
+      } else {
+        hideHoverTip();
+      }
+    }
+
+    if (routeCoordinates.length < 2 || routeCumulativeMeters.length !== routeCoordinates.length) {
+      if (hoverPointerKind === 'map') setHoverCumulativeMeters(null, null);
+      return;
+    }
+    const lonLat = ol.proj.toLonLat(event.coordinate);
+    const proj = window.RouteMath.routeProjection(lonLat, routeCoordinates, routeCumulativeMeters);
+    if (!proj) {
+      if (hoverPointerKind === 'map') setHoverCumulativeMeters(null, null);
+      return;
+    }
+    // Tolerance: 12 px in current view, but at least 50 m so very-zoomed-in
+    // views still allow a hover band wider than a hair.
+    const view = map.getView();
+    const resolution = view ? view.getResolution() || 1 : 1;
+    const tolerance = Math.max(resolution * 12, 50);
+    if (proj.perpMeters > tolerance) {
+      if (hoverPointerKind === 'map') setHoverCumulativeMeters(null, null);
+      return;
+    }
+    setHoverCumulativeMeters(proj.alongMeters, 'map');
+  });
+
+  const mapViewport = map.getViewport();
+  if (mapViewport) {
+    mapViewport.addEventListener('mouseleave', () => {
+      if (hoverPointerKind === 'map') setHoverCumulativeMeters(null, null);
+      hideHoverTip();
+      hideLinkedTip();
+      clearHoverPreview();
+    });
+  }
+
+  // Chart → map: convert the cursor's X offset into cumulative meters along
+  // the route, then let `setHoverCumulativeMeters` place the marker. The same
+  // handler also checks whether the cursor is on an oasis dot — when it is, we
+  // show the same tooltip used on the map and preview the point.
+  const canvas = elements.elevationCanvas;
+  if (canvas) {
+    const handleChartMove = (event) => {
+      if (!routeElevationSeries || routeCoordinates.length < 2) return;
+      const rect = canvas.getBoundingClientRect();
+      if (!(rect.width > 0)) return;
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+      // Chart x padding mirrors padLeft (32) / padRight (6) in renderElevationChart.
+      const ratio = Math.max(0, Math.min(1, (x - 32) / Math.max(rect.width - 38, 1)));
+      const total = routeCumulativeMeters[routeCumulativeMeters.length - 1] || 0;
+      setHoverCumulativeMeters(ratio * total, 'chart');
+
+      const dot = findChartDotNear(rect, x, y);
+      if (dot && dot.id != null) {
+        const feature = findPointFeature(dot.id);
+        if (feature) {
+          const html = buildOasisHoverHtml(feature.get('properties'));
+          showHoverTip(html, event.clientX, event.clientY);
+          setHoverPreviewOasis(dot.id);
+          const coord = feature.getGeometry().getCoordinates();
+          const lonLat = ol.proj.toLonLat(coord);
+          const pos = mapMarkerViewportXY(lonLat[0], lonLat[1]);
+          if (pos) showLinkedTip(html, pos.x, pos.y);
+          else hideLinkedTip();
+          return;
+        }
+      }
+      clearHoverPreview();
+      hideHoverTip();
+      hideLinkedTip();
+    };
+    canvas.addEventListener('pointermove', handleChartMove);
+    canvas.addEventListener('pointerleave', () => {
+      if (hoverPointerKind === 'chart') setHoverCumulativeMeters(null, null);
+      clearHoverPreview();
+      hideHoverTip();
+      hideLinkedTip();
+    });
+  }
+}
+
+/**
+ * Returns the chart dot closest to the cursor's X position. The cursor's Y is
+ * ignored on purpose — the user only needs to sweep horizontally along the
+ * route to surface any Oasis at that distance, regardless of where the dot
+ * lands on the elevation curve. `rect` is the canvas bounding rect; (x, _y)
+ * are cursor coords relative to that rect.
+ */
+function findChartDotNear(rect, x, _y) {
+  const dots = getOasisChartDots();
+  if (!dots.length || !routeElevationSeries) return null;
+  const padLeft = CHART_PAD_LEFT;
+  const padRight = CHART_PAD_RIGHT;
+  const plotW = Math.max(rect.width - padLeft - padRight, 1);
+  const totalMeters = routeElevationSeries.totalDistanceMeters || 1;
+  const toX = (m) => padLeft + (Math.max(0, Math.min(m, totalMeters)) / totalMeters) * plotW;
+
+  const xTolerance = 6;
+  let best = null;
+  let bestDx = Infinity;
+  for (const dot of dots) {
+    const dx = Math.abs(toX(dot.alongMeters) - x);
+    if (dx <= xTolerance && dx < bestDx) {
+      best = dot;
+      bestDx = dx;
+    }
+  }
+  return best;
+}
+
+/** Reflects the hover state onto the map marker layer. */
+function syncHoverMarker() {
+  hoverMarkerSource.clear();
+  if (!Number.isFinite(hoverCumulativeMeters)) return;
+  const lonLat = lonLatAtRouteMeters(hoverCumulativeMeters);
+  if (!lonLat) return;
+  const feature = new ol.Feature({ geometry: new ol.geom.Point(ol.proj.fromLonLat(lonLat)) });
+  hoverMarkerSource.addFeature(feature);
+}
+
 /** Parses GPX text and converts it into an OpenLayers route feature. */
 function createRouteFeatureFromGpx(gpxText) {
   const parsed = window.GpxParser.parseGpxText(gpxText);
   return {
     coordinates: parsed.geometry.coordinates,
+    elevations: Array.isArray(parsed.properties?.elevations) ? parsed.properties.elevations : null,
     feature: routeGeoJsonFormat.readFeature(parsed)
   };
 }
 
 /** Builds an OpenLayers route feature from an ordered [lon, lat] coordinate array. */
-function createRouteFeatureFromCoords(coordinates) {
+function createRouteFeatureFromCoords(coordinates, elevations = null) {
   const geojson = {
     type: 'Feature',
     geometry: { type: 'LineString', coordinates },
@@ -718,6 +1492,7 @@ function createRouteFeatureFromCoords(coordinates) {
   };
   return {
     coordinates,
+    elevations: Array.isArray(elevations) ? elevations : null,
     feature: routeGeoJsonFormat.readFeature(geojson)
   };
 }
@@ -875,7 +1650,9 @@ async function handleRouteFile(event) {
         throw new Error('FIT から 2 点以上の経路座標を抽出できませんでした');
       }
       const coords = fit.records.map((r) => [r.lon, r.lat]);
-      parsedRoute = createRouteFeatureFromCoords(coords);
+      const eles = fit.records.map((r) => (Number.isFinite(r.elevationMeters) ? r.elevationMeters : null));
+      const hasEle = eles.some((e) => e !== null);
+      parsedRoute = createRouteFeatureFromCoords(coords, hasEle ? eles : null);
       coursePoints = fit.coursePoints;
     } else {
       const gpxText = await file.text();
@@ -885,6 +1662,7 @@ async function handleRouteFile(event) {
     if (loadToken !== latestRouteLoadToken) return;
     routeFeature = parsedRoute.feature;
     routeCoordinates = parsedRoute.coordinates;
+    routeElevations = parsedRoute.elevations || [];
     manualPoints = [];
     currentRwgId = null;
     elements.gpxFileName.textContent = file.name;
@@ -893,6 +1671,7 @@ async function handleRouteFile(event) {
     resetResults();
     updateRoutePointCount();
     fitToVisibleData();
+    renderElevationChart();
     syncUrlState();
     const cpInfo = coursePoints.length > 0 ? ` (PC ${coursePoints.length} 件)` : '';
     setStatus(`${isFit ? 'FIT' : 'GPX'} を読み込みました: ${file.name}${cpInfo}`);
@@ -930,9 +1709,12 @@ async function handleRwgFetch(event) {
       throw new Error('RWG ルートから 2 点以上の経路座標を取得できませんでした');
     }
     const coords = rwg.records.map((r) => [r.lon, r.lat]);
-    const parsedRoute = createRouteFeatureFromCoords(coords);
+    const eles = rwg.records.map((r) => (Number.isFinite(r.elevationMeters) ? r.elevationMeters : null));
+    const hasEle = eles.some((e) => e !== null);
+    const parsedRoute = createRouteFeatureFromCoords(coords, hasEle ? eles : null);
     routeFeature = parsedRoute.feature;
     routeCoordinates = parsedRoute.coordinates;
+    routeElevations = parsedRoute.elevations || [];
     manualPoints = [];
     const displayName = rwg.name || `RWG #${id}`;
     elements.gpxFileName.textContent = displayName;
@@ -941,6 +1723,7 @@ async function handleRwgFetch(event) {
     resetResults();
     updateRoutePointCount();
     fitToVisibleData();
+    renderElevationChart();
     const cpInfo = (rwg.coursePoints || []).length > 0 ? ` (PC ${rwg.coursePoints.length} 件)` : '';
     setStatus(`RWG ルートを読み込みました: ${displayName}${cpInfo}`);
     currentRwgId = id;
@@ -970,17 +1753,21 @@ async function handleManualMapClick(mapCoord) {
   if (manualPoints.length === 1) {
     routeFeature = null;
     routeCoordinates = [];
+    routeElevations = [];
     resetResults();
     updateRoutePointCount();
+    renderElevationChart();
     setStatus('目的地をクリックしてください');
     return;
   }
 
   routeFeature = routeSource.getFeatures()[0] || null;
   routeCoordinates = manualPoints.map((coord) => [coord[0], coord[1]]);
+  routeElevations = [];
   resetResults();
   updateRoutePointCount();
   fitToVisibleData();
+  renderElevationChart();
   setStatus('手動経路を生成しました');
   syncUrlState();
   if (loadToken !== latestRouteLoadToken) return;
@@ -992,11 +1779,13 @@ function resetManualState() {
   manualPoints = [];
   routeFeature = null;
   routeCoordinates = [];
+  routeElevations = [];
   ++latestRouteLoadToken;
   cancelPendingRefreshes();
   clearRouteVisualSources();
   resetResults();
   updateRoutePointCount();
+  renderElevationChart();
   if (selectedSourceMode() === 'manual') {
     setStatus('地図をクリックして出発地を指定してください');
   }
@@ -1024,11 +1813,13 @@ async function handleCurrentLocation() {
     const coord = [position.coords.longitude, position.coords.latitude];
     routeFeature = null;
     routeCoordinates = [coord];
+    routeElevations = [];
     manualPoints = [];
     renderCurrentLocation(coord);
     resetResults();
     updateRoutePointCount();
     fitToVisibleData();
+    renderElevationChart();
     setStatus('現在地を取得しました');
     syncUrlState();
     await refreshMap([...routeCoordinates]);
@@ -1090,6 +1881,7 @@ async function handleFollowPositionAsync(position) {
 
   routeFeature = null;
   routeCoordinates = [coord];
+  routeElevations = [];
   renderCurrentLocation(coord);
   updateRoutePointCount();
 
@@ -1280,10 +2072,12 @@ async function searchAtPlace(item) {
   const coord = [lon, lat];
   routeFeature = null;
   routeCoordinates = [coord];
+  routeElevations = [];
   renderCurrentLocation(coord);
   resetResults();
   updateRoutePointCount();
   fitToVisibleData();
+  renderElevationChart();
   setStatus(`「${item.display_name}」を中心に検索中...`);
   clearGeoSearchResults();
   await refreshMap([...routeCoordinates]);
@@ -1506,14 +2300,24 @@ function bindEvents() {
     if (desktopMediaQuery && desktopMediaQuery.matches) return;
     const expanded = elements.resultsSheet.classList.toggle('expanded');
     elements.resultsToggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-    setTimeout(() => map.updateSize(), 260);
+    setTimeout(() => {
+      map.updateSize();
+      renderElevationChart();
+    }, 260);
   });
   if (desktopMediaQuery) {
     desktopMediaQuery.addEventListener('change', () => {
       map.updateSize();
+      renderElevationChart();
     });
   }
-  window.addEventListener('resize', () => map.updateSize());
+  window.addEventListener('resize', () => {
+    map.updateSize();
+    renderElevationChart();
+  });
+
+  bindRouteHoverLinks();
+
   map.on('singleclick', (event) => {
     const supplyFeature = map.forEachFeatureAtPixel(
       event.pixel,

--- a/frontend/fit.js
+++ b/frontend/fit.js
@@ -60,12 +60,23 @@
    * Records / course points outside the valid lat/lon range are dropped.
    */
   function normalizeFitData(data) {
+    // fit-file-parser emits the FIT 'altitude' field as meters when lengthUnit:'m'
+    // is set on the parser. 'enhanced_altitude' is the GPS+barometric fused value
+    // when present; prefer it over the plain altitude for chart accuracy.
+    const pickElevation = (r) => {
+      const enhanced = Number(r?.enhanced_altitude);
+      if (Number.isFinite(enhanced)) return enhanced;
+      const altitude = Number(r?.altitude);
+      return Number.isFinite(altitude) ? altitude : null;
+    };
+
     const records = (Array.isArray(data?.records) ? data.records : [])
       .filter((r) => isValidLatLon(r?.position_lat, r?.position_long))
       .map((r) => ({
         lat: r.position_lat,
         lon: r.position_long,
-        distanceMeters: Number.isFinite(r.distance) ? r.distance : null
+        distanceMeters: Number.isFinite(r.distance) ? r.distance : null,
+        elevationMeters: pickElevation(r)
       }));
 
     const coursePoints = (Array.isArray(data?.course_points) ? data.course_points : [])

--- a/frontend/gpx.js
+++ b/frontend/gpx.js
@@ -5,34 +5,80 @@
   }
   root.GpxParser = factory();
 })(typeof globalThis !== 'undefined' ? globalThis : this, function () {
-  const POINT_TAG_RE = /<(trkpt|rtept)\b([^>]*)>/gi;
+  // Captures the open tag and the inner text up to the corresponding close tag so we
+  // can recover `<ele>` values nested inside `<trkpt>`/`<rtept>`. The `[\s\S]` form
+  // tolerates newlines that real-world GPX exporters insert between child elements.
+  const POINT_BLOCK_RE = /<(trkpt|rtept)\b([^>]*)>([\s\S]*?)<\/\1>/gi;
+  const POINT_SELFCLOSE_RE = /<(trkpt|rtept)\b([^>]*)\/>/gi;
   const ATTR_RE = /\b(lat|lon)\s*=\s*(['"])(.*?)\2/gi;
+  const ELE_RE = /<ele\b[^>]*>\s*([+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\s*<\/ele>/i;
+
+  /** Parses lat/lon attributes from a tag attribute string. */
+  function parseLatLonAttrs(attrString) {
+    const attrs = {};
+    let attrMatch;
+    const re = new RegExp(ATTR_RE.source, 'gi');
+    while ((attrMatch = re.exec(attrString)) !== null) {
+      attrs[attrMatch[1]] = attrMatch[3];
+    }
+    const lat = Number(attrs.lat);
+    const lng = Number(attrs.lon);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+    return { lat, lng };
+  }
+
+  /** Extracts elevation in meters from a `<trkpt>`/`<rtept>` inner XML, or null. */
+  function parseEleFromInner(innerXml) {
+    if (!innerXml) return null;
+    const m = ELE_RE.exec(innerXml);
+    if (!m) return null;
+    const value = Number(m[1]);
+    return Number.isFinite(value) ? value : null;
+  }
+
+  /**
+   * Walks the GPX text once and yields `{ lng, lat, ele }` for every well-formed
+   * track/route point, in document order. Used by the higher-level parsers below.
+   */
+  function parsePointsWithElevation(gpxText) {
+    const text = String(gpxText || '');
+    const matches = [];
+    let m;
+    const blockRe = new RegExp(POINT_BLOCK_RE.source, 'gi');
+    while ((m = blockRe.exec(text)) !== null) {
+      const latLon = parseLatLonAttrs(m[2]);
+      if (!latLon) continue;
+      matches.push({
+        index: m.index,
+        lng: latLon.lng,
+        lat: latLon.lat,
+        ele: parseEleFromInner(m[3])
+      });
+    }
+    const selfRe = new RegExp(POINT_SELFCLOSE_RE.source, 'gi');
+    while ((m = selfRe.exec(text)) !== null) {
+      const latLon = parseLatLonAttrs(m[2]);
+      if (!latLon) continue;
+      matches.push({ index: m.index, lng: latLon.lng, lat: latLon.lat, ele: null });
+    }
+    matches.sort((a, b) => a.index - b.index);
+    return matches.map(({ lng, lat, ele }) => ({ lng, lat, ele }));
+  }
 
   /** Extracts ordered [lng, lat] coordinates from GPX track or route point tags. */
   function parseCoordinateTokens(gpxText) {
-    const coords = [];
-    let tagMatch;
-    while ((tagMatch = POINT_TAG_RE.exec(String(gpxText || ''))) !== null) {
-      const attrs = {};
-      let attrMatch;
-      while ((attrMatch = ATTR_RE.exec(tagMatch[2])) !== null) {
-        attrs[attrMatch[1]] = attrMatch[3];
-      }
-      const lat = Number(attrs.lat);
-      const lng = Number(attrs.lon);
-      if (Number.isFinite(lat) && Number.isFinite(lng)) {
-        coords.push([lng, lat]);
-      }
-    }
-    return coords;
+    return parsePointsWithElevation(gpxText).map((p) => [p.lng, p.lat]);
   }
 
   /** Parses GPX text into a GeoJSON LineString feature for the route viewer. */
   function parseGpxText(gpxText) {
-    const coordinates = parseCoordinateTokens(String(gpxText || ''));
-    if (coordinates.length < 2) {
+    const points = parsePointsWithElevation(gpxText);
+    if (points.length < 2) {
       throw new Error('GPX から2点以上の経路座標を抽出できませんでした');
     }
+    const coordinates = points.map((p) => [p.lng, p.lat]);
+    const elevations = points.map((p) => p.ele);
+    const hasElevation = elevations.some((e) => e !== null);
     return {
       type: 'Feature',
       geometry: {
@@ -40,7 +86,8 @@
         coordinates
       },
       properties: {
-        point_count: coordinates.length
+        point_count: coordinates.length,
+        elevations: hasElevation ? elevations : null
       }
     };
   }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -129,6 +129,12 @@
           <button class="popup-close" id="popup-close" type="button" aria-label="閉じる">×</button>
           <div class="popup-body" id="popup-body"></div>
         </div>
+        <div class="elevation-chart" id="elevation-chart" hidden aria-label="標高プロファイル">
+          <canvas id="elevation-canvas"></canvas>
+          <div class="elevation-meta" id="elevation-meta"></div>
+        </div>
+        <div class="hover-tip" id="hover-tip" hidden role="tooltip"></div>
+        <div class="hover-tip hover-tip-linked" id="hover-tip-linked" hidden aria-hidden="true"></div>
       </main>
 
       <aside class="results-sheet" id="results-sheet" aria-label="検索結果">

--- a/frontend/rwg.js
+++ b/frontend/rwg.js
@@ -39,12 +39,14 @@
    * - name: the route's own display name (used as a substitute filename).
    */
   function normalizeRwgData(data) {
+    // RWG's track_points encode elevation as `e` (meters above sea level).
     const records = (Array.isArray(data?.track_points) ? data.track_points : [])
       .filter((p) => isValidLatLon(p?.y, p?.x))
       .map((p) => ({
         lat: p.y,
         lon: p.x,
-        distanceMeters: Number.isFinite(p.d) ? p.d : null
+        distanceMeters: Number.isFinite(p.d) ? p.d : null,
+        elevationMeters: Number.isFinite(p.e) ? p.e : null
       }));
 
     const cuePoints = (Array.isArray(data?.course_points) ? data.course_points : [])

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -598,6 +598,92 @@ input[type="search"]::-webkit-search-cancel-button {
   display: none;
 }
 
+.elevation-chart {
+  position: absolute;
+  left: var(--space-2);
+  right: var(--space-2);
+  bottom: var(--space-2);
+  height: 88px;
+  padding: 6px 10px 4px;
+  background: color-mix(in oklab, var(--c-surface) 92%, transparent);
+  border: 1px solid var(--c-line);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-md);
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.elevation-chart canvas {
+  cursor: crosshair;
+}
+
+.hover-tip {
+  position: fixed;
+  z-index: 50;
+  background: var(--c-surface);
+  border: 1px solid var(--c-line);
+  border-radius: var(--r-md);
+  padding: 6px 10px;
+  font-size: 12px;
+  line-height: 1.4;
+  pointer-events: none;
+  box-shadow: var(--shadow-md);
+  max-width: 260px;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+.hover-tip[hidden] {
+  display: none;
+}
+
+.hover-tip-chain {
+  color: var(--c-accent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hover-tip-title {
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.hover-tip-meta {
+  color: var(--c-ink-muted);
+  font-size: 11px;
+}
+
+.hover-tip-linked {
+  opacity: 0.92;
+  border-color: var(--c-accent);
+  box-shadow: 0 4px 12px rgba(34, 94, 168, 0.18);
+}
+
+.elevation-chart[hidden] {
+  display: none;
+}
+
+.elevation-chart canvas {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.elevation-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--c-ink-muted);
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+}
+
 .popup-close {
   position: absolute;
   top: 6px;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -615,7 +615,15 @@ input[type="search"]::-webkit-search-cancel-button {
   gap: 2px;
 }
 
+.elevation-chart[hidden] {
+  display: none;
+}
+
 .elevation-chart canvas {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  display: block;
   cursor: crosshair;
 }
 
@@ -662,17 +670,6 @@ input[type="search"]::-webkit-search-cancel-button {
   opacity: 0.92;
   border-color: var(--c-accent);
   box-shadow: 0 4px 12px rgba(34, 94, 168, 0.18);
-}
-
-.elevation-chart[hidden] {
-  display: none;
-}
-
-.elevation-chart canvas {
-  flex: 1;
-  width: 100%;
-  height: 100%;
-  display: block;
 }
 
 .elevation-meta {

--- a/tests/fit.test.js
+++ b/tests/fit.test.js
@@ -6,7 +6,7 @@ const { normalizeFitData, parseFitArrayBuffer, _resetCacheForTests } = require('
 test('FIT Parser: records と course_points を内部形式に正規化する', () => {
   const data = {
     records: [
-      { position_lat: 35.0, position_long: 139.0, distance: 0 },
+      { position_lat: 35.0, position_long: 139.0, distance: 0, altitude: 12.5 },
       { position_lat: 35.1, position_long: 139.1, distance: 1234.5 }
     ],
     course_points: [
@@ -15,8 +15,8 @@ test('FIT Parser: records と course_points を内部形式に正規化する', 
   };
   const out = normalizeFitData(data);
   assert.equal(out.records.length, 2);
-  assert.deepEqual(out.records[0], { lat: 35.0, lon: 139.0, distanceMeters: 0 });
-  assert.deepEqual(out.records[1], { lat: 35.1, lon: 139.1, distanceMeters: 1234.5 });
+  assert.deepEqual(out.records[0], { lat: 35.0, lon: 139.0, distanceMeters: 0, elevationMeters: 12.5 });
+  assert.deepEqual(out.records[1], { lat: 35.1, lon: 139.1, distanceMeters: 1234.5, elevationMeters: null });
   assert.equal(out.coursePoints.length, 1);
   assert.deepEqual(out.coursePoints[0], {
     lat: 35.5,
@@ -71,7 +71,21 @@ test('FIT Parser: distance が無い record / course_point は distanceMeters: n
     course_points: [{ position_lat: 35.5, position_long: 139.5 }]
   });
   assert.equal(out.records[0].distanceMeters, null);
+  assert.equal(out.records[0].elevationMeters, null);
   assert.equal(out.coursePoints[0].distanceMeters, null);
+});
+
+test('FIT Parser: enhanced_altitude を優先しつつ altitude にフォールバックする', () => {
+  const out = normalizeFitData({
+    records: [
+      { position_lat: 35, position_long: 139, altitude: 10, enhanced_altitude: 11 },
+      { position_lat: 35.1, position_long: 139.1, altitude: 20 },
+      { position_lat: 35.2, position_long: 139.2 }
+    ]
+  });
+  assert.equal(out.records[0].elevationMeters, 11);
+  assert.equal(out.records[1].elevationMeters, 20);
+  assert.equal(out.records[2].elevationMeters, null);
 });
 
 test('FIT Parser: name / type が文字列でない場合は default 値で正規化する', () => {

--- a/tests/route_math.test.js
+++ b/tests/route_math.test.js
@@ -45,6 +45,61 @@ test('Route Math: 2点未満の GPX は例外を投げる', () => {
   assert.throws(() => parseGpxText('<gpx><trkpt lat="35" lon="139"></trkpt></gpx>'), /2点以上/);
 });
 
+test('GPX Elevation: trkpt 内の ele を読み取り properties.elevations を返す', () => {
+  const xml = [
+    '<gpx><trk><trkseg>',
+    '<trkpt lat="35.0" lon="139.0"><ele>10.5</ele></trkpt>',
+    '<trkpt lat="35.1" lon="139.1"><ele>20</ele></trkpt>',
+    '<trkpt lat="35.2" lon="139.2"><ele>15.25</ele></trkpt>',
+    '</trkseg></trk></gpx>'
+  ].join('');
+  const parsed = parseGpxText(xml);
+  assert.deepEqual(parsed.geometry.coordinates, [
+    [139.0, 35.0],
+    [139.1, 35.1],
+    [139.2, 35.2]
+  ]);
+  assert.deepEqual(parsed.properties.elevations, [10.5, 20, 15.25]);
+});
+
+test('GPX Elevation: 一部の trkpt に ele が無い場合は null を残す', () => {
+  const xml = [
+    '<gpx><trk><trkseg>',
+    '<trkpt lat="35.0" lon="139.0"><ele>10</ele></trkpt>',
+    '<trkpt lat="35.1" lon="139.1"></trkpt>',
+    '<trkpt lat="35.2" lon="139.2"><ele>30</ele></trkpt>',
+    '</trkseg></trk></gpx>'
+  ].join('');
+  const parsed = parseGpxText(xml);
+  assert.deepEqual(parsed.properties.elevations, [10, null, 30]);
+});
+
+test('GPX Elevation: ele が全く無い GPX では elevations は null', () => {
+  const xml = [
+    '<gpx><trk><trkseg>',
+    '<trkpt lat="35.0" lon="139.0"></trkpt>',
+    '<trkpt lat="35.1" lon="139.1"></trkpt>',
+    '</trkseg></trk></gpx>'
+  ].join('');
+  const parsed = parseGpxText(xml);
+  assert.equal(parsed.properties.elevations, null);
+});
+
+test('GPX Elevation: 自己終端タグや属性順違いでも順序通り抽出できる', () => {
+  const xml = [
+    '<gpx><rte>',
+    "<rtept lon='139.0' lat='35.0'><ele>5</ele></rtept>",
+    '<rtept lat="35.1" lon="139.1" />',
+    '</rte></gpx>'
+  ].join('');
+  const parsed = parseGpxText(xml);
+  assert.deepEqual(parsed.geometry.coordinates, [
+    [139.0, 35.0],
+    [139.1, 35.1]
+  ]);
+  assert.deepEqual(parsed.properties.elevations, [5, null]);
+});
+
 test('Route Math: bbox を算出できる', () => {
   assert.deepEqual(
     computeBbox([

--- a/tests/rwg.test.js
+++ b/tests/rwg.test.js
@@ -36,7 +36,7 @@ test('RWG: normalizeRwgData は track_points / course_points / POI を統合す�
   const data = {
     name: '神戸-伊勢',
     track_points: [
-      { x: 139.0, y: 35.0, d: 0 },
+      { x: 139.0, y: 35.0, d: 0, e: 12.3 },
       { x: 139.001, y: 35.001, d: 150 }
     ],
     course_points: [
@@ -54,7 +54,8 @@ test('RWG: normalizeRwgData は track_points / course_points / POI を統合す�
   const out = normalizeRwgData(data);
   assert.equal(out.name, '神戸-伊勢');
   assert.equal(out.records.length, 2);
-  assert.deepEqual(out.records[0], { lat: 35.0, lon: 139.0, distanceMeters: 0 });
+  assert.deepEqual(out.records[0], { lat: 35.0, lon: 139.0, distanceMeters: 0, elevationMeters: 12.3 });
+  assert.equal(out.records[1].elevationMeters, null);
   assert.equal(out.coursePoints.length, 2);
   assert.equal(out.coursePoints[0].name, '右折');
   assert.equal(out.coursePoints[0].type, 'right');

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,13 @@ main = "worker.mjs"
 compatibility_date = "2026-04-01"
 compatibility_flags = ["nodejs_compat"]
 
+# Custom domain と併用しても workers.dev / version preview URL を残す。
+# false にすると `<version-id>-ride-oasis.teacatus.workers.dev` も同時に
+# 無効化され Workers Builds の per-branch preview が機能しなくなるため、
+# 意図的に true で固定する。
+workers_dev = true
+preview_urls = true
+
 # Custom domain. The DNS record + worker route are managed in the Cloudflare
 # Dashboard (Workers & Pages → ride-oasis → Settings → Domains & Routes); this
 # entry mirrors that binding so `wrangler deploy` does not warn about an


### PR DESCRIPTION
## Summary
- GPX (`<ele>`) / FIT (`altitude` + `enhanced_altitude`) / RWG (track_points `e`) から標高を抽出し、マップ下部に標高プロファイルを Canvas で描画
- マップ ↔ 標高チャートで **累計距離を共通軸として双方向ホバー**: マップ pointermove → チャートに十字ガイド (Google Maps 風の距離 / 標高+勾配ラベル)。チャート pointermove → マップに hover marker
- **Oasis 点を標高チャートにも投影**: routeProjection で alongMeters / 標高高さに緑ドット、active 時は朱色
- **Oasis / FIT-RWG コース点に hover tooltip**: マップ・チャート両面でチェーン / 店名 / ルート距離を表示。Oasis は対応する dot 側に linked tooltip も同時表示
- 標高チャートのドット判定は **X 軸のみ ±6px**（Y は無視）。Y がどこでも X 一致で oasis が出る
- 標高なしルートはチャート非表示。複数 GPX のキャッシュ動作も検証済み

## 主な変更
- `frontend/gpx.js`: `<ele>` を読み取り `properties.elevations` を返す。self-closing 要素 / 単引用クォート / 属性順違いに耐性
- `frontend/fit.js`: `enhanced_altitude` を優先、`altitude` にフォールバック
- `frontend/rwg.js`: track_points `e` を `records[].elevationMeters`
- `frontend/app.js`: 標高チャート描画 / 双方向ホバー / dual tooltip / 線形補間ヘルパー
- `frontend/index.html` + `styles.css`: チャートと tooltip のマークアップ・スタイル
- テスト: GPX 標高 4 件 / FIT 標高フォールバック 1 件 / RWG 標高 1 件追加

## Test plan
- [x] `npm test` 115 件 pass
- [x] `node --check frontend/{app,gpx,fit,rwg}.js`
- [x] Playwright スモーク (`.local/elevation_*_smoketest.mjs`):
  - GPX 標高抽出 → チャート描画 (`距離 2.3 km / 標高 10–70 m / ↑75m / ↓15m`)
  - マップ→チャート 双方向ホバー (`1.5 km / 全 3.0 km 標高 62 m` 系)
  - マップ Oasis ホバー → fixed tooltip + チャート linked tooltip
  - チャート dot X 軸スイープ (y=top) → 30 ステップ中 26 ステップで oasis ヒット
- [x] Cloudflare preview (`npm run cf:preview`) で目視確認: `d369d98b-ride-oasis.teacatus.workers.dev`