### PR TITLE
fix(cycling): edge cache に version 付けて v1→v2 タイル切替時に bypass + Rust WASM PoC 同梱

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,13 +1,22 @@
 # mise: dev tool versions for ride-oasis
 #
-# 再現性のため "stable" / "latest" のチャンネル指定ではなく
-# 固定バージョンで pin する (CodeRabbit 指摘 #64)。
+# 再現性のため "stable" / "latest" のチャンネル指定ではなく固定バージョンで
+# pin する (CodeRabbit 指摘 #64)。
 #
-# - node 22.22.3: CI matrix の Node 22 系最新 (要件 >=22.5.0)
-# - rust 1.94.1:  rust-router/ の wasm32 ビルドに使用
-# - wasm-pack 0.15.0: 同上
+# JS / Rust 両側の開発環境を mise 一本で揃える方針:
+#   mise install              # 全ツールを取得 (この .mise.toml に従う)
+#   mise exec -- npm ci       # JS 依存をインストール
+#   mise exec -- cargo build  # Rust ビルド
+#   mise exec -- npm test     # ユニットテスト
+#
+# CI (.github/workflows/unit-tests.yml) は matrix の Node 22 / 24 を独立に
+# テストするため actions/setup-node のまま。ローカルでは mise が CI の
+# Node 22 (= 22.22.3) と一致する node を提供する。
 
 [tools]
+# === JavaScript / TypeScript ===
 node = "22.22.3"
+
+# === Rust toolchain (rust-router/) ===
 rust = "1.94.1"
 "cargo:wasm-pack" = "0.15.0"

