### PR TITLE
feat(api): /api/route response に algorithm field を含める

### DIFF
--- a/worker.mjs
+++ b/worker.mjs
@@ -141,7 +141,8 @@ async function handleRoute(url, env) {
         node_count: r.node_count,
         settled: r.settled,
         snap_from_m: r.snap_from_m,
-        snap_to_m: r.snap_to_m
+        snap_to_m: r.snap_to_m,
+        algorithm: r.algorithm
       }
     },
     {


### PR DESCRIPTION
TiledRouter が返す algorithm ('ch' / 'ch-fallback-nba' / 'nba') を Worker レスポンスに通し、本番でどのアルゴリズムが使われたか観測可能にする。CH デプロイ前後の検証に必要。