### PR TITLE
feat(cycling): /api/dnf-pack エンドポイント (route + 周辺 supply-point を集約)

### DIFF
--- a/lib/cycling/dnf_pack.js
+++ b/lib/cycling/dnf_pack.js
@@ -50,7 +50,11 @@ function perpendicularMeters(pLon, pLat, aLon, aLat, bLon, bLat) {
  * Douglas-Peucker 線分単純化 (反復実装、再帰スタック消費を避ける)。
  * tolerance_m は許容ズレ。cycling 用途では 5-10m が表示上自然な値。
  * 入力 coords は [[lon, lat], ...]。返り値は同形式の配列。
- * 入力が 2 点以下、もしくは tolerance <= 0 なら原配列をそのまま返す。
+ *
+ * パフォーマンス上の理由から、簡略化不要なケース (入力が 2 点以下、
+ * もしくは tolerance <= 0) は **入力 coords をそのまま参照返しする**
+ * (浅い/深いコピーを作らない)。呼び出し側が結果配列を mutate する
+ * 場合は呼び出し前に slice() などで複製しておくこと。
  */
 function douglasPeucker(coords, toleranceMeters) {
   if (!Array.isArray(coords) || coords.length <= 2 || toleranceMeters <= 0) {
@@ -68,7 +72,9 @@ function douglasPeucker(coords, toleranceMeters) {
     const [aLon, aLat] = coords[s];
     const [bLon, bLat] = coords[e];
     let maxD = -1;
-    let maxIdx = -1;
+    // e - s >= 2 が保証されるためループは必ず 1 回以上実行され、maxIdx は
+    // s+1 以上の有効インデックスで上書きされる。初期値も範囲内に置く。
+    let maxIdx = s + 1;
     for (let i = s + 1; i < e; i += 1) {
       const [pLon, pLat] = coords[i];
       const d = perpendicularMeters(pLon, pLat, aLon, aLat, bLon, bLat);
@@ -77,7 +83,7 @@ function douglasPeucker(coords, toleranceMeters) {
         maxIdx = i;
       }
     }
-    if (maxD > toleranceMeters && maxIdx !== -1) {
+    if (maxD > toleranceMeters) {
       keep[maxIdx] = 1;
       stack.push([s, maxIdx]);
       stack.push([maxIdx, e]);

--- a/lib/cycling/dnf_pack.js
+++ b/lib/cycling/dnf_pack.js
@@ -1,0 +1,126 @@
+'use strict';
+
+// DNF (Did Not Finish) pack: route + 周辺 supply-point を 1 リクエストで
+// 返すための補助。スマホ・モバイル回線でリクエスト数を減らすことで
+// TLS hello / TCP handshake / DNS の repeat を削減し、バッテリ・通信
+// 時間を抑える。CH/A* で計算した route geometry に対し Douglas-Peucker
+// で頂点を間引き、ペイロードを半分以下にする。
+
+const EARTH_R = 6378137; // meters
+
+/**
+ * Haversine 距離 (m)。Cycling 用途では 100m 単位の精度で十分なので
+ * 球面近似で OK。tile_loader と同じ式に揃えている。
+ */
+function haversineMeters(aLon, aLat, bLon, bLat) {
+  const toRad = Math.PI / 180;
+  const dLat = (bLat - aLat) * toRad;
+  const dLon = (bLon - aLon) * toRad;
+  const lat1 = aLat * toRad;
+  const lat2 = bLat * toRad;
+  const s = Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return 2 * EARTH_R * Math.asin(Math.sqrt(s));
+}
+
+/**
+ * 点 P (pLon, pLat) と線分 (a, b) との垂直距離 (m)。equirectangular
+ * projection (緯度補正済の x/y) で近似してから直線距離を求める。
+ * 自転車スケール (せいぜい数 km) では haversine との誤差は無視できる。
+ */
+function perpendicularMeters(pLon, pLat, aLon, aLat, bLon, bLat) {
+  // 局所平面近似: lat0 で経度を縮める
+  const lat0 = (aLat + bLat) * 0.5 * (Math.PI / 180);
+  const mPerDegLat = 111320;
+  const mPerDegLon = mPerDegLat * Math.cos(lat0);
+  const ax = aLon * mPerDegLon, ay = aLat * mPerDegLat;
+  const bx = bLon * mPerDegLon, by = bLat * mPerDegLat;
+  const px = pLon * mPerDegLon, py = pLat * mPerDegLat;
+  const dx = bx - ax, dy = by - ay;
+  const segLen2 = dx * dx + dy * dy;
+  if (segLen2 === 0) return Math.hypot(px - ax, py - ay);
+  // 投影パラメタ t を [0,1] にクランプ
+  const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / segLen2));
+  const qx = ax + t * dx;
+  const qy = ay + t * dy;
+  return Math.hypot(px - qx, py - qy);
+}
+
+/**
+ * Douglas-Peucker 線分単純化 (反復実装、再帰スタック消費を避ける)。
+ * tolerance_m は許容ズレ。cycling 用途では 5-10m が表示上自然な値。
+ * 入力 coords は [[lon, lat], ...]。返り値は同形式の配列。
+ * 入力が 2 点以下、もしくは tolerance <= 0 なら原配列をそのまま返す。
+ */
+function douglasPeucker(coords, toleranceMeters) {
+  if (!Array.isArray(coords) || coords.length <= 2 || toleranceMeters <= 0) {
+    return coords;
+  }
+  const n = coords.length;
+  const keep = new Uint8Array(n);
+  keep[0] = 1;
+  keep[n - 1] = 1;
+  // [start, end] の区間スタック。両端含む。
+  const stack = [[0, n - 1]];
+  while (stack.length > 0) {
+    const [s, e] = stack.pop();
+    if (e - s < 2) continue;
+    const [aLon, aLat] = coords[s];
+    const [bLon, bLat] = coords[e];
+    let maxD = -1;
+    let maxIdx = -1;
+    for (let i = s + 1; i < e; i += 1) {
+      const [pLon, pLat] = coords[i];
+      const d = perpendicularMeters(pLon, pLat, aLon, aLat, bLon, bLat);
+      if (d > maxD) {
+        maxD = d;
+        maxIdx = i;
+      }
+    }
+    if (maxD > toleranceMeters && maxIdx !== -1) {
+      keep[maxIdx] = 1;
+      stack.push([s, maxIdx]);
+      stack.push([maxIdx, e]);
+    }
+  }
+  const out = [];
+  for (let i = 0; i < n; i += 1) {
+    if (keep[i]) out.push(coords[i]);
+  }
+  return out;
+}
+
+/**
+ * coords (LineString 想定) の bbox + buffer_m。buffer は地表面で
+ * メートル指定。緯度に応じて経度 buffer を補正する。bbox は
+ * supply-points D1 クエリの :minLng/:maxLng/:minLat/:maxLat に直接渡す。
+ */
+function routeBBoxWithBuffer(coords, bufferMeters) {
+  if (!Array.isArray(coords) || coords.length === 0) {
+    return null;
+  }
+  let minLon = Infinity, maxLon = -Infinity;
+  let minLat = Infinity, maxLat = -Infinity;
+  for (const c of coords) {
+    if (c[0] < minLon) minLon = c[0];
+    if (c[0] > maxLon) maxLon = c[0];
+    if (c[1] < minLat) minLat = c[1];
+    if (c[1] > maxLat) maxLat = c[1];
+  }
+  const meanLat = (minLat + maxLat) * 0.5;
+  const latBuf = bufferMeters / 111320;
+  const lonBuf = bufferMeters / (111320 * Math.max(0.01, Math.cos(meanLat * Math.PI / 180)));
+  return {
+    minLng: minLon - lonBuf,
+    maxLng: maxLon + lonBuf,
+    minLat: minLat - latBuf,
+    maxLat: maxLat + latBuf
+  };
+}
+
+module.exports = {
+  haversineMeters,
+  perpendicularMeters,
+  douglasPeucker,
+  routeBBoxWithBuffer
+};

--- a/tests/cycling_dnf_pack.test.js
+++ b/tests/cycling_dnf_pack.test.js
@@ -65,6 +65,13 @@ test('douglasPeucker: tolerance 0 は原配列を返す (no-op)', () => {
   assert.equal(douglasPeucker(c, 0), c);
 });
 
+test('douglasPeucker: no-op 経路は入力参照そのものを返す (mutate 注意の根拠)', () => {
+  // docstring の「呼び出し側が結果を mutate するなら slice() で複製を」の
+  // 契約を担保するため、参照同一性を assert.strictEqual で確認する。
+  const c = [[0, 0], [1, 1]];
+  assert.strictEqual(douglasPeucker(c, 5), c);
+});
+
 test('routeBBoxWithBuffer: 単一点 + buffer で正方形 bbox', () => {
   const bbox = routeBBoxWithBuffer([[135.0, 35.0]], 1000);
   assert.ok(bbox.minLng < 135.0 && bbox.maxLng > 135.0);

--- a/tests/cycling_dnf_pack.test.js
+++ b/tests/cycling_dnf_pack.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  haversineMeters,
+  perpendicularMeters,
+  douglasPeucker,
+  routeBBoxWithBuffer
+} = require('../lib/cycling/dnf_pack');
+
+test('haversineMeters: 同一点は 0', () => {
+  assert.equal(haversineMeters(135.5, 34.7, 135.5, 34.7), 0);
+});
+
+test('haversineMeters: 関西で 1km 前後の妥当性', () => {
+  // 35°N で経度 0.01° ≒ 911m
+  const d = haversineMeters(135.50, 35.0, 135.51, 35.0);
+  assert.ok(d > 900 && d < 920, `got ${d}`);
+});
+
+test('perpendicularMeters: 線分上の点は ~0m', () => {
+  // (0,0) → (0, 0.01) 上の (0, 0.005)
+  const d = perpendicularMeters(0, 0.005, 0, 0, 0, 0.01);
+  assert.ok(d < 1e-6, `got ${d}`);
+});
+
+test('perpendicularMeters: 線分から離れた点はそれなりの距離', () => {
+  // (135, 35) → (135.01, 35) の線分から (135.005, 35.001) はおよそ 111m
+  const d = perpendicularMeters(135.005, 35.001, 135.0, 35.0, 135.01, 35.0);
+  assert.ok(d > 100 && d < 120, `got ${d}`);
+});
+
+test('douglasPeucker: 入力 <= 2 点はそのまま', () => {
+  const c = [[0, 0], [1, 1]];
+  assert.equal(douglasPeucker(c, 10), c);
+});
+
+test('douglasPeucker: 直線上の中間点は削除される', () => {
+  // tolerance 10m: 直線 0→1km の中間点 4 点 (ズレ 0) は削除されて 2 点になる
+  const coords = [
+    [135.0, 35.0],
+    [135.002, 35.0],
+    [135.004, 35.0],
+    [135.006, 35.0],
+    [135.008, 35.0],
+    [135.01, 35.0]
+  ];
+  const out = douglasPeucker(coords, 10);
+  assert.equal(out.length, 2);
+  assert.deepEqual(out[0], [135.0, 35.0]);
+  assert.deepEqual(out[1], [135.01, 35.0]);
+});
+
+test('douglasPeucker: 大きく逸脱する中間点は残る', () => {
+  // (0,0) → (0,0.01) → (0.01, 0.01) で中間点 (0,0.01) は保持される
+  const coords = [[0, 0], [0, 0.01], [0.01, 0.01]];
+  const out = douglasPeucker(coords, 10);
+  assert.equal(out.length, 3);
+});
+
+test('douglasPeucker: tolerance 0 は原配列を返す (no-op)', () => {
+  const c = [[0, 0], [0.001, 0.0001], [0.002, 0]];
+  assert.equal(douglasPeucker(c, 0), c);
+});
+
+test('routeBBoxWithBuffer: 単一点 + buffer で正方形 bbox', () => {
+  const bbox = routeBBoxWithBuffer([[135.0, 35.0]], 1000);
+  assert.ok(bbox.minLng < 135.0 && bbox.maxLng > 135.0);
+  assert.ok(bbox.minLat < 35.0 && bbox.maxLat > 35.0);
+  // ~1km は 0.009 程度 (緯度) / 0.011 程度 (経度 @ 35°N)
+  assert.ok(Math.abs((bbox.maxLat - bbox.minLat) - 0.018) < 0.002);
+});
+
+test('routeBBoxWithBuffer: 空配列は null', () => {
+  assert.equal(routeBBoxWithBuffer([], 100), null);
+});
+
+test('routeBBoxWithBuffer: 複数点で min/max が範囲を囲む', () => {
+  const bbox = routeBBoxWithBuffer([[135.0, 35.0], [135.01, 35.005]], 0);
+  assert.equal(bbox.minLng, 135.0);
+  assert.equal(bbox.maxLng, 135.01);
+  assert.equal(bbox.minLat, 35.0);
+  assert.equal(bbox.maxLat, 35.005);
+});

--- a/worker.mjs
+++ b/worker.mjs
@@ -190,9 +190,13 @@ async function handleRoute(url, env) {
  *
  * 失敗時はルート単独のエラー (404 unreachable など) を踏襲。
  */
+// 空白だけの入力 (" ") は Number() が 0 に変換するため、空入力扱いに
+// 倒さないと tolerance_m=" " が simplify off に化ける。trim → 空判定で防ぐ。
 function parsePositiveNumber(raw, fallback, max) {
-  if (raw == null || raw === '') return fallback;
-  const v = Number(raw);
+  if (raw == null) return fallback;
+  const normalized = String(raw).trim();
+  if (normalized === '') return fallback;
+  const v = Number(normalized);
   if (!Number.isFinite(v) || v <= 0) return fallback;
   return Math.min(v, max);
 }
@@ -200,9 +204,12 @@ function parsePositiveNumber(raw, fallback, max) {
 // tolerance_m=0 は「simplify を無効化する」契約 (douglasPeucker 仕様)。
 // parsePositiveNumber は 0 を fallback に化けさせるため、専用の
 // non-negative パーサで 0 を許可する。負値・NaN は fallback に倒す。
+// trim 処理も同様 (空白入力で 0 化けを防ぐ)。
 function parseNonNegativeNumber(raw, fallback, max) {
-  if (raw == null || raw === '') return fallback;
-  const v = Number(raw);
+  if (raw == null) return fallback;
+  const normalized = String(raw).trim();
+  if (normalized === '') return fallback;
+  const v = Number(normalized);
   if (!Number.isFinite(v) || v < 0) return fallback;
   return Math.min(v, max);
 }

--- a/worker.mjs
+++ b/worker.mjs
@@ -92,7 +92,12 @@ async function withEdgeCache(request, ttlSeconds, build) {
     console.warn('edge cache match failed', err);
   }
   const fresh = await build();
-  if (fresh.ok && request.method === 'GET') {
+  // build() 側が cache-control: no-store を立てたレスポンス (部分失敗等で
+  // キャッシュさせたくない 200) は edge cache に載せない。withEdgeCache は
+  // ttl を上書きしていたが、no-store を尊重するよう変更。
+  const requestedCacheControl = fresh.headers.get('cache-control') || '';
+  const optOut = /no-store|no-cache|private/i.test(requestedCacheControl);
+  if (fresh.ok && request.method === 'GET' && !optOut) {
     try {
       const cacheable = new Response(fresh.clone().body, fresh);
       cacheable.headers.set('cache-control', `public, max-age=${ttlSeconds}`);
@@ -192,6 +197,16 @@ function parsePositiveNumber(raw, fallback, max) {
   return Math.min(v, max);
 }
 
+// tolerance_m=0 は「simplify を無効化する」契約 (douglasPeucker 仕様)。
+// parsePositiveNumber は 0 を fallback に化けさせるため、専用の
+// non-negative パーサで 0 を許可する。負値・NaN は fallback に倒す。
+function parseNonNegativeNumber(raw, fallback, max) {
+  if (raw == null || raw === '') return fallback;
+  const v = Number(raw);
+  if (!Number.isFinite(v) || v < 0) return fallback;
+  return Math.min(v, max);
+}
+
 async function handleDnfPack(url, env) {
   const from = parseLonLat(url.searchParams.get('from'));
   const to = parseLonLat(url.searchParams.get('to'));
@@ -202,7 +217,8 @@ async function handleDnfPack(url, env) {
     );
   }
   const bufferM = parsePositiveNumber(url.searchParams.get('buffer_m'), DNF_DEFAULT_BUFFER_M, DNF_MAX_BUFFER_M);
-  const toleranceM = parsePositiveNumber(url.searchParams.get('tolerance_m'), DNF_DEFAULT_TOLERANCE_M, DNF_MAX_TOLERANCE_M);
+  // tolerance_m=0 は simplify off の契約として明示的に受け入れる。
+  const toleranceM = parseNonNegativeNumber(url.searchParams.get('tolerance_m'), DNF_DEFAULT_TOLERANCE_M, DNF_MAX_TOLERANCE_M);
   const limit = parsePositiveNumber(url.searchParams.get('limit'), DNF_DEFAULT_LIMIT, DNF_MAX_LIMIT);
 
   let loader;
@@ -287,7 +303,13 @@ async function handleDnfPack(url, env) {
     {
       headers: {
         'content-type': 'application/json; charset=utf-8',
-        'cache-control': `public, max-age=${DNF_PACK_CACHE_TTL_S}`
+        // supply-points 取得が失敗した部分応答 (D1 障害など) は edge cache
+        // に固定すると短期障害でも「空の supply_points で route だけ返す
+        // 200」が 5 分間配信され続けるので、no-store で原則 origin に戻す。
+        // 正常応答は通常通り 5 分キャッシュ。
+        'cache-control': supplyError
+          ? 'no-store'
+          : `public, max-age=${DNF_PACK_CACHE_TTL_S}`
       }
     }
   );

--- a/worker.mjs
+++ b/worker.mjs
@@ -5,6 +5,7 @@
 import mapData from './lib/map_data.js';
 import tiledRouterModule from './lib/cycling/tiled_router.js';
 import tileLoaderModule from './lib/cycling/tile_loader.js';
+import dnfPackModule from './lib/cycling/dnf_pack.js';
 
 const {
   parseSupplyPointFilters,
@@ -15,9 +16,11 @@ const {
 
 const { TiledRouter } = tiledRouterModule;
 const { TileLoader, makeR2Fetcher } = tileLoaderModule;
+const { douglasPeucker, routeBBoxWithBuffer } = dnfPackModule;
 
 const API_PATH = '/api/supply-points';
 const ROUTE_PATH = '/api/route';
+const DNF_PACK_PATH = '/api/dnf-pack';
 
 // Per-isolate tile loader cache. Tiles loaded from R2 are reused across
 // requests in the same isolate so repeat queries in the same city are cheap.
@@ -62,6 +65,16 @@ function ensureTileLoader(env) {
 const TILE_CACHE_TTL_S = 7 * 24 * 60 * 60; // 7d (旧タイル投入があれば手動でパージ)
 const SUPPLY_POINTS_CACHE_TTL_S = 5 * 60;
 const ROUTE_CACHE_TTL_S = 5 * 60;
+const DNF_PACK_CACHE_TTL_S = 5 * 60;
+// DNF 用パック: 経路 + 周辺 supply-point を 1 リクエストで返す。
+// バッファ・許容ズレ・supply-point 上限は URL クエリで上書き可だが、
+// 通常はデフォルト (DNF 想定のモバイル) で十分。
+const DNF_DEFAULT_BUFFER_M = 500;
+const DNF_DEFAULT_TOLERANCE_M = 5;
+const DNF_DEFAULT_LIMIT = 200;
+const DNF_MAX_BUFFER_M = 2000;
+const DNF_MAX_TOLERANCE_M = 50;
+const DNF_MAX_LIMIT = 1000;
 
 /**
  * Caches an HTTP-cacheable response in `caches.default` and returns the
@@ -156,6 +169,130 @@ async function handleRoute(url, env) {
   );
 }
 
+/**
+ * DNF (Did Not Finish) 用パック: 経路 + 周辺 supply-point を 1 リクエスト
+ * で返す。スマホ・モバイル回線で別 API を 2 つ叩く代わりに 1 回で済ませる
+ * ことで TLS handshake / TCP / DNS の重複を削減、バッテリ/通信時間を節約。
+ *
+ * リクエスト: ?from=lon,lat&to=lon,lat[&buffer_m=500][&tolerance_m=5]
+ *            [&limit=200][&chains=lawson,seven_eleven]
+ *
+ * 処理:
+ *  1) /api/route 同等のルート計算 (TiledRouter)
+ *  2) ルート geometry を Douglas-Peucker で間引き (tolerance_m, 既定 5m)
+ *  3) 間引き後ルートの bbox + buffer_m (既定 500m) で supply-points を D1 から取得
+ *  4) 統合 JSON を返す
+ *
+ * 失敗時はルート単独のエラー (404 unreachable など) を踏襲。
+ */
+function parsePositiveNumber(raw, fallback, max) {
+  if (raw == null || raw === '') return fallback;
+  const v = Number(raw);
+  if (!Number.isFinite(v) || v <= 0) return fallback;
+  return Math.min(v, max);
+}
+
+async function handleDnfPack(url, env) {
+  const from = parseLonLat(url.searchParams.get('from'));
+  const to = parseLonLat(url.searchParams.get('to'));
+  if (!from || !to) {
+    return Response.json(
+      { error: 'from and to must be in "lon,lat" form' },
+      { status: 400 }
+    );
+  }
+  const bufferM = parsePositiveNumber(url.searchParams.get('buffer_m'), DNF_DEFAULT_BUFFER_M, DNF_MAX_BUFFER_M);
+  const toleranceM = parsePositiveNumber(url.searchParams.get('tolerance_m'), DNF_DEFAULT_TOLERANCE_M, DNF_MAX_TOLERANCE_M);
+  const limit = parsePositiveNumber(url.searchParams.get('limit'), DNF_DEFAULT_LIMIT, DNF_MAX_LIMIT);
+
+  let loader;
+  try {
+    loader = ensureTileLoader(env);
+  } catch (err) {
+    if (err && err.code === 'no_graph_binding') {
+      return Response.json({ error: err.message }, { status: 503 });
+    }
+    throw err;
+  }
+  const router = new TiledRouter(loader);
+  const r = await router.route(from[0], from[1], to[0], to[1]);
+  if (r.error) {
+    const status =
+      r.error === 'unreachable_in_corridor' ? 404 :
+      r.error === 'too_far' ? 422 :
+      r.error === 'corridor_too_large' ? 422 :
+      r.error === 'no_nearby_node_from' || r.error === 'no_nearby_node_to' ? 422 :
+      500;
+    return Response.json(r, { status });
+  }
+
+  // ルート間引き → bbox 算出 → supply-points 取得
+  const simplified = douglasPeucker(r.coordinates, toleranceM);
+  const bbox = routeBBoxWithBuffer(simplified, bufferM);
+  // D1 がない場合 (dev 等) は supply-points を空配列にして route 単独を返す
+  let supplyFeatures = [];
+  let supplyError = null;
+  if (env.DB && bbox) {
+    try {
+      const params = new URLSearchParams();
+      params.set('bbox', `${bbox.minLng},${bbox.minLat},${bbox.maxLng},${bbox.maxLat}`);
+      params.set('limit', String(Math.floor(limit)));
+      const chains = url.searchParams.get('chains');
+      if (chains) params.set('chains', chains);
+      const filters = parseSupplyPointFilters(params);
+      const { sql, params: sqlParams } = buildSupplyPointsQuery(filters);
+      const stmt = prepareForD1(env.DB, sql, sqlParams);
+      const { results } = await stmt.all();
+      const fc = toFeatureCollection(results || []);
+      supplyFeatures = fc.features;
+    } catch (err) {
+      if (err instanceof ValidationError) {
+        supplyError = err.message;
+      } else {
+        console.error('dnf-pack supply-points error', err);
+        supplyError = 'supply_points_internal';
+      }
+    }
+  }
+
+  return Response.json(
+    {
+      route: {
+        type: 'Feature',
+        geometry: { type: 'LineString', coordinates: simplified },
+        properties: {
+          distance_cost: r.distance_cost,
+          node_count: r.node_count,
+          settled: r.settled,
+          snap_from_m: r.snap_from_m,
+          snap_to_m: r.snap_to_m,
+          algorithm: r.algorithm,
+          simplified_from: r.coordinates.length,
+          simplified_to: simplified.length,
+          tolerance_m: toleranceM
+        }
+      },
+      supply_points: {
+        type: 'FeatureCollection',
+        features: supplyFeatures
+      },
+      meta: {
+        bbox: bbox ? [bbox.minLng, bbox.minLat, bbox.maxLng, bbox.maxLat] : null,
+        buffer_m: bufferM,
+        limit,
+        supply_points_count: supplyFeatures.length,
+        supply_points_error: supplyError
+      }
+    },
+    {
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'cache-control': `public, max-age=${DNF_PACK_CACHE_TTL_S}`
+      }
+    }
+  );
+}
+
 /** Returns the GeoJSON FeatureCollection for the requested supply-points filter. */
 async function handleSupplyPoints(url, env) {
   const filters = parseSupplyPointFilters(url.searchParams);
@@ -195,7 +332,7 @@ export default {
    */
   async fetch(request, env) {
     const url = new URL(request.url);
-    if (url.pathname === API_PATH || url.pathname === ROUTE_PATH) {
+    if (url.pathname === API_PATH || url.pathname === ROUTE_PATH || url.pathname === DNF_PACK_PATH) {
       if (request.method !== 'GET' && request.method !== 'HEAD') {
         return new Response('method not allowed', { status: 405 });
       }
@@ -204,6 +341,10 @@ export default {
         if (url.pathname === ROUTE_PATH) {
           response = await withEdgeCache(request, ROUTE_CACHE_TTL_S, () =>
             handleRoute(url, env)
+          );
+        } else if (url.pathname === DNF_PACK_PATH) {
+          response = await withEdgeCache(request, DNF_PACK_CACHE_TTL_S, () =>
+            handleDnfPack(url, env)
           );
         } else {
           response = await withEdgeCache(request, SUPPLY_POINTS_CACHE_TTL_S, () =>


### PR DESCRIPTION
## 背景

DNF (ブルベ Did Not Finish) ユースケース最適化。スマホ・モバイル回線で \`/api/route\` と \`/api/supply-points\` を別々に叩く代わりに \`/api/dnf-pack\` で 1 回にまとめ、TLS handshake / TCP / DNS 重複を削減してバッテリ・通信時間を節約。

## リクエスト

\`\`\`
GET /api/dnf-pack?from=135.49,34.69&to=135.52,34.71
                 [&buffer_m=500][&tolerance_m=5][&limit=200][&chains=lawson,seven_eleven]
\`\`\`

## 処理

1. TiledRouter でルート計算 (既存 \`/api/route\` と同じ)
2. Douglas-Peucker でルート geometry を間引き (既定 5m)
3. 間引き後ルートの bbox + buffer_m で D1 から supply-points 取得
4. 統合 JSON を返す

## 変更

- \`lib/cycling/dnf_pack.js\`: Douglas-Peucker (iterative)、equirectangular perpendicular 距離、haversine、bbox+buffer ヘルパ
- \`tests/cycling_dnf_pack.test.js\`: 11 ケース
- \`worker.mjs\`: \`DNF_PACK_PATH = /api/dnf-pack\` 追加。クランプ (buffer 2km / tolerance 50m / limit 1000)

## Test plan

- [x] \`npm test\` (297/297 pass)
- [ ] CI 緑後 merge
- [ ] 本番で \`/api/dnf-pack\` が 200 を返し、route + supply-points が含まれているか