### PR TITLE
perf(cycling): タイル形式を NDJSON → バイナリ v1 (~5x 縮小)

### DIFF
--- a/lib/cycling/tile_binary.js
+++ b/lib/cycling/tile_binary.js
@@ -1,0 +1,116 @@
+'use strict';
+
+// Binary tile format v1
+// -----------------------------------------------------------------------------
+// Header (16 bytes, little endian):
+//   0..3  magic        "RIDE" (ASCII)
+//   4     version      u8 = 1
+//   5     flags        u8 (reserved, 0)
+//   6..7  padding      u16
+//   8..11 nodeCount    u32
+//   12..15 edgeCount   u32
+//
+// Nodes section (nodeCount * 16 bytes):
+//   0..7  id           Float64 (JS-safe integer)
+//   8..11 lon          Float32
+//   12..15 lat         Float32
+//
+// Edges section (edgeCount * 28 bytes):
+//   0..7  from         Float64
+//   8..15 to           Float64
+//   16..19 toLon       Float32
+//   20..23 toLat       Float32
+//   24..27 cost        Float32
+//
+// `kind` を意図的に除外: ルーティングロジックは事前計算済 cost_m しか使わない。
+
+const MAGIC = 0x45444952; // "RIDE" little-endian
+const VERSION = 1;
+const HEADER_BYTES = 16;
+const NODE_BYTES = 16;
+const EDGE_BYTES = 28;
+
+function encodeTile(nodes, edges) {
+  const total =
+    HEADER_BYTES + nodes.length * NODE_BYTES + edges.length * EDGE_BYTES;
+  const buf = new ArrayBuffer(total);
+  const dv = new DataView(buf);
+
+  dv.setUint32(0, MAGIC, true);
+  dv.setUint8(4, VERSION);
+  dv.setUint8(5, 0);
+  dv.setUint16(6, 0, true);
+  dv.setUint32(8, nodes.length, true);
+  dv.setUint32(12, edges.length, true);
+
+  let off = HEADER_BYTES;
+  for (const n of nodes) {
+    dv.setFloat64(off, n.id, true);
+    dv.setFloat32(off + 8, n.lon, true);
+    dv.setFloat32(off + 12, n.lat, true);
+    off += NODE_BYTES;
+  }
+  for (const e of edges) {
+    dv.setFloat64(off, e.from, true);
+    dv.setFloat64(off + 8, e.to, true);
+    dv.setFloat32(off + 16, e.toLon, true);
+    dv.setFloat32(off + 20, e.toLat, true);
+    dv.setFloat32(off + 24, e.cost, true);
+    off += EDGE_BYTES;
+  }
+  return buf;
+}
+
+function decodeTile(arrayBuffer) {
+  if (arrayBuffer.byteLength < HEADER_BYTES) {
+    throw new Error('tile too small');
+  }
+  const dv = new DataView(arrayBuffer);
+  const magic = dv.getUint32(0, true);
+  if (magic !== MAGIC) throw new Error('tile magic mismatch');
+  const version = dv.getUint8(4);
+  if (version !== VERSION) throw new Error(`unsupported tile version ${version}`);
+  const nodeCount = dv.getUint32(8, true);
+  const edgeCount = dv.getUint32(12, true);
+
+  const expected =
+    HEADER_BYTES + nodeCount * NODE_BYTES + edgeCount * EDGE_BYTES;
+  if (arrayBuffer.byteLength !== expected) {
+    throw new Error(
+      `tile size mismatch: got ${arrayBuffer.byteLength} expected ${expected}`
+    );
+  }
+
+  const nodes = new Array(nodeCount);
+  let off = HEADER_BYTES;
+  for (let i = 0; i < nodeCount; i += 1) {
+    nodes[i] = {
+      id: dv.getFloat64(off, true),
+      lon: dv.getFloat32(off + 8, true),
+      lat: dv.getFloat32(off + 12, true)
+    };
+    off += NODE_BYTES;
+  }
+  const edges = new Array(edgeCount);
+  for (let i = 0; i < edgeCount; i += 1) {
+    edges[i] = {
+      from: dv.getFloat64(off, true),
+      to: dv.getFloat64(off + 8, true),
+      toLon: dv.getFloat32(off + 16, true),
+      toLat: dv.getFloat32(off + 20, true),
+      cost: dv.getFloat32(off + 24, true)
+    };
+    off += EDGE_BYTES;
+  }
+  return { nodes, edges };
+}
+
+module.exports = {
+  MAGIC,
+  VERSION,
+  HEADER_BYTES,
+  NODE_BYTES,
+  EDGE_BYTES,
+  encodeTile,
+  decodeTile
+};

