### PR TITLE
fix(cycling): v2 shortcut フィルタ + cache v3 で 1102 暴走を解消

### DIFF
--- a/lib/cycling/tile_loader.js
+++ b/lib/cycling/tile_loader.js
@@ -107,15 +107,19 @@ class TileLoader {
     };
     const parsed = decodeTile(arrayBuffer);
     const { nodes: tileNodes, edges: tileEdges, version } = parsed;
-    // hasCh は意図的に有効化されるまで false のまま。CH クエリパスは
-    // production で CPU 1102 を出した実績があるため、明示フラグで opt-in
-    // 制御し、v2 タイルが混じっても勝手に有効化しないようにする。
-    if (this.opts && this.opts.enableCh && version === 2) this.view.hasCh = true;
+    // CH モードは明示 opt-in (TileLoader opts.enableCh=true) でのみ有効。
+    // v2 タイルが混ざっていても勝手に有効化しない (chQuery 未調査のため)。
+    const useCh = !!(this.opts && this.opts.enableCh) && version === 2;
+    if (useCh) this.view.hasCh = true;
     for (const n of tileNodes) {
       registerNode(n.id, n.lon, n.lat);
-      if (version === 2 && !levels.has(n.id)) levels.set(n.id, n.level);
+      if (useCh && !levels.has(n.id)) levels.set(n.id, n.level);
     }
     for (const e of tileEdges) {
+      // v2 で CH 無効化中: shortcut edge (viaId != 0) は無視。これを view に
+      // 入れると nbaStarOnView が大量の "実態のない長距離エッジ" を expand
+      // して CPU 1102 になる。CH オフ運用では original エッジのみ使う。
+      if (!useCh && version === 2 && e.viaId && e.viaId !== 0) continue;
       let f = fwd.get(e.from);
       if (!f) {
         f = [];

--- a/worker.mjs
+++ b/worker.mjs
@@ -52,9 +52,9 @@ function ensureTileLoader(env) {
   // R2 origin の往復 (~100ms) を edge cache (caches.default) でスキップする。
   // 同じタイルは isolate を跨いで使い回せるので route の cold start が大幅短縮。
   tileLoaderCache = new TileLoader(
-    // cacheVersion='v2' で旧 v1 タイル時代の edge cache エントリを bypass。
-    // タイル形式を変えたら必ず bump する (v3 へ更新時は 'v3' に)。
-    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default, 'v2')
+    // cacheVersion を bump して旧 (v2 タイル) cache エントリを bypass。
+    // v1 タイル運用に戻したので v3 で fresh fetch を強制。
+    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default, 'v3')
   );
   return tileLoaderCache;
 }


### PR DESCRIPTION
本番が CPU 1102 を出していた原因と対処。

原因: PR #69 投入時に v2 タイルが edge cache に残留、PR #70 で hasCh は無効化したが shortcut edge は view に積み続け、nbaStarOnView が長距離 edge を大量に expand → CPU 限界。

対処:
- tile_loader.js: v2 タイル + CH 無効化中は viaId!=0 のエッジを skip
- worker.mjs: cacheVersion v2 → v3 で edge cache を完全 bypass、R2 の v1 を fresh fetch