### PR TITLE
perf(frontend): /api/supply-points bbox を 0.01° grid に量子化

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,11 +1,13 @@
 # mise: dev tool versions for ride-oasis
 #
-# - node 22: matches CI (.github/workflows/unit-tests.yml runs on 22 + 24).
-#   wrangler / @geolonia deps support both; we pin LTS for reproducibility.
-# - rust stable: used by the experimental rust-wasm/ cycling router PoC.
-# - wasm-pack: builds the rust crate to wasm32 for browser/Worker bundling.
+# 再現性のため "stable" / "latest" のチャンネル指定ではなく
+# 固定バージョンで pin する (CodeRabbit 指摘 #64)。
+#
+# - node 22.22.3: CI matrix の Node 22 系最新 (要件 >=22.5.0)
+# - rust 1.94.1:  rust-router/ の wasm32 ビルドに使用
+# - wasm-pack 0.15.0: 同上
 
 [tools]
-node = "22"
-rust = "stable"
-"cargo:wasm-pack" = "latest"
+node = "22.22.3"
+rust = "1.94.1"
+"cargo:wasm-pack" = "0.15.0"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,11 @@
+# mise: dev tool versions for ride-oasis
+#
+# - node 22: matches CI (.github/workflows/unit-tests.yml runs on 22 + 24).
+#   wrangler / @geolonia deps support both; we pin LTS for reproducibility.
+# - rust stable: used by the experimental rust-wasm/ cycling router PoC.
+# - wasm-pack: builds the rust crate to wasm32 for browser/Worker bundling.
+
+[tools]
+node = "22"
+rust = "stable"
+"cargo:wasm-pack" = "latest"

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1622,10 +1622,17 @@ function createRouteFeatureFromCoords(coordinates, elevations = null) {
   };
 }
 
+// /api/supply-points の Worker edge cache (caches.default) はキー = URL なので
+// 微妙に異なる bbox URL ばかりだと cache hit しない。0.01° (~1km) の格子に
+// 量子化することで、同エリアの 2 回目以降は同じ URL になり edge cache 命中。
+// over-fetch 分は post-filter の filterMatchedPoints が距離で削るので影響なし。
+const SUPPLY_POINTS_BBOX_GRID_DEG = 0.01;
+
 /** Expands the route bbox so the API can return nearby candidate points. */
 function expandedBboxForQuery(routeSnapshot, distanceMeters) {
   const routeBbox = window.RouteMath.computeBbox(routeSnapshot);
-  return window.RouteMath.expandBbox(routeBbox, Math.max(distanceMeters, 2000));
+  const padded = window.RouteMath.expandBbox(routeBbox, Math.max(distanceMeters, 2000));
+  return window.RouteMath.quantizeBbox(padded, SUPPLY_POINTS_BBOX_GRID_DEG);
 }
 
 /** Loads candidate supply points from the local API for the current filters. */

--- a/frontend/route_math.js
+++ b/frontend/route_math.js
@@ -110,6 +110,23 @@
     return [minLng, minLat, maxLng, maxLat];
   }
 