--- a/lib/cycling/tile_loader.js
+++ b/lib/cycling/tile_loader.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { SpatialGrid } = require('./spatial_grid');
+const { decodeTile } = require('./tile_binary');
 
 const DEFAULT_MAX_TILES = 128;
 const DEFAULT_MAX_MISSES = 1024;
@@ -47,8 +48,8 @@ class TileLoader {
       }
       p = (async () => {
         try {
-          const text = await this.fetcher(key);
-          if (text == null) {
+          const buf = await this.fetcher(key);
+          if (buf == null) {
             // Bounded miss set: drop arbitrary entries when full so we don't
             // grow indefinitely from probes / out-of-region requests.
             if (this.misses.size >= this.maxMisses) {
@@ -58,7 +59,7 @@ class TileLoader {
             this.misses.add(key);
             return false;
           }
-          this._mergeText(text);
+          this._mergeBinary(buf);
           this.loaded.add(key);
           return true;
         } finally {
@@ -85,38 +86,32 @@ class TileLoader {
     return results;
   }
 
-  _mergeText(text) {
+  _mergeBinary(arrayBuffer) {
     const { nodes, fwd, rev } = this.view;
     const grid = this.grid;
-    let start = 0;
-    while (start < text.length) {
-      const end = text.indexOf('\n', start);
-      const line = end === -1 ? text.slice(start) : text.slice(start, end);
-      start = end === -1 ? text.length : end + 1;
-      if (!line) continue;
-      const item = JSON.parse(line);
-      if (item.t === 'n') {
-        if (!nodes.has(item.id)) {
-          nodes.set(item.id, [item.lon, item.lat]);
-          grid.add(item.id, item.lon, item.lat);
-        }
-      } else if (item.t === 'e') {
-        let f = fwd.get(item.from);
-        if (!f) {
-          f = [];
-          fwd.set(item.from, f);
-        }
-        f.push(item);
-        let r = rev.get(item.to);
-        if (!r) {
-          r = [];
-          rev.set(item.to, r);
-        }
-        r.push(item);
-        if (!nodes.has(item.to)) {
-          nodes.set(item.to, [item.toLon, item.toLat]);
-          grid.add(item.to, item.toLon, item.toLat);
-        }
+    const { nodes: tileNodes, edges: tileEdges } = decodeTile(arrayBuffer);
+    for (const n of tileNodes) {
+      if (!nodes.has(n.id)) {
+        nodes.set(n.id, [n.lon, n.lat]);
+        grid.add(n.id, n.lon, n.lat);
+      }
+    }
+    for (const e of tileEdges) {
+      let f = fwd.get(e.from);
+      if (!f) {
+        f = [];
+        fwd.set(e.from, f);
+      }
+      f.push(e);
+      let r = rev.get(e.to);
+      if (!r) {
+        r = [];
+        rev.set(e.to, r);
+      }
+      r.push(e);
+      if (!nodes.has(e.to)) {
+        nodes.set(e.to, [e.toLon, e.toLat]);
+        grid.add(e.to, e.toLon, e.toLat);
       }
     }
   }
@@ -124,9 +119,9 @@ class TileLoader {
 
 function makeR2Fetcher(bucket, prefix = 'tiles/') {
   return async (key) => {
-    const obj = await bucket.get(`${prefix}${key}.ndjson`);
+    const obj = await bucket.get(`${prefix}${key}.bin`);
     if (!obj) return null;
-    return obj.text();
+    return obj.arrayBuffer();
   };
 }
 
@@ -134,9 +129,10 @@ function makeFsFetcher(dir) {
   const fs = require('fs');
   const path = require('path');
   return async (key) => {
-    const p = path.join(dir, 'tiles', `${key}.ndjson`);
+    const p = path.join(dir, 'tiles', `${key}.bin`);
     if (!fs.existsSync(p)) return null;
-    return fs.readFileSync(p, 'utf8');
+    const buf = fs.readFileSync(p);
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
   };
 }
 

--- a/scripts/cycling_tile_split.js
+++ b/scripts/cycling_tile_split.js
@@ -3,9 +3,9 @@
 const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
-const { finished } = require('stream/promises');
 
 const { tileKey } = require('../lib/cycling/tile_partition');
+const { encodeTile } = require('../lib/cycling/tile_binary');
 
 function parseArgs(argv = process.argv.slice(2)) {
   const args = { dir: null };
@@ -23,12 +23,12 @@ function usage() {
     'Usage: node scripts/cycling_tile_split.js --dir <graphDir>',
     '',
     'Reads <graphDir>/nodes.ndjson + edges.ndjson and writes:',
-    '  <graphDir>/tiles/{x}_{y}.ndjson  - per-tile content (one item per line)',
-    '  <graphDir>/tile_index.json       - { tiles: ["x_y", ...], cellDeg, bbox }',
+    '  <graphDir>/tiles/{x}_{y}.bin  - binary v1 tile (see lib/cycling/tile_binary.js)',
+    '  <graphDir>/tile_index.json    - { tiles, cell_deg, bbox }',
     '',
-    'Tile NDJSON items:',
-    '  {"t":"n","id":N,"lon":F,"lat":F}                                   primary node',
-    '  {"t":"e","from":N,"to":N,"toLon":F,"toLat":F,"cost":F,"kind":?}    directed edge'
+    'Binary format trades JSON readability for ~5x smaller size and faster parse',
+    'on the Worker side. NDJSON intermediates (nodes/edges.ndjson) are still kept',
+    'because cycling_route.js (debug CLI) reads them directly.'
   ].join('\n');
 }
 
@@ -70,6 +70,8 @@ async function main() {
 
   const nodes = new Map();
   const nodeToTile = new Map();
+  const tileNodes = new Map();
+  const tileEdges = new Map();
   let bbox = null;
   let nodeCount = 0;
 
@@ -77,7 +79,14 @@ async function main() {
   await streamLines(nodesPath, (line) => {
     const n = JSON.parse(line);
     nodes.set(n.id, [n.lon, n.lat]);
-    nodeToTile.set(n.id, tileKey(n.lon, n.lat));
+    const key = tileKey(n.lon, n.lat);
+    nodeToTile.set(n.id, key);
+    let arr = tileNodes.get(key);
+    if (!arr) {
+      arr = [];
+      tileNodes.set(key, arr);
+    }
+    arr.push({ id: n.id, lon: n.lon, lat: n.lat });
     nodeCount += 1;
     if (!bbox) bbox = { west: n.lon, east: n.lon, south: n.lat, north: n.lat };
     else {
@@ -89,23 +98,14 @@ async function main() {
   });
   process.stderr.write(`  nodes=${nodeCount} in ${Date.now() - t0}ms\n`);
 
-  const tileStreams = new Map();
-  const tileStats = new Map();
-  const openTile = (key) => {
-    let s = tileStreams.get(key);
-    if (!s) {
-      s = fs.createWriteStream(path.join(tilesDir, `${key}.ndjson`));
-      tileStreams.set(key, s);
-      tileStats.set(key, { nodes: 0, edges: 0 });
+  const pushEdge = (key, edge) => {
+    let arr = tileEdges.get(key);
+    if (!arr) {
+      arr = [];
+      tileEdges.set(key, arr);
     }
-    return s;
+    arr.push(edge);
   };
-
-  for (const [id, [lon, lat]] of nodes) {
-    const key = nodeToTile.get(id);
-    openTile(key).write(`${JSON.stringify({ t: 'n', id, lon, lat })}\n`);
-    tileStats.get(key).nodes += 1;
-  }
 
   const t1 = Date.now();
   process.stderr.write(`[pass 2/2] tiling edges from ${edgesPath}\n`);
@@ -115,58 +115,53 @@ async function main() {
     const fromTile = nodeToTile.get(e.from);
     const toCoord = nodes.get(e.to);
     if (!fromTile || !toCoord) return;
-    openTile(fromTile).write(
-      `${JSON.stringify({
-        t: 'e',
-        from: e.from,
-        to: e.to,
-        toLon: toCoord[0],
-        toLat: toCoord[1],
-        cost: e.cost_m,
-        kind: e.kind || null
-      })}\n`
-    );
-    tileStats.get(fromTile).edges += 1;
+    pushEdge(fromTile, {
+      from: e.from,
+      to: e.to,
+      toLon: toCoord[0],
+      toLat: toCoord[1],
+      cost: e.cost_m
+    });
     edgeRecords += 1;
-
     if (!e.oneway) {
       const toTile = nodeToTile.get(e.to);
       const fromCoord = nodes.get(e.from);
       if (toTile && fromCoord) {
-        openTile(toTile).write(
-          `${JSON.stringify({
-            t: 'e',
-            from: e.to,
-            to: e.from,
-            toLon: fromCoord[0],
-            toLat: fromCoord[1],
-            cost: e.cost_m,
-            kind: e.kind || null
-          })}\n`
-        );
-        tileStats.get(toTile).edges += 1;
+        pushEdge(toTile, {
+          from: e.to,
+          to: e.from,
+          toLon: fromCoord[0],
+          toLat: fromCoord[1],
+          cost: e.cost_m
+        });
         edgeRecords += 1;
       }
     }
   });
   process.stderr.write(`  directed edge records=${edgeRecords} in ${Date.now() - t1}ms\n`);
 
-  await Promise.all(
-    [...tileStreams.values()].map(async (s) => {
-      s.end();
-      await finished(s);
-    })
-  );
+  const tileKeys = new Set([...tileNodes.keys(), ...tileEdges.keys()]);
+  let bytesWritten = 0;
+  for (const key of tileKeys) {
+    const ns = tileNodes.get(key) || [];
+    const es = tileEdges.get(key) || [];
+    const buf = encodeTile(ns, es);
+    const outPath = path.join(tilesDir, `${key}.bin`);
+    fs.writeFileSync(outPath, Buffer.from(buf));
+    bytesWritten += buf.byteLength;
+  }
 
-  const tileKeys = [...tileStats.keys()].sort();
+  const sortedKeys = [...tileKeys].sort();
   fs.writeFileSync(
     path.join(args.dir, 'tile_index.json'),
     JSON.stringify(
       {
         cell_deg: 0.05,
         bbox,
-        tile_count: tileKeys.length,
-        tiles: tileKeys
+        tile_count: sortedKeys.length,
+        tiles: sortedKeys,
+        format: 'binary-v1',
+        bytes: bytesWritten
       },
       null,
       2
@@ -175,7 +170,7 @@ async function main() {
 
   const totalMs = Date.now() - t0;
   process.stderr.write(
-    `done: ${tileKeys.length} tiles, ${(totalMs / 1000).toFixed(1)}s\n`
+    `done: ${sortedKeys.length} tiles, ${(bytesWritten / 1024 / 1024).toFixed(1)}MB, ${(totalMs / 1000).toFixed(1)}s\n`
   );
 }
 

--- a/tests/cycling_tile_binary.test.js
+++ b/tests/cycling_tile_binary.test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  encodeTile,
+  decodeTile,
+  HEADER_BYTES,
+  NODE_BYTES,
+  EDGE_BYTES,
+  MAGIC,
+  VERSION
+} = require('../lib/cycling/tile_binary');
+
+function fuzzNodes(n, seed = 1) {
+  let s = seed;
+  const rand = () => (s = (s * 1664525 + 1013904223) >>> 0) / 0xffffffff;
+  return Array.from({ length: n }, (_, i) => ({
+    id: 10_000_000_000 + i,
+    lon: 135 + rand() * 2,
+    lat: 34 + rand() * 2
+  }));
+}
+
+function fuzzEdges(n, seed = 2) {
+  let s = seed;
+  const rand = () => (s = (s * 1664525 + 1013904223) >>> 0) / 0xffffffff;
+  return Array.from({ length: n }, (_, i) => ({
+    from: 10_000_000_000 + i,
+    to: 10_000_000_000 + ((i + 1) % n),
+    toLon: 135 + rand() * 2,
+    toLat: 34 + rand() * 2,
+    cost: rand() * 1000
+  }));
+}
+
+test('round-trip: 空のタイル', () => {
+  const buf = encodeTile([], []);
+  assert.equal(buf.byteLength, HEADER_BYTES);
+  const r = decodeTile(buf);
+  assert.deepEqual(r.nodes, []);
+  assert.deepEqual(r.edges, []);
+});
+
+test('round-trip: 単一ノード単一エッジ (Float32 誤差は許容)', () => {
+  const nodes = [{ id: 42, lon: 135.5, lat: 34.7 }];
+  const edges = [
+    { from: 42, to: 43, toLon: 135.51, toLat: 34.71, cost: 100 }
+  ];
+  const buf = encodeTile(nodes, edges);
+  assert.equal(buf.byteLength, HEADER_BYTES + NODE_BYTES + EDGE_BYTES);
+  const r = decodeTile(buf);
+  // 緯度経度は Float32 → ~1cm 精度。実用上は問題なし。
+  assert.equal(r.nodes[0].id, 42);
+  assert.ok(Math.abs(r.nodes[0].lon - 135.5) < 1e-4);
+  assert.ok(Math.abs(r.nodes[0].lat - 34.7) < 1e-4);
+  assert.equal(r.edges[0].from, 42);
+  assert.equal(r.edges[0].to, 43);
+  assert.ok(Math.abs(r.edges[0].toLon - 135.51) < 1e-4);
+  assert.ok(Math.abs(r.edges[0].toLat - 34.71) < 1e-4);
+  assert.ok(Math.abs(r.edges[0].cost - 100) < 1e-2);
+});
+
+test('round-trip: ファジング 1000 ノード + 2000 エッジで形状一致', () => {
+  const nodes = fuzzNodes(1000);
+  const edges = fuzzEdges(2000);
+  const buf = encodeTile(nodes, edges);
+  const r = decodeTile(buf);
+  assert.equal(r.nodes.length, 1000);
+  assert.equal(r.edges.length, 2000);
+  // ID は Float64 で保持されるので完全一致
+  for (let i = 0; i < 100; i += 1) {
+    assert.equal(r.nodes[i].id, nodes[i].id);
+    assert.equal(r.edges[i].from, edges[i].from);
+    assert.equal(r.edges[i].to, edges[i].to);
+  }
+});
+
+test('decode: magic mismatch を例外で弾く', () => {
+  const buf = new ArrayBuffer(HEADER_BYTES);
+  assert.throws(() => decodeTile(buf), /magic mismatch/);
+});
+
+test('decode: version mismatch を例外で弾く', () => {
+  const buf = new ArrayBuffer(HEADER_BYTES);
+  const dv = new DataView(buf);
+  dv.setUint32(0, MAGIC, true);
+  dv.setUint8(4, 99);
+  assert.throws(() => decodeTile(buf), /unsupported tile version/);
+});
+
+test('decode: ヘッダ未満のバッファは例外', () => {
+  assert.throws(() => decodeTile(new ArrayBuffer(4)), /too small/);
+});
+
+test('decode: 宣言された count とバイト数が合わないと例外', () => {
+  const nodes = [{ id: 1, lon: 0, lat: 0 }];
+  const edges = [];
+  const buf = encodeTile(nodes, edges);
+  // 1 バイト切り詰めて壊す
+  const truncated = buf.slice(0, buf.byteLength - 1);
+  assert.throws(() => decodeTile(truncated), /size mismatch/);
+});
+
+test('サイズが NDJSON 比で大幅に縮む (~4x 以上)', () => {
+  const nodes = fuzzNodes(100);
+  const edges = fuzzEdges(200);
+  const ndjsonBytes =
+    nodes.reduce((acc, n) => acc + JSON.stringify({ t: 'n', ...n }).length + 1, 0) +
+    edges.reduce((acc, e) => acc + JSON.stringify({ t: 'e', ...e }).length + 1, 0);
+  const binaryBytes = encodeTile(nodes, edges).byteLength;
+  assert.ok(
+    binaryBytes * 4 < ndjsonBytes,
+    `expected binary << ndjson; got bin=${binaryBytes} ndjson=${ndjsonBytes}`
+  );
+});
+
+test('Version 定数が 1', () => {
+  assert.equal(VERSION, 1);
+});

--- a/tests/cycling_tile_loader.test.js
+++ b/tests/cycling_tile_loader.test.js
@@ -4,20 +4,21 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const { TileLoader } = require('../lib/cycling/tile_loader');
+const { encodeTile } = require('../lib/cycling/tile_binary');
 
 function makeMemFetcher(data) {
   return async (key) => (key in data ? data[key] : null);
 }
 
-function ndjson(...items) {
-  return items.map((i) => JSON.stringify(i)).join('\n') + '\n';
+function tileOf(nodes, edges) {
+  return encodeTile(nodes, edges);
 }
 
 test('load: 同じ key を 2 回呼んでも fetcher は 1 回 (cache)', async () => {
   let calls = 0;
   const fetcher = async () => {
     calls += 1;
-    return ndjson({ t: 'n', id: 1, lon: 0, lat: 0 });
+    return tileOf([{ id: 1, lon: 0, lat: 0 }], []);
   };
   const loader = new TileLoader(fetcher);
   await loader.load('A');
@@ -30,7 +31,7 @@ test('load: 並列呼び出しでも fetcher は 1 回 (inflight dedup)', async 
   const fetcher = async () => {
     calls += 1;
     await new Promise((r) => setTimeout(r, 10));
-    return '';
+    return tileOf([], []);
   };
   const loader = new TileLoader(fetcher);
   await Promise.all([loader.load('A'), loader.load('A'), loader.load('A')]);
@@ -50,15 +51,14 @@ test('load: 存在しないキーは false を返し、二度目以降は fetche
 });
 
 test('loadMany: boolean 配列を返す', async () => {
-  const loader = new TileLoader(
-    makeMemFetcher({ A: ndjson({ t: 'n', id: 1, lon: 0, lat: 0 }) })
-  );
+  const data = { A: tileOf([{ id: 1, lon: 0, lat: 0 }], []) };
+  const loader = new TileLoader(makeMemFetcher(data));
   const got = await loader.loadMany(['A', 'B']);
   assert.deepEqual(got, [true, false]);
 });
 
 test('has: load 後に true', async () => {
-  const loader = new TileLoader(makeMemFetcher({ A: '' }));
+  const loader = new TileLoader(makeMemFetcher({ A: tileOf([], []) }));
   assert.equal(loader.has('A'), false);
   await loader.load('A');
   assert.equal(loader.has('A'), true);
@@ -67,33 +67,25 @@ test('has: load 後に true', async () => {
 test('load 後に view にノードとエッジが反映される', async () => {
   const loader = new TileLoader(
     makeMemFetcher({
-      A: ndjson(
-        { t: 'n', id: 1, lon: 135.5, lat: 34.7 },
-        {
-          t: 'e',
-          from: 1,
-          to: 2,
-          toLon: 135.51,
-          toLat: 34.71,
-          cost: 100
-        }
+      A: tileOf(
+        [{ id: 1, lon: 135.5, lat: 34.7 }],
+        [{ from: 1, to: 2, toLon: 135.51, toLat: 34.71, cost: 100 }]
       )
     })
   );
   await loader.load('A');
-  assert.deepEqual(loader.view.nodes.get(1), [135.5, 34.7]);
-  // 'to' ノードも座標が伝搬する (隣接タイル未読み込みでもエッジを辿れる)
-  assert.deepEqual(loader.view.nodes.get(2), [135.51, 34.71]);
+  const c1 = loader.view.nodes.get(1);
+  assert.ok(c1 && Math.abs(c1[0] - 135.5) < 1e-4);
+  const c2 = loader.view.nodes.get(2);
+  assert.ok(c2 && Math.abs(c2[0] - 135.51) < 1e-4);
   assert.equal(loader.view.fwd.get(1).length, 1);
   assert.equal(loader.view.rev.get(2).length, 1);
 });
 
 test('複数タイルがマージされる (同じノード ID は重複登録しない)', async () => {
+  const node = { id: 1, lon: 135.5, lat: 34.7 };
   const loader = new TileLoader(
-    makeMemFetcher({
-      A: ndjson({ t: 'n', id: 1, lon: 135.5, lat: 34.7 }),
-      B: ndjson({ t: 'n', id: 1, lon: 135.5, lat: 34.7 })
-    })
+    makeMemFetcher({ A: tileOf([node], []), B: tileOf([node], []) })
   );
   await loader.loadMany(['A', 'B']);
   assert.equal(loader.view.nodes.size, 1);
@@ -101,11 +93,43 @@ test('複数タイルがマージされる (同じノード ID は重複登録�
 
 test('grid からスナップ検索が可能', async () => {
   const loader = new TileLoader(
-    makeMemFetcher({
-      A: ndjson({ t: 'n', id: 42, lon: 135.5, lat: 34.7 })
-    })
+    makeMemFetcher({ A: tileOf([{ id: 42, lon: 135.5, lat: 34.7 }], []) })
   );
   await loader.load('A');
   const r = loader.grid.nearest(135.5001, 34.7001);
   assert.equal(r.id, 42);
+});
+
+test('容量到達 ∧ 他者進行中のとき新規 load は skip', async () => {
+  // maxTiles=2 で 3 つ並列に load 開始 → A,B 完了で cap 到達、
+  // 直後 D を呼ぶ (C は in-flight) と skip 経路に入る
+  const gates = new Map();
+  const makeGate = (key) => {
+    let release;
+    const p = new Promise((r) => { release = r; });
+    gates.set(key, { p, release });
+  };
+  ['A', 'B', 'C', 'D'].forEach(makeGate);
+  let calls = 0;
+  const fetcher = async (key) => {
+    calls += 1;
+    await gates.get(key).p;
+    return tileOf([{ id: key.charCodeAt(0), lon: 0, lat: 0 }], []);
+  };
+  const loader = new TileLoader(fetcher, { maxTiles: 2 });
+  const pA = loader.load('A');
+  const pB = loader.load('B');
+  const pC = loader.load('C');
+  // A, B を完了させ cap (2) 到達
+  gates.get('A').release();
+  await pA;
+  gates.get('B').release();
+  await pB;
+  assert.equal(loader.loaded.size, 2);
+  // この瞬間: loaded={A,B} (cap), inflight={C} → D は skip
+  const okD = await loader.load('D');
+  assert.equal(okD, false);
+  // クリーンアップ
+  gates.get('C').release();
+  await pC;
 });

--- a/tests/cycling_tile_loader.test.js
+++ b/tests/cycling_tile_loader.test.js
@@ -129,6 +129,7 @@ test('容量到達 ∧ 他者進行中のとき新規 load は skip', async () =
   // この瞬間: loaded={A,B} (cap), inflight={C} → D は skip
   const okD = await loader.load('D');
   assert.equal(okD, false);
+  assert.equal(calls, 3, 'D should not trigger a fetch');
   // クリーンアップ
   gates.get('C').release();
   await pC;

--- a/tests/cycling_tiled_router.test.js
+++ b/tests/cycling_tiled_router.test.js
@@ -6,6 +6,7 @@ const assert = require('node:assert/strict');
 const { TileLoader } = require('../lib/cycling/tile_loader');
 const { TiledRouter, bidiDijkstraOnView } = require('../lib/cycling/tiled_router');
 const { tileKey } = require('../lib/cycling/tile_partition');
+const { encodeTile } = require('../lib/cycling/tile_binary');
 
 function buildKansaiSyntheticTiles() {
   // 大阪近辺の合成データ: 3 ノード A-B-C を西→東に並べる
@@ -15,32 +16,29 @@ function buildKansaiSyntheticTiles() {
   const A = { id: 1, lon: 135.50, lat: 34.70 };
   const B = { id: 2, lon: 135.55, lat: 34.70 };
   const C = { id: 3, lon: 135.60, lat: 34.70 };
-  const cost_AB = 5000;
-  const cost_BC = 5000;
+  const cost = 5000;
   const tiles = {};
-  const push = (key, item) => {
-    if (!tiles[key]) tiles[key] = [];
-    tiles[key].push(item);
+  const ensure = (key) => {
+    if (!tiles[key]) tiles[key] = { nodes: [], edges: [] };
+    return tiles[key];
   };
-  for (const n of [A, B, C]) {
-    push(tileKey(n.lon, n.lat), { t: 'n', ...n });
-  }
+  for (const n of [A, B, C]) ensure(tileKey(n.lon, n.lat)).nodes.push(n);
   // 非 oneway: A↔B, B↔C を双方向で 2 つずつ emit
-  push(tileKey(A.lon, A.lat), {
-    t: 'e', from: A.id, to: B.id, toLon: B.lon, toLat: B.lat, cost: cost_AB
+  ensure(tileKey(A.lon, A.lat)).edges.push({
+    from: A.id, to: B.id, toLon: B.lon, toLat: B.lat, cost
   });
-  push(tileKey(B.lon, B.lat), {
-    t: 'e', from: B.id, to: A.id, toLon: A.lon, toLat: A.lat, cost: cost_AB
+  ensure(tileKey(B.lon, B.lat)).edges.push({
+    from: B.id, to: A.id, toLon: A.lon, toLat: A.lat, cost
   });
-  push(tileKey(B.lon, B.lat), {
-    t: 'e', from: B.id, to: C.id, toLon: C.lon, toLat: C.lat, cost: cost_BC
+  ensure(tileKey(B.lon, B.lat)).edges.push({
+    from: B.id, to: C.id, toLon: C.lon, toLat: C.lat, cost
   });
-  push(tileKey(C.lon, C.lat), {
-    t: 'e', from: C.id, to: B.id, toLon: B.lon, toLat: B.lat, cost: cost_BC
+  ensure(tileKey(C.lon, C.lat)).edges.push({
+    from: C.id, to: B.id, toLon: B.lon, toLat: B.lat, cost
   });
   const data = {};
-  for (const [key, items] of Object.entries(tiles)) {
-    data[key] = items.map((i) => JSON.stringify(i)).join('\n') + '\n';
+  for (const [key, { nodes, edges }] of Object.entries(tiles)) {
+    data[key] = encodeTile(nodes, edges);
   }
   return data;
 }
@@ -55,7 +53,8 @@ test('TiledRouter: 隣接タイル跨ぎ A→C を解ける', async () => {
   const router = new TiledRouter(loader);
   const r = await router.route(135.501, 34.701, 135.601, 34.701);
   assert.equal(r.error, undefined);
-  assert.equal(r.distance_cost, 10000);
+  // Float32 → cost 比較は近似
+  assert.ok(Math.abs(r.distance_cost - 10000) < 1);
   assert.equal(r.node_count, 3);
   assert.equal(r.coordinates.length, 3);
   assert.ok(r.loaded_tiles >= 1);
@@ -64,28 +63,29 @@ test('TiledRouter: 隣接タイル跨ぎ A→C を解ける', async () => {
 test('TiledRouter: 近すぎる点が無いと no_nearby_node_from', async () => {
   const data = buildKansaiSyntheticTiles();
   const loader = new TileLoader(memFetcher(data));
-  // maxSnapMeters=10 で、from は合成データから 1km 以上離れた点 (straight line cap は通る)
   const router = new TiledRouter(loader, { maxSnapMeters: 10 });
   const r = await router.route(135.40, 34.70, 135.55, 34.70);
   assert.equal(r.error, 'no_nearby_node_from');
 });
 
 test('TiledRouter: 同じタイル内の往復', async () => {
-  const data = {};
-  data[tileKey(135.55, 34.70)] = [
-    JSON.stringify({ t: 'n', id: 1, lon: 135.550, lat: 34.700 }),
-    JSON.stringify({ t: 'n', id: 2, lon: 135.555, lat: 34.700 }),
-    JSON.stringify({
-      t: 'e', from: 1, to: 2, toLon: 135.555, toLat: 34.700, cost: 500
-    }),
-    JSON.stringify({
-      t: 'e', from: 2, to: 1, toLon: 135.550, toLat: 34.700, cost: 500
-    })
-  ].join('\n') + '\n';
+  const key = tileKey(135.55, 34.70);
+  const data = {
+    [key]: encodeTile(
+      [
+        { id: 1, lon: 135.550, lat: 34.700 },
+        { id: 2, lon: 135.555, lat: 34.700 }
+      ],
+      [
+        { from: 1, to: 2, toLon: 135.555, toLat: 34.700, cost: 500 },
+        { from: 2, to: 1, toLon: 135.550, toLat: 34.700, cost: 500 }
+      ]
+    )
+  };
   const loader = new TileLoader(memFetcher(data));
   const router = new TiledRouter(loader);
   const r = await router.route(135.550, 34.700, 135.555, 34.700);
-  assert.equal(r.distance_cost, 500);
+  assert.ok(Math.abs(r.distance_cost - 500) < 0.1);
 });
 
 test('bidiDijkstraOnView: 単純な view で動作する', () => {
@@ -114,8 +114,6 @@ test('TiledRouter: タイル読み込みは corridor 範囲内のキーで loadM
   });
   const router = new TiledRouter(loader, { corridorPadding: 0, snapNeighborhoodRadius: 0 });
   await router.route(135.501, 34.701, 135.601, 34.701);
-  // corridor: from タイル + to タイルの間 (padding=0) → 3 タイル
-  // それぞれ 1 回ずつ fetch
   const distinct = new Set(requested);
   assert.ok(distinct.size >= 3, `expected at least 3 distinct fetches, got ${distinct.size}`);
 });


### PR DESCRIPTION
## Summary
- 各タイルを独自バイナリ v1 形式に変更。関西タイル合計 2.8GB → 547MB (~5x 縮小)、Worker 側 JSON.parse のコストも削減
- 仕様: header 16B + node 16B (Float64 id + Float32 lon/lat) + edge 28B (Float64 from/to + Float32 toLon/toLat/cost)
- \`kind\` フィールドは routing に未使用なので削除済 (cost_m に内包済)

## 変更
- 新規 \`lib/cycling/tile_binary.js\` で encodeTile/decodeTile
- \`tile_loader.js\` fetcher を arrayBuffer に変更 (R2 obj.arrayBuffer(), Buffer → ArrayBuffer)
- \`scripts/cycling_tile_split.js\` を per-tile バッファ + encodeTile 一括書きに変更 (count を事前に必要なため)
- tile_index.json に \`format: \"binary-v1\"\` を追記
- 既存テスト 2 件を binary fixture に更新 + 新規 9 件追加

## 実機
- 関西 1482 タイル (547MB) を R2 投入済
- \`npm test\` 239 → 249 件 (+10, 全パス)

## Test plan
- [ ] CI: unit-tests / dependency-review / Workers Builds
- [ ] /api/route 動作確認 (前 PR と同等のレイテンシ or 改善)