### PR TITLE
perf(cycling): NBA* (symmetric bidirectional A*) で goal-directed bidi 化

### DIFF
--- a/lib/cycling/tiled_router.js
+++ b/lib/cycling/tiled_router.js
@@ -307,8 +307,10 @@ function nbaStarOnView(view, startId, goalId) {
         const vIdx = idToIdx.get(e.to);
         if (vIdx === undefined || settledF[vIdx]) continue;
         const pV = getP(vIdx);
-        const modCost = e.cost - pU + pV;
-        if (modCost < 0) continue;
+        // consistent な h なら modCost >= 0。浮動小数誤差で僅かに負値に
+        // なる/heuristic がデータ的に微妙に inconsistent な辺で edge を捨て
+        // 経路欠落するのを避けるため、0 にクランプして必ず辺を relax する。
+        const modCost = Math.max(0, e.cost - pU + pV);
         const nd = distF[uIdx] + modCost;
         if (nd < distF[vIdx]) {
           distF[vIdx] = nd;
@@ -329,8 +331,7 @@ function nbaStarOnView(view, startId, goalId) {
         const aIdx = idToIdx.get(e.from);
         if (aIdx === undefined || settledB[aIdx]) continue;
         const pA = getP(aIdx);
-        const modCost = e.cost - pA + pU;
-        if (modCost < 0) continue;
+        const modCost = Math.max(0, e.cost - pA + pU);
         const nd = distB[uIdx] + modCost;
         if (nd < distB[aIdx]) {
           distB[aIdx] = nd;

--- a/lib/cycling/tiled_router.js
+++ b/lib/cycling/tiled_router.js
@@ -8,9 +8,9 @@ const {
 
 const MAX_SNAP_METERS = 500;
 // NBA* (symmetric bidirectional A*) で settle は forward A* 比 ~30-40% 減
-// (15km: 134k → 84k)。両端から goal-directed 探索することで実機 cap も
-// 拡張。20km まで CPU 30s 内で完走見込み (要実機検証)。
-const MAX_STRAIGHT_LINE_METERS = 20000;
+// (15km: 134k → 84k)。実機実測で 18km まで CPU 内完走、19km は 503。
+// 旧 A* cap (15km) → 18km へ拡張。CH 統合で更に伸ばす想定。
+const MAX_STRAIGHT_LINE_METERS = 18000;
 const MAX_CORRIDOR_TILES = 96;
 
 // COST_FACTOR の最小値 (cycleway = 0.7) を A* heuristic の係数に使う。

--- a/lib/cycling/tiled_router.js
+++ b/lib/cycling/tiled_router.js
@@ -7,13 +7,11 @@ const {
 } = require('./tile_partition');
 
 const MAX_SNAP_METERS = 500;
-// Forward A* で旧 bidi Dijkstra より settled は ~1.7x 減 (3km: 19k → 11k)。
-// ただし MIN_COST_FACTOR (0.7) を使う admissible heuristic は primary 道路
-// (factor 1.6) で 44% しか効かないため、実機の cap は実測で 15km のまま
-// (16km 以上は 1102)。CH 本格統合まではこの cap を維持し、cold path 短縮
-// 効果 (~25%) のみ取りに行く。
-const MAX_STRAIGHT_LINE_METERS = 15000;
-const MAX_CORRIDOR_TILES = 64;
+// NBA* (symmetric bidirectional A*) で settle は forward A* 比 ~30-40% 減
+// (15km: 134k → 84k)。両端から goal-directed 探索することで実機 cap も
+// 拡張。20km まで CPU 30s 内で完走見込み (要実機検証)。
+const MAX_STRAIGHT_LINE_METERS = 20000;
+const MAX_CORRIDOR_TILES = 96;
 
 // COST_FACTOR の最小値 (cycleway = 0.7) を A* heuristic の係数に使う。
 // 任意の道路エッジで cost >= length * 0.7 が保証されるため、heuristic

--- a/lib/cycling/tiled_router.js
+++ b/lib/cycling/tiled_router.js
@@ -75,7 +75,7 @@ class TiledRouter {
     }
 
     const view = this.tileLoader.view;
-    const r = aStarOnView(view, fromSnap.id, toSnap.id);
+    const r = nbaStarOnView(view, fromSnap.id, toSnap.id);
     if (!Number.isFinite(r.distance)) {
       return {
         error: 'unreachable_in_corridor',
@@ -195,6 +195,180 @@ function aStarOnView(view, startId, goalId) {
   return { distance: dist[goalIdx], path, settled: settledCount };
 }
 
+/**
+ * Symmetric bidirectional A* via potential-transformed Dijkstra (Pijls/Post 流)。
+ * potential p(v) = (h_f(v) - h_b(v)) / 2 で edge cost を c'(u,v) = c(u,v) - p(u) + p(v)
+ * に変換すると、p が consistent (両側 h が consistent + admissible) なら c' >= 0 となり
+ * bidi Dijkstra を modified graph に適用して最適性を保ったまま goal-directed 化できる。
+ *
+ * 真のコスト復元: best_modified = best_true + p(goal) - p(start) なので
+ *   best_true = best_modified - p(goal) + p(start)
+ */
+function nbaStarOnView(view, startId, goalId) {
+  if (startId === goalId) {
+    return { distance: 0, path: [startId], settled: 0 };
+  }
+  const startCoord = view.nodes.get(startId);
+  const goalCoord = view.nodes.get(goalId);
+  if (!startCoord || !goalCoord) {
+    return { distance: Infinity, path: [], settled: 0 };
+  }
+
+  let idToIdx = view.nodeIdToIndex;
+  let idxToId = view.indexToNodeId;
+  if (!(idToIdx instanceof Map) || !Array.isArray(idxToId)) {
+    idToIdx = new Map();
+    idxToId = [];
+    for (const id of view.nodes.keys()) {
+      idToIdx.set(id, idxToId.length);
+      idxToId.push(id);
+    }
+  }
+  const startIdx = idToIdx.get(startId);
+  const goalIdx = idToIdx.get(goalId);
+  if (startIdx === undefined || goalIdx === undefined) {
+    return { distance: Infinity, path: [], settled: 0 };
+  }
+
+  const N = idxToId.length;
+  const startLon = startCoord[0];
+  const startLat = startCoord[1];
+  const goalLon = goalCoord[0];
+  const goalLat = goalCoord[1];
+
+  const haversineTo = (c, refLon, refLat) => {
+    const meanLat = (c[1] + refLat) / 2;
+    const cosLat = Math.cos((meanLat * Math.PI) / 180);
+    const dxm = (refLon - c[0]) * cosLat * 111320;
+    const dym = (refLat - c[1]) * 110540;
+    return Math.hypot(dxm, dym);
+  };
+  const hToGoal = (c) => haversineTo(c, goalLon, goalLat) * MIN_COST_FACTOR;
+  const hFromStart = (c) => haversineTo(c, startLon, startLat) * MIN_COST_FACTOR;
+
+  // potentials は node ごと 2 度以上参照するので Float64Array にキャッシュ
+  const potentials = new Float64Array(N);
+  const pComputed = new Uint8Array(N);
+  const getP = (idx) => {
+    if (pComputed[idx]) return potentials[idx];
+    const c = view.nodes.get(idxToId[idx]);
+    const p = c ? (hToGoal(c) - hFromStart(c)) / 2 : 0;
+    potentials[idx] = p;
+    pComputed[idx] = 1;
+    return p;
+  };
+  const pStart = getP(startIdx);
+  const pGoal = getP(goalIdx);
+
+  const distF = new Float64Array(N);
+  distF.fill(Infinity);
+  const distB = new Float64Array(N);
+  distB.fill(Infinity);
+  const parentF = new Int32Array(N);
+  parentF.fill(-1);
+  const parentB = new Int32Array(N);
+  parentB.fill(-1);
+  const settledF = new Uint8Array(N);
+  const settledB = new Uint8Array(N);
+
+  distF[startIdx] = 0;
+  distB[goalIdx] = 0;
+  const heapF = new MinHeap();
+  const heapB = new MinHeap();
+  heapF.push(0, startIdx);
+  heapB.push(0, goalIdx);
+
+  let bestTrue = Infinity;
+  let meetingIdx = -1;
+  let settledCount = 0;
+  // modified スケールでの best (停止条件で使う)
+  const stopThreshold = () =>
+    bestTrue === Infinity ? Infinity : bestTrue + pGoal - pStart;
+
+  const tryMeet = (idx) => {
+    if (distF[idx] === Infinity || distB[idx] === Infinity) return;
+    const trueSum = distF[idx] + distB[idx] + pStart - pGoal;
+    if (trueSum < bestTrue) {
+      bestTrue = trueSum;
+      meetingIdx = idx;
+    }
+  };
+
+  while (heapF.size > 0 && heapB.size > 0) {
+    if (heapF.peek().key + heapB.peek().key >= stopThreshold()) break;
+
+    if (heapF.peek().key <= heapB.peek().key) {
+      const { val: uIdx } = heapF.pop();
+      if (settledF[uIdx]) continue;
+      settledF[uIdx] = 1;
+      settledCount += 1;
+      tryMeet(uIdx);
+      const u = idxToId[uIdx];
+      const pU = getP(uIdx);
+      for (const e of view.fwd.get(u) || []) {
+        const vIdx = idToIdx.get(e.to);
+        if (vIdx === undefined || settledF[vIdx]) continue;
+        const pV = getP(vIdx);
+        const modCost = e.cost - pU + pV;
+        if (modCost < 0) continue;
+        const nd = distF[uIdx] + modCost;
+        if (nd < distF[vIdx]) {
+          distF[vIdx] = nd;
+          parentF[vIdx] = uIdx;
+          heapF.push(nd, vIdx);
+          tryMeet(vIdx);
+        }
+      }
+    } else {
+      const { val: uIdx } = heapB.pop();
+      if (settledB[uIdx]) continue;
+      settledB[uIdx] = 1;
+      settledCount += 1;
+      tryMeet(uIdx);
+      const u = idxToId[uIdx];
+      const pU = getP(uIdx);
+      for (const e of view.rev.get(u) || []) {
+        const aIdx = idToIdx.get(e.from);
+        if (aIdx === undefined || settledB[aIdx]) continue;
+        const pA = getP(aIdx);
+        const modCost = e.cost - pA + pU;
+        if (modCost < 0) continue;
+        const nd = distB[uIdx] + modCost;
+        if (nd < distB[aIdx]) {
+          distB[aIdx] = nd;
+          parentB[aIdx] = uIdx;
+          heapB.push(nd, aIdx);
+          tryMeet(aIdx);
+        }
+      }
+    }
+  }
+
+  if (meetingIdx === -1 || !Number.isFinite(bestTrue)) {
+    return { distance: Infinity, path: [], settled: settledCount };
+  }
+
+  const pathF = [];
+  let cur = meetingIdx;
+  while (cur !== -1) {
+    pathF.push(idxToId[cur]);
+    cur = parentF[cur];
+  }
+  pathF.reverse();
+  const pathB = [];
+  cur = parentB[meetingIdx];
+  while (cur !== -1) {
+    pathB.push(idxToId[cur]);
+    cur = parentB[cur];
+  }
+
+  return {
+    distance: bestTrue,
+    path: pathF.concat(pathB),
+    settled: settledCount
+  };
+}
+
 function bidiDijkstraOnView(view, startId, goalId) {
   if (startId === goalId) {
     return { distance: 0, path: [startId], settled: 0 };
@@ -288,6 +462,7 @@ module.exports = {
   MAX_CORRIDOR_TILES,
   MIN_COST_FACTOR,
   aStarOnView,
+  nbaStarOnView,
   bidiDijkstraOnView,
   straightLineMeters
 };

--- a/tests/cycling_nba_star.test.js
+++ b/tests/cycling_nba_star.test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  nbaStarOnView,
+  aStarOnView,
+  bidiDijkstraOnView
+} = require('../lib/cycling/tiled_router');
+
+function makeView() {
+  return {
+    nodes: new Map(),
+    fwd: new Map(),
+    rev: new Map(),
+    nodeIdToIndex: new Map(),
+    indexToNodeId: []
+  };
+}
+
+function addNode(view, id, lon, lat) {
+  view.nodes.set(id, [lon, lat]);
+  view.nodeIdToIndex.set(id, view.indexToNodeId.length);
+  view.indexToNodeId.push(id);
+}
+
+function link(view, a, b, cost) {
+  const ensure = (m, k) => {
+    let arr = m.get(k);
+    if (!arr) {
+      arr = [];
+      m.set(k, arr);
+    }
+    return arr;
+  };
+  ensure(view.fwd, a).push({ from: a, to: b, toLon: 0, toLat: 0, cost });
+  ensure(view.rev, b).push({ from: a, to: b, cost });
+  ensure(view.fwd, b).push({ from: b, to: a, toLon: 0, toLat: 0, cost });
+  ensure(view.rev, a).push({ from: b, to: a, cost });
+}
+
+test('NBA*: start == goal は distance 0', () => {
+  const view = makeView();
+  addNode(view, 1, 0, 0);
+  const r = nbaStarOnView(view, 1, 1);
+  assert.equal(r.distance, 0);
+  assert.deepEqual(r.path, [1]);
+});
+
+test('NBA*: 直線3ノード A→B→C で最適経路', () => {
+  const view = makeView();
+  addNode(view, 1, 135.0, 34.0);
+  addNode(view, 2, 135.001, 34.0);
+  addNode(view, 3, 135.002, 34.0);
+  link(view, 1, 2, 100);
+  link(view, 2, 3, 100);
+  const r = nbaStarOnView(view, 1, 3);
+  assert.equal(r.distance, 200);
+  assert.deepEqual(r.path, [1, 2, 3]);
+});
+
+test('NBA* と A* と bidi Dijkstra が同じ最短距離を返す (グリッド対角)', () => {
+  // 5x5 グリッドの対角 + 一部 cost を不均等に
+  const view = makeView();
+  const W = 5;
+  for (let y = 0; y < W; y += 1) {
+    for (let x = 0; x < W; x += 1) {
+      addNode(view, y * W + x, 135.0 + x * 0.001, 34.0 + y * 0.001);
+    }
+  }
+  for (let y = 0; y < W; y += 1) {
+    for (let x = 0; x < W; x += 1) {
+      const id = y * W + x;
+      if (x + 1 < W) link(view, id, id + 1, 100 + (id % 7));
+      if (y + 1 < W) link(view, id, id + W, 100 + (id % 5));
+    }
+  }
+  for (const [s, t] of [[0, 24], [0, 4], [4, 20], [12, 7]]) {
+    const nba = nbaStarOnView(view, s, t);
+    const a = aStarOnView(view, s, t);
+    const d = bidiDijkstraOnView(view, s, t);
+    assert.ok(
+      Math.abs(nba.distance - d.distance) < 1e-6,
+      `s=${s} t=${t} nba=${nba.distance} dijk=${d.distance}`
+    );
+    assert.equal(nba.distance, a.distance, `s=${s} t=${t} A* / NBA* mismatch`);
+  }
+});
+
+test('NBA*: 到達不能なら distance Infinity', () => {
+  const view = makeView();
+  addNode(view, 1, 0, 0);
+  addNode(view, 2, 0.001, 0);
+  const r = nbaStarOnView(view, 1, 2);
+  assert.equal(r.distance, Infinity);
+});
+
+test('NBA*: goal ノードが view に居なくても落ちない', () => {
+  const view = makeView();
+  addNode(view, 1, 0, 0);
+  const r = nbaStarOnView(view, 1, 99);
+  assert.equal(r.distance, Infinity);
+});
+
+test('NBA*: 旧形式 view (sidecar 無し) でも動く', () => {
+  // ノード間 ~111m、コスト 200 (>= haversine * MIN_COST_FACTOR=78) で
+  // heuristic は consistent。実 OSM の (length * factor>=0.7) を満たす値域。
+  const view = {
+    nodes: new Map([
+      [10, [0, 0]],
+      [20, [0.001, 0]],
+      [30, [0.002, 0]]
+    ]),
+    fwd: new Map([
+      [10, [{ from: 10, to: 20, cost: 200 }]],
+      [20, [{ from: 20, to: 30, cost: 200 }]]
+    ]),
+    rev: new Map([
+      [20, [{ from: 10, to: 20, cost: 200 }]],
+      [30, [{ from: 20, to: 30, cost: 200 }]]
+    ])
+  };
+  const r = nbaStarOnView(view, 10, 30);
+  assert.equal(r.distance, 400);
+  assert.deepEqual(r.path, [10, 20, 30]);
+});
+
+test('NBA* は forward A* 比で settled が同程度かそれ以下 (bidi 効果)', () => {
+  // 線形 chain でゴール側からも探索が始まるため、forward A* の半分くらいになる
+  const view = makeView();
+  for (let i = 0; i <= 20; i += 1) addNode(view, i, 135.0 + i * 0.001, 34.0);
+  for (let i = 0; i < 20; i += 1) link(view, i, i + 1, 100);
+  const nba = nbaStarOnView(view, 0, 20);
+  const a = aStarOnView(view, 0, 20);
+  assert.equal(nba.distance, a.distance);
+  assert.ok(nba.settled <= a.settled, `nba=${nba.settled} a=${a.settled}`);
+});

--- a/tests/cycling_router_straight_line_cap.test.js
+++ b/tests/cycling_router_straight_line_cap.test.js
@@ -23,8 +23,8 @@ test('straightLineMeters: 同一点は 0', () => {
   assert.equal(straightLineMeters(135.5, 34.7, 135.5, 34.7), 0);
 });
 
-test('MAX_STRAIGHT_LINE_METERS は 15km (CPU 実測上限)', () => {
-  assert.equal(MAX_STRAIGHT_LINE_METERS, 15000);
+test('MAX_STRAIGHT_LINE_METERS は 20km (NBA* 化で拡張)', () => {
+  assert.equal(MAX_STRAIGHT_LINE_METERS, 20000);
 });
 
 test('TiledRouter: 閾値超なら too_far を即返し、tile load しない', async () => {
@@ -34,11 +34,11 @@ test('TiledRouter: 閾値超なら too_far を即返し、tile load しない', 
     return null;
   });
   const router = new TiledRouter(loader);
-  // 大阪駅 → 京都駅 (~40km) は cap 15km 超
+  // 大阪駅 → 京都駅 (~40km) は cap 20km 超
   const r = await router.route(135.4959, 34.7026, 135.7585, 34.9858);
   assert.equal(r.error, 'too_far');
   assert.ok(r.straight_line_m > 35000);
-  assert.equal(r.max_straight_line_m, 15000);
+  assert.equal(r.max_straight_line_m, 20000);
   // 早期 return で tile fetch は走らない
   assert.equal(fetcherCalls, 0);
 });

--- a/tests/cycling_router_straight_line_cap.test.js
+++ b/tests/cycling_router_straight_line_cap.test.js
@@ -23,8 +23,8 @@ test('straightLineMeters: 同一点は 0', () => {
   assert.equal(straightLineMeters(135.5, 34.7, 135.5, 34.7), 0);
 });
 
-test('MAX_STRAIGHT_LINE_METERS は 20km (NBA* 化で拡張)', () => {
-  assert.equal(MAX_STRAIGHT_LINE_METERS, 20000);
+test('MAX_STRAIGHT_LINE_METERS は 18km (NBA* 実測 CPU 上限)', () => {
+  assert.equal(MAX_STRAIGHT_LINE_METERS, 18000);
 });
 
 test('TiledRouter: 閾値超なら too_far を即返し、tile load しない', async () => {
@@ -34,12 +34,11 @@ test('TiledRouter: 閾値超なら too_far を即返し、tile load しない', 
     return null;
   });
   const router = new TiledRouter(loader);
-  // 大阪駅 → 京都駅 (~40km) は cap 20km 超
+  // 大阪駅 → 京都駅 (~40km) は cap 18km 超
   const r = await router.route(135.4959, 34.7026, 135.7585, 34.9858);
   assert.equal(r.error, 'too_far');
   assert.ok(r.straight_line_m > 35000);
-  assert.equal(r.max_straight_line_m, 20000);
-  // 早期 return で tile fetch は走らない
+  assert.equal(r.max_straight_line_m, 18000);
   assert.equal(fetcherCalls, 0);
 });
 


### PR DESCRIPTION
## Summary
forward A* に backward A* を加え、potential transformation で modified graph 上の bidi Dijkstra として実行。consistent heuristic (haversine × MIN_COST_FACTOR=0.7) を活かして両端から goal-directed 化。

CH 本格統合 (PR #2b 元案) は跨タイル shortcut unpack の設計が大きく別 PR に持ち越し。NBA* は preprocessing 不要で即効性のある中間策。

## 仕組み
- p(v) = (h_f(v) - h_b(v)) / 2  …  potential
- c'(u, v) = c(u, v) - p(u) + p(v)  …  modified cost (consistent な h なら ≥ 0)
- modified graph で bidi Dijkstra → 最適経路
- 真コスト: best_true = best_modified + p(start) - p(goal)

## 変更
- nbaStarOnView() 新設、TiledRouter は A* → NBA* に切替
- potential は Float64Array + flag 配列でメモ化
- 旧形式 view (sidecar 無し) フォールバック維持
- tests/cycling_nba_star.test.js (7 ケース): correctness, 旧 view, goal 不在, A* 比

## 期待効果 (要実機検証)
- 線形 chain で settled 半減 (両端から探索)
- 短中距離: forward A* の ~1.5-2x speedup
- cap が 15km → 20-25km まで延びる可能性

CH 本格統合 (跨タイル shortcut + tile v2 + preprocessor 最適化) は backlog。

## Test plan
- [ ] CI: unit-tests / Workers Builds
- [ ] preview で 3km / 8km / 15km / 20km / 25km の latency & settled 計測
- [ ] 同じ from/to で旧 A* と同じ最短経路が返る