### PR TITLE
fix(cycling): CH 自動有効化を停止 (hot-fix, opt-in 化)

### DIFF
--- a/lib/cycling/tile_loader.js
+++ b/lib/cycling/tile_loader.js
@@ -10,6 +10,7 @@ const DEFAULT_LOAD_CONCURRENCY = 8;
 class TileLoader {
   constructor(fetcher, opts = {}) {
     this.fetcher = fetcher;
+    this.opts = opts;
     this.maxTiles = opts.maxTiles ?? DEFAULT_MAX_TILES;
     this.maxMisses = opts.maxMisses ?? DEFAULT_MAX_MISSES;
     this.loadConcurrency = opts.loadConcurrency ?? DEFAULT_LOAD_CONCURRENCY;
@@ -106,11 +107,12 @@ class TileLoader {
     };
     const parsed = decodeTile(arrayBuffer);
     const { nodes: tileNodes, edges: tileEdges, version } = parsed;
-    if (version === 2) this.view.hasCh = true;
+    // hasCh は意図的に有効化されるまで false のまま。CH クエリパスは
+    // production で CPU 1102 を出した実績があるため、明示フラグで opt-in
+    // 制御し、v2 タイルが混じっても勝手に有効化しないようにする。
+    if (this.opts && this.opts.enableCh && version === 2) this.view.hasCh = true;
     for (const n of tileNodes) {
       registerNode(n.id, n.lon, n.lat);
-      // v2: 全ノードの level を保存 (0 含む)。v1 タイルは n.level === 0
-      // だが levels に入れると CH 探索の前提を満たしてしまうため、v2 のときだけ。
       if (version === 2 && !levels.has(n.id)) levels.set(n.id, n.level);
     }
     for (const e of tileEdges) {


### PR DESCRIPTION
v2 タイル投入後 chQueryOnView が CPU 1102 を出したため、hasCh の自動有効化を opt-in に変更して production 復旧。CH デバッグまでの hot-fix。