+  /**
+   * Snaps a bbox to a grid of `gridDeg` cells so similar routes share the same
+   * bounding box URL. With the Worker's edge cache (caches.default keyed on
+   * URL), this dramatically improves hit rate as the user pans / reloads
+   * routes within the same area, at the cost of a small over-fetch.
+   */
+  function quantizeBbox(bbox, gridDeg) {
+    if (!bbox) return null;
+    const step = Number.isFinite(gridDeg) && gridDeg > 0 ? gridDeg : 0.01;
+    return [
+      Math.floor(bbox[0] / step) * step,
+      Math.floor(bbox[1] / step) * step,
+      Math.ceil(bbox[2] / step) * step,
+      Math.ceil(bbox[3] / step) * step
+    ];
+  }
+
   /** Expands a bbox by a meter padding converted around the route center latitude. */
   function expandBbox(bbox, meters) {
     if (!bbox) return null;
@@ -238,6 +255,7 @@
   return {
     computeBbox,
     expandBbox,
+    quantizeBbox,
     pointToPointDistanceMeters,
     pointToRouteDistanceMeters,
     bearingDegrees,

--- a/frontend/route_math.js
+++ b/frontend/route_math.js
@@ -117,7 +117,17 @@
    * routes within the same area, at the cost of a small over-fetch.
    */
   function quantizeBbox(bbox, gridDeg) {
-    if (!bbox) return null;
+    if (
+      !Array.isArray(bbox) ||
+      bbox.length !== 4 ||
+      !bbox.every(Number.isFinite) ||
+      bbox[0] > bbox[2] ||
+      bbox[1] > bbox[3]
+    ) {
+      // 不正形状 (長さ不正 / NaN / min>max) を null で弾き、不正な
+      // URL クエリの組み立てを防ぐ。
+      return null;
+    }
     const step = Number.isFinite(gridDeg) && gridDeg > 0 ? gridDeg : 0.01;
     return [
       Math.floor(bbox[0] / step) * step,

--- a/tests/route_math.test.js
+++ b/tests/route_math.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const {
   computeBbox,
   expandBbox,
+  quantizeBbox,
   pointToPointDistanceMeters,
   pointToRouteDistanceMeters,
   bearingDegrees,
@@ -260,4 +261,35 @@ test('Route Math: routeProjection は不正な点で null を返す', () => {
   const coords = [[139.0, 35.0], [139.001, 35.0]];
   assert.equal(routeProjection([Number.NaN, 35.0], coords), null);
   assert.equal(routeProjection(null, coords), null);
+});
+
+test('Route Math: quantizeBbox は grid セル境界に揃える', () => {
+  // 0.01° grid 上で min/max が同じセル内に収まる入力
+  const q = quantizeBbox([135.5023, 34.6937, 135.5051, 34.6950], 0.01);
+  assert.deepEqual(q, [135.50, 34.69, 135.51, 34.70]);
+});
+
+test('Route Math: quantizeBbox は粒度を跨ぐ bbox をそれぞれ floor/ceil', () => {
+  const q = quantizeBbox([135.502, 34.693, 135.522, 34.713], 0.01);
+  assert.deepEqual(q, [135.50, 34.69, 135.53, 34.72]);
+});
+
+test('Route Math: quantizeBbox はデフォルト grid 0.01°', () => {
+  const q = quantizeBbox([135.5023, 34.6937, 135.5051, 34.6950]);
+  // 浮動小数誤差を許容
+  assert.ok(Math.abs(q[0] - 135.50) < 1e-9);
+  assert.ok(Math.abs(q[1] - 34.69) < 1e-9);
+  assert.ok(Math.abs(q[2] - 135.51) < 1e-9);
+  assert.ok(Math.abs(q[3] - 34.70) < 1e-9);
+});
+
+test('Route Math: quantizeBbox(null) は null', () => {
+  assert.equal(quantizeBbox(null, 0.01), null);
+});
+
+test('Route Math: 隣接の似たエリアは quantize 後に同じ bbox になる (cache hit 期待)', () => {
+  // 同じ ~1km セル内の 2 つの異なる詳細 bbox は同じ量子化結果を返す
+  const a = quantizeBbox([135.502, 34.693, 135.504, 34.695], 0.01);
+  const b = quantizeBbox([135.503, 34.694, 135.505, 34.696], 0.01);
+  assert.deepEqual(a, b);
 });

--- a/tests/route_math.test.js
+++ b/tests/route_math.test.js
@@ -287,6 +287,16 @@ test('Route Math: quantizeBbox(null) は null', () => {
   assert.equal(quantizeBbox(null, 0.01), null);
 });
 
+test('Route Math: quantizeBbox は不正形状を null で弾く', () => {
+  // 長さ不正
+  assert.equal(quantizeBbox([135, 34, 136], 0.01), null);
+  // NaN 含む
+  assert.equal(quantizeBbox([135, NaN, 136, 35], 0.01), null);
+  // min>max 逆転
+  assert.equal(quantizeBbox([136, 34, 135, 35], 0.01), null);
+  assert.equal(quantizeBbox([135, 35, 136, 34], 0.01), null);
+});
+
 test('Route Math: 隣接の似たエリアは quantize 後に同じ bbox になる (cache hit 期待)', () => {
   // 同じ ~1km セル内の 2 つの異なる詳細 bbox は同じ量子化結果を返す
   const a = quantizeBbox([135.502, 34.693, 135.504, 34.695], 0.01);


### PR DESCRIPTION
## Summary
Worker の caches.default (PR #60) はキー = URL なので、route ごとに微妙に異なる bbox URL だと edge cache がほぼヒットしない。0.01° (~1km) grid に量子化することで、同エリアの 2 回目以降が edge cache 命中で ~5-10ms に。

## 変更
- frontend/route_math.js: quantizeBbox() 新設 (min floor / max ceil)
- frontend/app.js: expandedBboxForQuery で expand 後に quantize
- over-fetch 分は post-filter (filterMatchedPoints) で削るので結果に影響なし
- tests 5 ケース追加

## おまけ
.mise.toml で Node 22 / Rust stable / wasm-pack を pin。Rust WASM 実験用ブランチで使う前提環境。

## 期待効果
- 同エリア再 fetch: 数百 ms → 〜5-10ms
- 過剰 fetch は意図された (cache 効率) ので問題なし

## Test plan
- [ ] CI: unit-tests 265 件
- [ ] preview で同 route 再読み込みが速い