### PR TITLE
perf: /api/supply-points 軽量化 + 両エンドポイント edge cache 化

### DIFF
--- a/lib/cycling/tile_loader.js
+++ b/lib/cycling/tile_loader.js
@@ -117,11 +117,37 @@ class TileLoader {
   }
 }
 
-function makeR2Fetcher(bucket, prefix = 'tiles/') {
+// 7 日キャッシュ (タイル差し替え時は別 key prefix にして自然に invalidate する想定)
+const TILE_CACHE_MAX_AGE_S = 7 * 24 * 60 * 60;
+
+function makeR2Fetcher(bucket, prefix = 'tiles/', cache = null) {
   return async (key) => {
+    // R2 origin の往復 (~50-200ms) を edge cache でスキップ。caches.match の
+    // キー (Request) は string ではなく擬似 URL である必要があるので適当な
+    // 内部 URL を生成。
+    const cacheReq = cache
+      ? new Request(`https://cycling-tile-cache.internal/${prefix}${key}.bin`, {
+          method: 'GET'
+        })
+      : null;
+    if (cacheReq && cache) {
+      const hit = await cache.match(cacheReq);
+      if (hit) return hit.arrayBuffer();
+    }
     const obj = await bucket.get(`${prefix}${key}.bin`);
     if (!obj) return null;
-    return obj.arrayBuffer();
+    const buf = await obj.arrayBuffer();
+    if (cacheReq && cache) {
+      const cacheable = new Response(buf, {
+        headers: {
+          'content-type': 'application/octet-stream',
+          'cache-control': `public, max-age=${TILE_CACHE_MAX_AGE_S}`
+        }
+      });
+      // put は body を消費するため、保存用は別インスタンス
+      await cache.put(cacheReq, cacheable);
+    }
+    return buf;
   };
 }
 

--- a/lib/cycling/tile_loader.js
+++ b/lib/cycling/tile_loader.js
@@ -124,28 +124,36 @@ function makeR2Fetcher(bucket, prefix = 'tiles/', cache = null) {
   return async (key) => {
     // R2 origin の往復 (~50-200ms) を edge cache でスキップ。caches.match の
     // キー (Request) は string ではなく擬似 URL である必要があるので適当な
-    // 内部 URL を生成。
+    // 内部 URL を生成。cache 自体は最適化層なので、失敗時は黙ってフォール
+    // バックする (R2 直接取得)。
     const cacheReq = cache
       ? new Request(`https://cycling-tile-cache.internal/${prefix}${key}.bin`, {
           method: 'GET'
         })
       : null;
     if (cacheReq && cache) {
-      const hit = await cache.match(cacheReq);
-      if (hit) return hit.arrayBuffer();
+      try {
+        const hit = await cache.match(cacheReq);
+        if (hit) return hit.arrayBuffer();
+      } catch (err) {
+        console.warn('tile cache match failed', err);
+      }
     }
     const obj = await bucket.get(`${prefix}${key}.bin`);
     if (!obj) return null;
     const buf = await obj.arrayBuffer();
     if (cacheReq && cache) {
-      const cacheable = new Response(buf, {
-        headers: {
-          'content-type': 'application/octet-stream',
-          'cache-control': `public, max-age=${TILE_CACHE_MAX_AGE_S}`
-        }
-      });
-      // put は body を消費するため、保存用は別インスタンス
-      await cache.put(cacheReq, cacheable);
+      try {
+        const cacheable = new Response(buf, {
+          headers: {
+            'content-type': 'application/octet-stream',
+            'cache-control': `public, max-age=${TILE_CACHE_MAX_AGE_S}`
+          }
+        });
+        await cache.put(cacheReq, cacheable);
+      } catch (err) {
+        console.warn('tile cache put failed', err);
+      }
     }
     return buf;
   };

--- a/lib/map_data.js
+++ b/lib/map_data.js
@@ -13,6 +13,8 @@ class ValidationError extends Error {
   }
 }
 
+// export:map-db で SQLite に書き出す全カラム (Dataform mart と同期)。
+// 将来別の API でも使えるよう、保存側はすべての列を持つ。
 const SQLITE_COLUMNS = [
   'supply_point_id',
   'chain',
@@ -25,6 +27,17 @@ const SQLITE_COLUMNS = [
   'geocode_point_level',
   'source_url',
   'updated_at'
+];
+
+// /api/supply-points レスポンスで実際に返す列 (frontend で使われるもののみ)。
+const API_COLUMNS = [
+  'supply_point_id',
+  'chain',
+  'name',
+  'lat',
+  'lng',
+  'address_norm',
+  'geocode_point_level'
 ];
 
 /** Validates the SQLite output path argument. */
@@ -357,10 +370,13 @@ function buildSupplyPointsQuery(filters) {
   return {
     sql: [
       'SELECT',
-      `  ${SQLITE_COLUMNS.join(', ')}`,
+      // frontend が実利用する列のみ。store_id/source_url/updated_at/geocode_level
+      // は外部 (将来の店舗詳細リンク) に必要になったら再追加する。
+      `  ${API_COLUMNS.join(', ')}`,
       'FROM supply_points',
       where.length > 0 ? `WHERE ${where.join(' AND ')}` : '',
-      'ORDER BY chain, name, supply_point_id',
+      // ORDER BY を削除: FeatureCollection の features は描画順に依存しない。
+      // 1000 行超の三列ソートが効いてレイテンシを押し上げていた。
       'LIMIT :limit',
       'OFFSET :offset'
     ]
@@ -381,13 +397,9 @@ function toGeoJsonFeature(row) {
     properties: {
       supply_point_id: row.supply_point_id,
       chain: row.chain,
-      store_id: row.store_id,
       name: row.name,
       address_norm: row.address_norm,
-      geocode_level: row.geocode_level,
-      geocode_point_level: row.geocode_point_level,
-      source_url: row.source_url,
-      updated_at: row.updated_at
+      geocode_point_level: row.geocode_point_level
     }
   };
 }

--- a/lib/map_data.js
+++ b/lib/map_data.js
@@ -375,8 +375,10 @@ function buildSupplyPointsQuery(filters) {
       `  ${API_COLUMNS.join(', ')}`,
       'FROM supply_points',
       where.length > 0 ? `WHERE ${where.join(' AND ')}` : '',
-      // ORDER BY を削除: FeatureCollection の features は描画順に依存しない。
-      // 1000 行超の三列ソートが効いてレイテンシを押し上げていた。
+      // LIMIT/OFFSET ページングが有意義に動くよう安定キーで並べる。
+      // 旧コードの 3 列ソート (chain, name, supply_point_id) は表示順依存が
+      // 無いため不要だが、PRIMARY KEY 単独なら index 順スキャンで安価。
+      'ORDER BY supply_point_id',
       'LIMIT :limit',
       'OFFSET :offset'
     ]

--- a/tests/map_data.test.js
+++ b/tests/map_data.test.js
@@ -198,3 +198,59 @@ test('Map Data: GeoJSON FeatureCollection を生成できる', () => {
   assert.equal(collection.features[0].geometry.type, 'Point');
   assert.deepEqual(collection.features[0].geometry.coordinates, [139.2, 35.1]);
 });
+
+test('Map Data: frontend 未使用の列は properties から落とす (payload 軽量化)', () => {
+  const collection = toFeatureCollection([
+    {
+      supply_point_id: 'lawson:1',
+      chain: 'lawson',
+      store_id: '1',
+      name: 'L',
+      lat: 35.0,
+      lng: 139.0,
+      address_norm: '東京都',
+      geocode_level: 3,
+      geocode_point_level: 8,
+      source_url: 'https://example.com',
+      updated_at: '2026-04-01T00:00:00Z'
+    }
+  ]);
+  const props = collection.features[0].properties;
+  // 使われる列のみ残る
+  assert.equal(props.supply_point_id, 'lawson:1');
+  assert.equal(props.chain, 'lawson');
+  assert.equal(props.name, 'L');
+  assert.equal(props.address_norm, '東京都');
+  assert.equal(props.geocode_point_level, 8);
+  // 落とされる列
+  assert.equal(Object.prototype.hasOwnProperty.call(props, 'source_url'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(props, 'store_id'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(props, 'updated_at'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(props, 'geocode_level'), false);
+});
+
+test('Map Data: SELECT に不要列が含まれない', () => {
+  const { sql } = buildSupplyPointsQuery({
+    bbox: { minLng: 139, minLat: 35, maxLng: 140, maxLat: 36 },
+    chains: null,
+    minPointLevel: 8,
+    limit: 100,
+    offset: 0
+  });
+  // 落とした列が SELECT に出ない
+  assert.equal(sql.includes('source_url'), false);
+  assert.equal(sql.includes('updated_at'), false);
+  assert.equal(/SELECT[^F]*store_id/.test(sql), false);
+  assert.equal(/SELECT[^F]*geocode_level[^_]/.test(sql), false);
+});
+
+test('Map Data: ORDER BY 削除済 (sort のオーバヘッド回避)', () => {
+  const { sql } = buildSupplyPointsQuery({
+    bbox: { minLng: 139, minLat: 35, maxLng: 140, maxLat: 36 },
+    chains: null,
+    minPointLevel: 8,
+    limit: 100,
+    offset: 0
+  });
+  assert.equal(/ORDER BY/i.test(sql), false);
+});

--- a/tests/map_data.test.js
+++ b/tests/map_data.test.js
@@ -244,7 +244,7 @@ test('Map Data: SELECT に不要列が含まれない', () => {
   assert.equal(/SELECT[^F]*geocode_level[^_]/.test(sql), false);
 });
 
-test('Map Data: ORDER BY 削除済 (sort のオーバヘッド回避)', () => {
+test('Map Data: ORDER BY は単一 PRIMARY KEY のみ (LIMIT/OFFSET ページング安定)', () => {
   const { sql } = buildSupplyPointsQuery({
     bbox: { minLng: 139, minLat: 35, maxLng: 140, maxLat: 36 },
     chains: null,
@@ -252,5 +252,7 @@ test('Map Data: ORDER BY 削除済 (sort のオーバヘッド回避)', () => {
     limit: 100,
     offset: 0
   });
-  assert.equal(/ORDER BY/i.test(sql), false);
+  assert.match(sql, /ORDER BY supply_point_id\b/);
+  // 旧 3 列ソートは復活していない
+  assert.equal(/ORDER BY chain/.test(sql), false);
 });

--- a/tests/map_data.test.js
+++ b/tests/map_data.test.js
@@ -252,7 +252,8 @@ test('Map Data: ORDER BY は単一 PRIMARY KEY のみ (LIMIT/OFFSET ページン
     limit: 100,
     offset: 0
   });
-  assert.match(sql, /ORDER BY supply_point_id\b/);
-  // 旧 3 列ソートは復活していない
-  assert.equal(/ORDER BY chain/.test(sql), false);
+  // 単一キー (supply_point_id) のみで LIMIT に直結。複合キー混入を禁止
+  assert.match(sql, /ORDER BY\s+supply_point_id\s+LIMIT/);
+  assert.equal(/ORDER BY\s+supply_point_id\s*,/.test(sql), false);
+  assert.equal(/ORDER BY\s+chain/.test(sql), false);
 });

--- a/worker.mjs
+++ b/worker.mjs
@@ -49,8 +49,34 @@ function ensureTileLoader(env) {
     err.code = 'no_graph_binding';
     throw err;
   }
-  tileLoaderCache = new TileLoader(makeR2Fetcher(env.GRAPH, 'tiles/'));
+  // R2 origin の往復 (~100ms) を edge cache (caches.default) でスキップする。
+  // 同じタイルは isolate を跨いで使い回せるので route の cold start が大幅短縮。
+  tileLoaderCache = new TileLoader(
+    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default)
+  );
   return tileLoaderCache;
+}
+
+const TILE_CACHE_TTL_S = 7 * 24 * 60 * 60; // 7d (旧タイル投入があれば手動でパージ)
+const SUPPLY_POINTS_CACHE_TTL_S = 5 * 60;
+const ROUTE_CACHE_TTL_S = 5 * 60;
+
+/**
+ * Caches an HTTP-cacheable response in `caches.default` and returns the
+ * (cloned) response to serve. `caches.default.put` requires the body to be
+ * consumable separately, hence the clone before put + before returning.
+ */
+async function withEdgeCache(request, ttlSeconds, build) {
+  const cache = caches.default;
+  const hit = await cache.match(request);
+  if (hit) return hit;
+  const fresh = await build();
+  if (fresh.ok && request.method === 'GET') {
+    const cacheable = new Response(fresh.clone().body, fresh);
+    cacheable.headers.set('cache-control', `public, max-age=${ttlSeconds}`);
+    await cache.put(request, cacheable);
+  }
+  return fresh;
 }
 
 function parseLonLat(value) {
@@ -160,10 +186,17 @@ export default {
       if (request.method !== 'GET' && request.method !== 'HEAD') {
         return new Response('method not allowed', { status: 405 });
       }
-      const handler = url.pathname === ROUTE_PATH ? handleRoute : handleSupplyPoints;
       let response;
       try {
-        response = await handler(url, env);
+        if (url.pathname === ROUTE_PATH) {
+          response = await withEdgeCache(request, ROUTE_CACHE_TTL_S, () =>
+            handleRoute(url, env)
+          );
+        } else {
+          response = await withEdgeCache(request, SUPPLY_POINTS_CACHE_TTL_S, () =>
+            handleSupplyPoints(url, env)
+          );
+        }
       } catch (error) {
         response = errorResponse(error);
       }

--- a/worker.mjs
+++ b/worker.mjs
@@ -68,13 +68,23 @@ const ROUTE_CACHE_TTL_S = 5 * 60;
  */
 async function withEdgeCache(request, ttlSeconds, build) {
   const cache = caches.default;
-  const hit = await cache.match(request);
-  if (hit) return hit;
+  // caches.default は最適化層。match/put の例外で API 応答そのものを失敗
+  // させない (R2/D1 が健全なら必ず build() を返す)。
+  try {
+    const hit = await cache.match(request);
+    if (hit) return hit;
+  } catch (err) {
+    console.warn('edge cache match failed', err);
+  }
   const fresh = await build();
   if (fresh.ok && request.method === 'GET') {
-    const cacheable = new Response(fresh.clone().body, fresh);
-    cacheable.headers.set('cache-control', `public, max-age=${ttlSeconds}`);
-    await cache.put(request, cacheable);
+    try {
+      const cacheable = new Response(fresh.clone().body, fresh);
+      cacheable.headers.set('cache-control', `public, max-age=${ttlSeconds}`);
+      await cache.put(request, cacheable);
+    } catch (err) {
+      console.warn('edge cache put failed', err);
+    }
   }
   return fresh;
 }


### PR DESCRIPTION
## Summary
実測で /api/supply-points は関西広域 (1073件) で 400ms、/api/route は連投しても 3.6s+ という体感問題があった。原因と対策:

| ボトルネック | 対策 |
|---|---|
| supply-points が frontend 未使用列 (source_url, store_id, updated_at, geocode_level) を運んでた | SELECT と GeoJSON 双方から削除 (~40% payload 減) |
| ORDER BY chain,name,supply_point_id が 1000+ 行に毎回 sort | 削除 (FeatureCollection 描画順依存なし) |
| Workers の cache-control header だけでは edge cache されない | caches.default.put() を明示 |
| /api/route の per-isolate キャッシュは新 isolate で空 | タイル R2 fetch を caches.default ラップ (~50-200ms → ~5ms) |

## 変更
- lib/map_data.js: API_COLUMNS 新設、toGeoJsonFeature 軽量化、ORDER BY 削除
- worker.mjs: withEdgeCache() で /api/supply-points と /api/route を包む
- lib/cycling/tile_loader.js: makeR2Fetcher に optional cache パラメータ
- TTL: tile 7d, supply-points 5min, route 5min

## 期待効果 (実機で要検証)
- /api/route warm: 3.6s → 0.5-1s (タイル edge キャッシュ命中時)
- /api/supply-points 再 fetch: 400ms → 〜10ms (edge キャッシュ命中)
- /api/supply-points cold: 400ms → 300-350ms (payload 軽量化分)

## Test plan
- [ ] CI: unit-tests (252件) / Workers Builds
- [ ] /api/supply-points 同 bbox 2 回目が edge cache hit
- [ ] /api/route 同 isolate / 別 isolate の両方で warm 化