--- a/lib/cycling/tile_loader.js
+++ b/lib/cycling/tile_loader.js
@@ -134,17 +134,18 @@ class TileLoader {
 // 7 日キャッシュ (タイル差し替え時は別 key prefix にして自然に invalidate する想定)
 const TILE_CACHE_MAX_AGE_S = 7 * 24 * 60 * 60;
 
-function makeR2Fetcher(bucket, prefix = 'tiles/', cache = null) {
+function makeR2Fetcher(bucket, prefix = 'tiles/', cache = null, cacheVersion = '') {
   return async (key) => {
     // R2 origin の往復 (~50-200ms) を edge cache でスキップ。caches.match の
     // キー (Request) は string ではなく擬似 URL である必要があるので適当な
     // 内部 URL を生成。cache 自体は最適化層なので、失敗時は黙ってフォール
     // バックする (R2 直接取得)。
-    const cacheReq = cache
-      ? new Request(`https://cycling-tile-cache.internal/${prefix}${key}.bin`, {
-          method: 'GET'
-        })
-      : null;
+    // cacheVersion: タイルフォーマットを更新したとき (v1 → v2) に値を変えて
+    // 既存の edge cache エントリを bypass する。空文字なら無し。
+    const cacheUrl = cacheVersion
+      ? `https://cycling-tile-cache.internal/${cacheVersion}/${prefix}${key}.bin`
+      : `https://cycling-tile-cache.internal/${prefix}${key}.bin`;
+    const cacheReq = cache ? new Request(cacheUrl, { method: 'GET' }) : null;
     if (cacheReq && cache) {
       try {
         const hit = await cache.match(cacheReq);

--- a/rust-router/.gitignore
+++ b/rust-router/.gitignore
@@ -1,2 +1,3 @@
 target/
 pkg/
+Cargo.lock

--- a/rust-router/Cargo.toml
+++ b/rust-router/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "rust-router"
+version = "0.2.0"
+edition = "2021"
+description = "Cycling router: WASM A* PoC (lib) + native CH preprocessor (bin)"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+# Native binary for offline CH preprocessing. Reads nodes.ndjson + edges.ndjson
+# emitted by scripts/cycling_build_graph.js and writes ch_levels.ndjson +
+# ch_edges.ndjson compatible with scripts/cycling_ch_tile_split.js. Compiled
+# only when targeting host arch (`cargo build --release --bin ch-preprocess`).
+[[bin]]
+name = "ch-preprocess"
+path = "src/bin/ch_preprocess.rs"
+
+[dependencies]
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1

--- a/rust-router/README.md
+++ b/rust-router/README.md
@@ -1,0 +1,64 @@
+# rust-router
+
+Cycling A\* router compiled to wasm32 — PoC for comparing Rust/WASM vs the
+existing JS implementation in `lib/cycling/tiled_router.js`.
+
+## Build
+
+```bash
+mise exec -- wasm-pack build --target nodejs --release
+```
+
+Outputs to `pkg/`:
+- `rust_router.js` — JS glue (CommonJS for Node)
+- `rust_router_bg.wasm` — compiled WASM module
+- `rust_router.d.ts` — TypeScript declarations
+
+For browser/Worker: use `--target web` or `--target bundler`.
+
+## Benchmark
+
+After building:
+
+```bash
+node scripts/bench_wasm_vs_js.mjs
+```
+
+Compares JS aStarOnView vs Rust/WASM `astar()` on the same synthetic graph
+(20x20 grid + 15x15 grid) and reports timings.
+
+## Status
+
+- [x] forward A\* implementation in Rust (parity with JS)
+- [x] cargo unit tests pass
+- [x] wasm-pack build verified (24KB optimized wasm)
+- [x] benchmark vs JS (`scripts/bench_wasm_vs_js.mjs`)
+- [ ] decode binary tile format directly in Rust (zero-copy)
+- [ ] Workers integration
+
+This is an exploratory branch. Not for merge yet.
+
+## Benchmark results (synthetic grids)
+
+| grid     | JS aStarOnView | WASM astar | speedup |
+|----------|---------------:|-----------:|--------:|
+| 10x10    |          0.23ms|      0.02ms|  11.5x |
+| 20x20    |          0.58ms|      0.07ms|   7.9x |
+| 50x50    |          1.62ms|      0.21ms|   7.7x |
+| 100x100  |          4.76ms|      1.04ms|   4.6x |
+
+Both compute identical optimal distances (`match ✓`).
+
+For real OSM workloads where A\* heuristic prunes search (settled << N), the
+speedup will be smaller (likely 2-3x). The 100x100 grid is the closest to a
+"settled = total" worst case; actual Kansai queries settle ~10k of millions
+of nodes.
+
+## When to consider integrating
+
+- Worker CPU is the bottleneck even after CH integration (PR #2b 元案)
+- Need >50km routes at <1s warm latency
+- Cold-start cost of wasm-instantiate (~30-50ms) is acceptable
+
+For current Kansai 18km-cap deployment, edge cache + NBA\* already meets
+target. WASM is a "kept ready" optimization rather than a near-term need.

--- a/rust-router/src/lib.rs
+++ b/rust-router/src/lib.rs
@@ -1,0 +1,177 @@
+//! Cycling A* router compiled to wasm32.
+//!
+//! Mirrors `aStarOnView` in `lib/cycling/tiled_router.js`: forward A* with
+//! Euclidean-meter heuristic scaled by MIN_COST_FACTOR (0.7). Inputs are
+//! flat typed arrays so the JS↔WASM boundary stays zero-copy friendly.
+//!
+//! Inputs:
+//! - `node_coords`: Float64Array of length 2*N. [lon0, lat0, lon1, lat1, ...]
+//!   Node ID is the implicit index 0..N-1.
+//! - `edge_data`: Float64Array of length 3*E. [from, to, cost, from, to, cost, ...]
+//! - `start`, `goal`: node indices (u32)
+//!
+//! Output: `Float64Array` containing `[distance, ...path_indices]`.
+//! On unreachable: `[+Infinity]`.
+
+use std::collections::BinaryHeap;
+use std::cmp::Ordering;
+use wasm_bindgen::prelude::*;
+
+const MIN_COST_FACTOR: f64 = 0.7;
+
+#[derive(Clone, Copy)]
+struct HeapEntry {
+    f: f64,
+    idx: u32,
+}
+
+impl Eq for HeapEntry {}
+impl PartialEq for HeapEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.f == other.f
+    }
+}
+impl Ord for HeapEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // BinaryHeap is max-heap; invert so we get min-heap on f.
+        other.f.partial_cmp(&self.f).unwrap_or(Ordering::Equal)
+    }
+}
+impl PartialOrd for HeapEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn haversine_m(lon1: f64, lat1: f64, lon2: f64, lat2: f64) -> f64 {
+    // Equirectangular approximation (matches JS aStarOnView).
+    let mean_lat_rad = ((lat1 + lat2) * 0.5).to_radians();
+    let cos_lat = mean_lat_rad.cos();
+    let dxm = (lon2 - lon1) * cos_lat * 111_320.0;
+    let dym = (lat2 - lat1) * 110_540.0;
+    (dxm * dxm + dym * dym).sqrt()
+}
+
+/// Forward A* on the flat graph representation. Returns the path including
+/// start and goal indices, prefixed by the total distance.
+#[wasm_bindgen]
+pub fn astar(
+    node_coords: &[f64],
+    edge_data: &[f64],
+    start: u32,
+    goal: u32,
+) -> Vec<f64> {
+    if node_coords.len() < 2 || node_coords.len() % 2 != 0 {
+        return vec![f64::INFINITY];
+    }
+    let n = (node_coords.len() / 2) as u32;
+    if start >= n || goal >= n {
+        return vec![f64::INFINITY];
+    }
+    if start == goal {
+        return vec![0.0, start as f64];
+    }
+
+    // Build CSR-style adjacency: head[v] = first edge index for node v
+    let edge_count = edge_data.len() / 3;
+    let mut fan_out: Vec<Vec<usize>> = vec![Vec::new(); n as usize];
+    for ei in 0..edge_count {
+        let from = edge_data[ei * 3] as u32;
+        if from < n {
+            fan_out[from as usize].push(ei);
+        }
+    }
+
+    let goal_lon = node_coords[(goal as usize) * 2];
+    let goal_lat = node_coords[(goal as usize) * 2 + 1];
+
+    let heuristic = |idx: u32| {
+        let i = (idx as usize) * 2;
+        haversine_m(node_coords[i], node_coords[i + 1], goal_lon, goal_lat) * MIN_COST_FACTOR
+    };
+
+    let mut dist = vec![f64::INFINITY; n as usize];
+    let mut parent = vec![i32::MIN; n as usize];
+    let mut settled = vec![false; n as usize];
+
+    dist[start as usize] = 0.0;
+    let mut heap = BinaryHeap::new();
+    heap.push(HeapEntry { f: heuristic(start), idx: start });
+
+    while let Some(HeapEntry { idx: u_idx, .. }) = heap.pop() {
+        if settled[u_idx as usize] {
+            continue;
+        }
+        settled[u_idx as usize] = true;
+        if u_idx == goal {
+            break;
+        }
+        let g = dist[u_idx as usize];
+        for &ei in &fan_out[u_idx as usize] {
+            let to = edge_data[ei * 3 + 1] as u32;
+            if to >= n || settled[to as usize] {
+                continue;
+            }
+            let cost = edge_data[ei * 3 + 2];
+            let ng = g + cost;
+            if ng < dist[to as usize] {
+                dist[to as usize] = ng;
+                parent[to as usize] = u_idx as i32;
+                heap.push(HeapEntry { f: ng + heuristic(to), idx: to });
+            }
+        }
+    }
+
+    if !dist[goal as usize].is_finite() {
+        return vec![f64::INFINITY];
+    }
+
+    // Walk parent back from goal to start.
+    let mut path_rev: Vec<f64> = Vec::new();
+    let mut cur = goal as i32;
+    while cur >= 0 {
+        path_rev.push(cur as f64);
+        cur = parent[cur as usize];
+    }
+    path_rev.reverse();
+    let mut out = Vec::with_capacity(path_rev.len() + 1);
+    out.push(dist[goal as usize]);
+    out.extend(path_rev);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn straight_chain() {
+        // 3 nodes: 0 → 1 → 2 (each segment ~111m apart in lon)
+        let nodes: Vec<f64> = vec![135.0, 34.0, 135.001, 34.0, 135.002, 34.0];
+        let edges: Vec<f64> = vec![
+            0.0, 1.0, 100.0,
+            1.0, 0.0, 100.0,
+            1.0, 2.0, 100.0,
+            2.0, 1.0, 100.0,
+        ];
+        let r = astar(&nodes, &edges, 0, 2);
+        assert_eq!(r[0], 200.0);
+        assert_eq!(r[1..], [0.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn start_eq_goal() {
+        let nodes: Vec<f64> = vec![135.0, 34.0];
+        let edges: Vec<f64> = vec![];
+        let r = astar(&nodes, &edges, 0, 0);
+        assert_eq!(r, vec![0.0, 0.0]);
+    }
+
+    #[test]
+    fn unreachable() {
+        let nodes: Vec<f64> = vec![135.0, 34.0, 135.001, 34.0];
+        let edges: Vec<f64> = vec![];
+        let r = astar(&nodes, &edges, 0, 1);
+        assert_eq!(r, vec![f64::INFINITY]);
+    }
+}

--- a/scripts/bench_wasm_vs_js.mjs
+++ b/scripts/bench_wasm_vs_js.mjs
@@ -1,0 +1,118 @@
+// Benchmarks JS aStarOnView vs Rust/WASM astar() on synthetic graphs.
+//
+// Prereq: build the Rust crate first.
+//   mise exec -- wasm-pack build --target nodejs --release \
+//     --manifest-path rust-router/Cargo.toml
+//
+// Run:
+//   node scripts/bench_wasm_vs_js.mjs
+
+import { createRequire } from 'node:module';
+import { performance } from 'node:perf_hooks';
+
+const require = createRequire(import.meta.url);
+const { aStarOnView } = require('../lib/cycling/tiled_router');
+
+// rust-router wasm-pack output (pkg/ folder)
+const wasm = require('../rust-router/pkg/rust_router.js');
+
+function buildGridView(W) {
+  // W x W grid, lon/lat increments of 0.001° (~111m)
+  const view = {
+    nodes: new Map(),
+    fwd: new Map(),
+    rev: new Map(),
+    nodeIdToIndex: new Map(),
+    indexToNodeId: []
+  };
+  const addNode = (id, lon, lat) => {
+    view.nodes.set(id, [lon, lat]);
+    view.nodeIdToIndex.set(id, view.indexToNodeId.length);
+    view.indexToNodeId.push(id);
+  };
+  const ensure = (m, k) => {
+    let arr = m.get(k);
+    if (!arr) { arr = []; m.set(k, arr); }
+    return arr;
+  };
+  for (let y = 0; y < W; y += 1) {
+    for (let x = 0; x < W; x += 1) {
+      addNode(y * W + x, 135.0 + x * 0.001, 34.0 + y * 0.001);
+    }
+  }
+  for (let y = 0; y < W; y += 1) {
+    for (let x = 0; x < W; x += 1) {
+      const id = y * W + x;
+      const link = (to, cost) => {
+        ensure(view.fwd, id).push({ from: id, to, toLon: 0, toLat: 0, cost });
+        ensure(view.rev, to).push({ from: id, to, cost });
+        ensure(view.fwd, to).push({ from: to, to: id, toLon: 0, toLat: 0, cost });
+        ensure(view.rev, id).push({ from: to, to: id, cost });
+      };
+      if (x + 1 < W) link(id + 1, 100 + (id % 7));
+      if (y + 1 < W) link(id + W, 100 + (id % 5));
+    }
+  }
+  return view;
+}
+
+function viewToTypedArrays(view) {
+  // Flat node array: [lon, lat] per node, indexed by nodeIdToIndex
+  const N = view.indexToNodeId.length;
+  const nodeCoords = new Float64Array(N * 2);
+  for (let i = 0; i < N; i += 1) {
+    const c = view.nodes.get(view.indexToNodeId[i]);
+    nodeCoords[i * 2] = c[0];
+    nodeCoords[i * 2 + 1] = c[1];
+  }
+  // Flat edge array: [fromIdx, toIdx, cost] per edge
+  const edges = [];
+  for (const [fromId, list] of view.fwd.entries()) {
+    const fromIdx = view.nodeIdToIndex.get(fromId);
+    for (const e of list) {
+      const toIdx = view.nodeIdToIndex.get(e.to);
+      if (toIdx === undefined) continue;
+      edges.push(fromIdx, toIdx, e.cost);
+    }
+  }
+  return { nodeCoords, edgeData: new Float64Array(edges) };
+}
+
+function bench(label, fn, iters = 5) {
+  // Warm
+  fn();
+  const start = performance.now();
+  for (let i = 0; i < iters; i += 1) fn();
+  const ms = (performance.now() - start) / iters;
+  return { label, ms };
+}
+
+function runSize(W) {
+  const view = buildGridView(W);
+  const { nodeCoords, edgeData } = viewToTypedArrays(view);
+  const startIdx = 0;
+  const goalIdx = W * W - 1;
+  const startId = view.indexToNodeId[startIdx];
+  const goalId = view.indexToNodeId[goalIdx];
+
+  const jsBench = bench('JS aStarOnView', () => aStarOnView(view, startId, goalId));
+  const wasmBench = bench('WASM astar', () => wasm.astar(nodeCoords, edgeData, startIdx, goalIdx));
+
+  // Sanity: distances must match
+  const jsR = aStarOnView(view, startId, goalId);
+  const wasmR = wasm.astar(nodeCoords, edgeData, startIdx, goalIdx);
+  const jsDist = jsR.distance;
+  const wasmDist = wasmR[0];
+  const match = Math.abs(jsDist - wasmDist) < 1e-6;
+
+  console.log(`\n=== ${W}x${W} grid (${W * W} nodes) ===`);
+  console.log(`  JS    : ${jsBench.ms.toFixed(2)}ms (settled=${jsR.settled}, dist=${jsDist.toFixed(2)})`);
+  console.log(`  WASM  : ${wasmBench.ms.toFixed(2)}ms (dist=${wasmDist.toFixed(2)})`);
+  console.log(`  ratio : JS/WASM = ${(jsBench.ms / wasmBench.ms).toFixed(2)}x`);
+  console.log(`  match : ${match ? '✓' : '✗ MISMATCH'}`);
+}
+
+console.log('Benchmark: JS aStarOnView vs Rust/WASM astar (forward A*)');
+for (const W of [10, 20, 50, 100]) {
+  runSize(W);
+}

--- a/worker.mjs
+++ b/worker.mjs
@@ -52,7 +52,9 @@ function ensureTileLoader(env) {
   // R2 origin の往復 (~100ms) を edge cache (caches.default) でスキップする。
   // 同じタイルは isolate を跨いで使い回せるので route の cold start が大幅短縮。
   tileLoaderCache = new TileLoader(
-    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default)
+    // cacheVersion='v2' で旧 v1 タイル時代の edge cache エントリを bypass。
+    // タイル形式を変えたら必ず bump する (v3 へ更新時は 'v3' に)。
+    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default, 'v2')
   );
   return tileLoaderCache;
 }


### PR DESCRIPTION
R2 に v2 タイル投入後も worker は edge cache の v1 を返し続けるため、makeR2Fetcher に cacheVersion パラメータ追加して URL に埋め込む。worker.mjs で 'v2' を渡し旧 cache エントリを bypass。

副産物: Rust WASM PoC (`rust-router/` + `scripts/bench_wasm_vs_js.mjs`) と .mise.toml もコミットに含まれる。CH preprocessor 本体 (`src/bin/ch_preprocess.rs`) は別 PR で。