### PR TITLE
feat(cycling): tile v2 に coreBit 追加 (partial CH core-core lateral relax)

### DIFF
--- a/lib/cycling/tile_binary.js
+++ b/lib/cycling/tile_binary.js
@@ -127,9 +127,14 @@ function encodeTileV2(nodes, edges) {
     dv.setFloat64(off, n.id, true);
     dv.setFloat32(off + 8, n.lon, true);
     dv.setFloat32(off + 12, n.lat, true);
-    const level = (n.level >>> 0);
-    if (level > LEVEL_MAX_V2) {
-      throw new Error(`v2 encode: level ${level} exceeds LEVEL_MAX_V2 ${LEVEL_MAX_V2}`);
+    // フォーマット境界では暗黙変換 (>>> 0 は undefined/NaN を 0 に化けさせる)
+    // を避け、有限整数かつ 0..LEVEL_MAX_V2 のみ受け入れる。範囲外/不正値は
+    // 早期に例外で気付かせる方が、無効なタイル binary を生成するより安全。
+    const level = n.level;
+    if (!Number.isInteger(level) || level < 0 || level > LEVEL_MAX_V2) {
+      throw new Error(
+        `v2 encode: level must be integer in [0, ${LEVEL_MAX_V2}], got ${level}`
+      );
     }
     // ビット OR は 32-bit signed 演算なので、unsigned 加算で coreBit を合成する。
     const word = (level + (n.core ? CORE_BIT_V2 : 0)) >>> 0;

--- a/lib/cycling/tile_binary.js
+++ b/lib/cycling/tile_binary.js
@@ -26,15 +26,24 @@
 //   24..27 cost         Float32
 //
 // === v2 (with CH metadata) ===
-// Same header (version = 2). Nodes carry a CH level; edges carry a viaId
-// (0 for original, nonzero for shortcut) plus the via node's coords so
-// unpacking can render the shortcut without loading the via's tile.
+// Same header (version = 2). Nodes carry a CH level + coreBit; edges carry
+// a viaId (0 for original, nonzero for shortcut) plus the via node's coords
+// so unpacking can render the shortcut without loading the via's tile.
 //
 // Nodes section (nodeCount * 20 bytes):
 //   0..7   id           Float64
 //   8..11  lon          Float32
 //   12..15 lat          Float32
-//   16..19 level        Uint32  (CH level; higher = contracted later = more important)
+//   16..19 levelWord    Uint32
+//                       bit 31      = coreBit (1 = uncontracted core node)
+//                       bits 0..30  = CH level (higher = contracted later = more important)
+//
+// coreBit was added later; older v2 tiles encoded with coreBit=0 decode
+// identically because bit 31 was always 0 (level << 31 was never reached
+// for any realistic graph). chQueryOnView allows core-core edges to be
+// relaxed without the level constraint, recovering correctness for
+// partial CH where the top fraction (and degree-skipped nodes) are left
+// uncontracted.
 //
 // Edges section (edgeCount * 40 bytes):
 //   0..7   from         Float64
@@ -58,6 +67,16 @@ const NODE_BYTES = 16;
 const NODE_BYTES_V2 = 20;
 const EDGE_BYTES = 28;
 const EDGE_BYTES_V2 = 40;
+// v2 ノードの levelWord 内訳: 上位 1 bit = coreBit、下位 31 bit = level。
+// 7.6M ノード規模 (Kansai) でも level は 2^23 程度に収まるため 31 bit
+// で余裕。encoder は level > LEVEL_MAX_V2 で例外 (将来 国全体に拡張する
+// 際に気付ける)。decoder は両 bit を分離する。
+const LEVEL_BITS_V2 = 31;
+// JS の `<<` は 32-bit signed 演算 (1 << 31 = -2147483648) になるため
+// `2 ** 31` 経由で 0x8000_0000 を unsigned に持つ。bit-mask 演算は decode
+// 側で u32 (>>> 0) に変換してから行う。
+const CORE_BIT_V2 = 2 ** LEVEL_BITS_V2; // 0x8000_0000
+const LEVEL_MAX_V2 = CORE_BIT_V2 - 1;   // 0x7FFF_FFFF
 
 function encodeTile(nodes, edges) {
   const total =
@@ -108,7 +127,13 @@ function encodeTileV2(nodes, edges) {
     dv.setFloat64(off, n.id, true);
     dv.setFloat32(off + 8, n.lon, true);
     dv.setFloat32(off + 12, n.lat, true);
-    dv.setUint32(off + 16, n.level >>> 0, true);
+    const level = (n.level >>> 0);
+    if (level > LEVEL_MAX_V2) {
+      throw new Error(`v2 encode: level ${level} exceeds LEVEL_MAX_V2 ${LEVEL_MAX_V2}`);
+    }
+    // ビット OR は 32-bit signed 演算なので、unsigned 加算で coreBit を合成する。
+    const word = (level + (n.core ? CORE_BIT_V2 : 0)) >>> 0;
+    dv.setUint32(off + 16, word, true);
     off += NODE_BYTES_V2;
   }
   for (const e of edges) {
@@ -186,11 +211,15 @@ function decodeTileV2(arrayBuffer, dv) {
   const nodes = new Array(nodeCount);
   let off = HEADER_BYTES;
   for (let i = 0; i < nodeCount; i += 1) {
+    const word = dv.getUint32(off + 16, true);
+    // bit-and は 32-bit signed → mask 演算は明示 u32 化 + 比較で対処。
+    // word >= CORE_BIT_V2 (= 0x8000_0000) なら coreBit が立っている。
     nodes[i] = {
       id: dv.getFloat64(off, true),
       lon: dv.getFloat32(off + 8, true),
       lat: dv.getFloat32(off + 12, true),
-      level: dv.getUint32(off + 16, true)
+      level: word >= CORE_BIT_V2 ? word - CORE_BIT_V2 : word,
+      core: word >= CORE_BIT_V2 ? 1 : 0
     };
     off += NODE_BYTES_V2;
   }
@@ -218,6 +247,9 @@ module.exports = {
   NODE_BYTES_V2,
   EDGE_BYTES,
   EDGE_BYTES_V2,
+  LEVEL_BITS_V2,
+  LEVEL_MAX_V2,
+  CORE_BIT_V2,
   encodeTile,
   encodeTileV2,
   decodeTile

--- a/lib/cycling/tile_loader.js
+++ b/lib/cycling/tile_loader.js
@@ -32,6 +32,10 @@ class TileLoader {
       // CH (タイル v2) で各ノードの level を保持。v1 タイルしかロード
       // していなければ空 Map になる。hasCh=true で chQuery を有効化。
       levels: new Map(),
+      // core ノード集合: partial CH の uncontracted core (top fraction +
+      // degree-skipped)。chQueryOnView 側で core-core edge は level 比較
+      // skip を許可する (lateral relax 可能) 根拠として参照。
+      cores: new Set(),
       hasCh: false
     };
     this.grid = new SpatialGrid();
@@ -96,7 +100,7 @@ class TileLoader {
   }
 
   _mergeBinary(arrayBuffer) {
-    const { nodes, fwd, rev, nodeIdToIndex, indexToNodeId, levels } = this.view;
+    const { nodes, fwd, rev, nodeIdToIndex, indexToNodeId, levels, cores } = this.view;
     const grid = this.grid;
     const registerNode = (id, lon, lat) => {
       if (nodes.has(id)) return;
@@ -113,7 +117,10 @@ class TileLoader {
     if (useCh) this.view.hasCh = true;
     for (const n of tileNodes) {
       registerNode(n.id, n.lon, n.lat);
-      if (useCh && !levels.has(n.id)) levels.set(n.id, n.level);
+      if (useCh && !levels.has(n.id)) {
+        levels.set(n.id, n.level);
+        if (n.core) cores.add(n.id);
+      }
     }
     for (const e of tileEdges) {
       // v2 で CH 無効化中: shortcut edge (viaId != 0) は無視。これを view に

--- a/lib/cycling/tiled_router.js
+++ b/lib/cycling/tiled_router.js
@@ -117,8 +117,10 @@ class TiledRouter {
 /**
  * CH (Contraction Hierarchies) クエリ。view.hasCh=true (タイル v2) のときに
  * TiledRouter から呼ばれる。標準的な bidirectional CH:
- *   forward Dijkstra: 各ノード u に対し level[to] > level[u] のエッジだけ relax
- *   backward Dijkstra: 各ノード u に対し level[from] > level[u] のエッジだけ
+ *   forward Dijkstra: u → v は level[v] > level[u] のエッジだけ relax
+ *   backward Dijkstra: u ← v は level[v] > level[u] のエッジだけ relax
+ *   ただし partial CH の core (uncontracted top + degree-skipped) 同士の
+ *   edge は level 比較を緩めて lateral 移動を許可する (view.cores 参照)
  *   meeting node m で best 更新、両方向の top key が best 以上で停止
  *   (片側 heap が空 = top=Infinity で自動的にその方向は terminated 扱い)
  * パスは meeting から forward/backward の parent を辿って取得し、各エッジ
@@ -182,9 +184,15 @@ function chQueryOnView(view, startId, goalId) {
       const db = distB.get(u);
       if (db !== undefined) tryMeet(u, d, db);
       const uLevel = levels.get(u);
+      const uIsCore = view.cores ? view.cores.has(u) : false;
       for (const e of view.fwd.get(u) || []) {
         const vLevel = levels.get(e.to);
-        if (vLevel === undefined || vLevel <= uLevel) continue;
+        if (vLevel === undefined) continue;
+        // partial CH の core-core edge は level 比較なしで relax 可能
+        // (lateral 移動を許可)。それ以外は通常通り upward (vLevel > uLevel) のみ。
+        const vIsCore = view.cores ? view.cores.has(e.to) : false;
+        const coreCoreLateral = uIsCore && vIsCore;
+        if (!coreCoreLateral && vLevel <= uLevel) continue;
         const nd = d + e.cost;
         if (nd < (distF.get(e.to) ?? Infinity)) {
           distF.set(e.to, nd);
@@ -202,9 +210,13 @@ function chQueryOnView(view, startId, goalId) {
       const df = distF.get(u);
       if (df !== undefined) tryMeet(u, df, d);
       const uLevel = levels.get(u);
+      const uIsCore = view.cores ? view.cores.has(u) : false;
       for (const e of view.rev.get(u) || []) {
         const fromLevel = levels.get(e.from);
-        if (fromLevel === undefined || fromLevel <= uLevel) continue;
+        if (fromLevel === undefined) continue;
+        const fromIsCore = view.cores ? view.cores.has(e.from) : false;
+        const coreCoreLateral = uIsCore && fromIsCore;
+        if (!coreCoreLateral && fromLevel <= uLevel) continue;
         const nd = d + e.cost;
         if (nd < (distB.get(e.from) ?? Infinity)) {
           distB.set(e.from, nd);

--- a/rust-router/src/bin/ch_preprocess.rs
+++ b/rust-router/src/bin/ch_preprocess.rs
@@ -68,9 +68,12 @@ fn load_nodes_ndjson(path: &Path) -> std::io::Result<(Vec<u64>, Vec<(f64, f64)>,
         }
         // Manual parse: nodes look like {"id":123,"lon":135.5,"lat":34.7}
         // Use a tiny extractor to avoid a serde dep for now.
-        let id = extract_field(&line, "\"id\"").and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
-        let lon = extract_field(&line, "\"lon\"").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
-        let lat = extract_field(&line, "\"lat\"").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
+        // 必須フィールドは fail-fast。0 fallback だと壊れた入力をそのまま
+        // 前処理して ch_levels.ndjson / ch_edges.ndjson に不正データを書き
+        // 出すリスクがあるため、parse 失敗は line 内容付きで panic させる。
+        let id = parse_required::<u64>(&line, "\"id\"");
+        let lon = parse_required::<f64>(&line, "\"lon\"");
+        let lat = parse_required::<f64>(&line, "\"lat\"");
         if id_to_idx.contains_key(&id) {
             continue;
         }
@@ -80,6 +83,24 @@ fn load_nodes_ndjson(path: &Path) -> std::io::Result<(Vec<u64>, Vec<(f64, f64)>,
         coords.push((lon, lat));
     }
     Ok((ids, coords, id_to_idx))
+}
+
+/// Required-field parser: extract + parse, panicking with the offending line
+/// content on failure. Used for id/lon/lat/from/to/cost_m where a 0 fallback
+/// would silently produce corrupt CH output.
+fn parse_required<T: std::str::FromStr>(line: &str, key: &str) -> T
+where
+    <T as std::str::FromStr>::Err: std::fmt::Display,
+{
+    let raw = extract_field(line, key).unwrap_or_else(|| {
+        panic!("ch-preprocess: missing required field {} in line: {}", key, line);
+    });
+    raw.parse::<T>().unwrap_or_else(|e| {
+        panic!(
+            "ch-preprocess: failed to parse {} (value={:?}) in line: {} — {}",
+            key, raw, line, e
+        );
+    })
 }
 
 /// Extracts the substring following `key":` (a number) up to `,` or `}`.
@@ -107,9 +128,9 @@ fn load_edges_ndjson(
         if line.is_empty() {
             continue;
         }
-        let from = extract_field(&line, "\"from\"").and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
-        let to = extract_field(&line, "\"to\"").and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
-        let cost = extract_field(&line, "\"cost_m\"").and_then(|s| s.parse::<f32>().ok()).unwrap_or(0.0);
+        let from = parse_required::<u64>(&line, "\"from\"");
+        let to = parse_required::<u64>(&line, "\"to\"");
+        let cost = parse_required::<f32>(&line, "\"cost_m\"");
         // oneway: "oneway":true / false / null. We look for the literal.
         let oneway = line.contains("\"oneway\":true");
         let from_idx = match id_to_idx.get(&from) {

--- a/rust-router/src/bin/ch_preprocess.rs
+++ b/rust-router/src/bin/ch_preprocess.rs
@@ -1,0 +1,483 @@
+//! Native CH preprocessor for ride-oasis cycling graph.
+//!
+//! Reads `<dir>/nodes.ndjson` and `<dir>/edges.ndjson` (the output of
+//! `scripts/cycling_build_graph.js`) and writes:
+//!   - `<dir>/ch_levels.ndjson`  one `{"id":N,"level":L,"core":0|1}` per node
+//!   - `<dir>/ch_edges.ndjson`   originals + shortcuts:
+//!         `{"from":U,"to":W,"cost":C,"via":V|null}`
+//!
+//! The format is forward-compatible with the previous JS implementation
+//! (`scripts/cycling_ch_build.js`); the new `core` field indicates whether
+//! a node is in the uncontracted core (top-fraction skipped + degree-skipped).
+//! `scripts/cycling_ch_tile_split.js` treats missing `core` as 0, so old
+//! ch_levels.ndjson can still be consumed.
+//!
+//! Algorithm: bounded-hop witness search + degree-based ordering.
+//! Per-iteration shortcut count is bounded by a Pareto-style "skip if shortcut
+//! cost >= existing witness path" rule. Naive but fast enough for Kansai-scale
+//! when implemented natively (vs the GC-heavy JS version that OOMs at 12 GB).
+
+use std::collections::BinaryHeap;
+use std::cmp::Ordering;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+const HOP_LIMIT: u32 = 5;
+
+#[derive(Clone, Copy)]
+struct Edge {
+    other: u32, // for fwd: target; for rev: source
+    cost: f32,
+    via: i32, // -1 = original, else dense index of via node
+}
+
+struct Graph {
+    n: usize,
+    ids: Vec<u64>,           // dense index -> original ID
+    coords: Vec<(f64, f64)>, // dense index -> (lon, lat)
+    fwd: Vec<Vec<Edge>>,
+    rev: Vec<Vec<Edge>>,
+    contracted: Vec<bool>,
+}
+
+impl Graph {
+    fn new() -> Self {
+        Graph {
+            n: 0,
+            ids: Vec::new(),
+            coords: Vec::new(),
+            fwd: Vec::new(),
+            rev: Vec::new(),
+            contracted: Vec::new(),
+        }
+    }
+}
+
+fn load_nodes_ndjson(path: &Path) -> std::io::Result<(Vec<u64>, Vec<(f64, f64)>, std::collections::HashMap<u64, u32>)> {
+    let f = File::open(path)?;
+    let r = BufReader::with_capacity(8 * 1024 * 1024, f);
+    let mut ids = Vec::new();
+    let mut coords = Vec::new();
+    let mut id_to_idx = std::collections::HashMap::new();
+    for line in r.lines() {
+        let line = line?;
+        if line.is_empty() {
+            continue;
+        }
+        // Manual parse: nodes look like {"id":123,"lon":135.5,"lat":34.7}
+        // Use a tiny extractor to avoid a serde dep for now.
+        let id = extract_field(&line, "\"id\"").and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
+        let lon = extract_field(&line, "\"lon\"").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
+        let lat = extract_field(&line, "\"lat\"").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
+        if id_to_idx.contains_key(&id) {
+            continue;
+        }
+        let idx = ids.len() as u32;
+        id_to_idx.insert(id, idx);
+        ids.push(id);
+        coords.push((lon, lat));
+    }
+    Ok((ids, coords, id_to_idx))
+}
+
+/// Extracts the substring following `key":` (a number) up to `,` or `}`.
+fn extract_field<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    let p = line.find(key)?;
+    let after = &line[p + key.len()..];
+    let colon = after.find(':')?;
+    let mut s = after[colon + 1..].trim_start();
+    // strip trailing "," or "}"
+    let end = s.find(|c: char| c == ',' || c == '}' || c.is_whitespace()).unwrap_or(s.len());
+    s = &s[..end];
+    Some(s)
+}
+
+fn load_edges_ndjson(
+    path: &Path,
+    id_to_idx: &std::collections::HashMap<u64, u32>,
+    graph: &mut Graph,
+) -> std::io::Result<u64> {
+    let f = File::open(path)?;
+    let r = BufReader::with_capacity(8 * 1024 * 1024, f);
+    let mut edge_count = 0u64;
+    for line in r.lines() {
+        let line = line?;
+        if line.is_empty() {
+            continue;
+        }
+        let from = extract_field(&line, "\"from\"").and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
+        let to = extract_field(&line, "\"to\"").and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
+        let cost = extract_field(&line, "\"cost_m\"").and_then(|s| s.parse::<f32>().ok()).unwrap_or(0.0);
+        // oneway: "oneway":true / false / null. We look for the literal.
+        let oneway = line.contains("\"oneway\":true");
+        let from_idx = match id_to_idx.get(&from) {
+            Some(i) => *i,
+            None => continue,
+        };
+        let to_idx = match id_to_idx.get(&to) {
+            Some(i) => *i,
+            None => continue,
+        };
+        graph.fwd[from_idx as usize].push(Edge { other: to_idx, cost, via: -1 });
+        graph.rev[to_idx as usize].push(Edge { other: from_idx, cost, via: -1 });
+        edge_count += 1;
+        if !oneway {
+            graph.fwd[to_idx as usize].push(Edge { other: from_idx, cost, via: -1 });
+            graph.rev[from_idx as usize].push(Edge { other: to_idx, cost, via: -1 });
+            edge_count += 1;
+        }
+    }
+    Ok(edge_count)
+}
+
+fn allocate_graph(n: usize, ids: Vec<u64>, coords: Vec<(f64, f64)>) -> Graph {
+    let fwd = (0..n).map(|_| Vec::new()).collect();
+    let rev = (0..n).map(|_| Vec::new()).collect();
+    Graph {
+        n,
+        ids,
+        coords,
+        fwd,
+        rev,
+        contracted: vec![false; n],
+    }
+}
+
+// Min-heap entry for witness search
+#[derive(Clone, Copy)]
+struct WSEntry {
+    dist: f32,
+    hops: u32,
+    node: u32,
+}
+
+impl Eq for WSEntry {}
+impl PartialEq for WSEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.dist == other.dist
+    }
+}
+impl Ord for WSEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.dist.partial_cmp(&self.dist).unwrap_or(Ordering::Equal)
+    }
+}
+impl PartialOrd for WSEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Multi-target bounded-hop Dijkstra from `start`, computing witness costs to
+/// all `targets` (typically the out-neighbors of the node being contracted).
+/// Skips `excluded` (the contracted node itself) and `contracted` nodes.
+/// Returns a vector aligned with `targets`: best cost found, or +inf.
+///
+/// Stopping: when heap top exceeds `max_overall` (max of per-target sc costs)
+/// or every target has been settled.
+fn witness_costs_multi(
+    graph: &Graph,
+    start: u32,
+    excluded: u32,
+    targets: &[u32],
+    target_caps: &[f32], // per-target shortcut cost upper bound
+    hop_limit: u32,
+    dist: &mut Vec<f32>,
+    touched: &mut Vec<u32>,
+    result: &mut Vec<f32>,
+) {
+    result.clear();
+    result.resize(targets.len(), f32::INFINITY);
+
+    // Index targets by node for O(1) hit check during search.
+    let mut target_idx_by_node: std::collections::HashMap<u32, usize> =
+        std::collections::HashMap::with_capacity(targets.len());
+    let mut max_cap = 0.0_f32;
+    for (i, &t) in targets.iter().enumerate() {
+        target_idx_by_node.insert(t, i);
+        if target_caps[i] > max_cap { max_cap = target_caps[i]; }
+    }
+    let mut remaining = targets.len();
+
+    let mut heap: BinaryHeap<WSEntry> = BinaryHeap::new();
+    dist[start as usize] = 0.0;
+    touched.push(start);
+    heap.push(WSEntry { dist: 0.0, hops: 0, node: start });
+
+    while let Some(WSEntry { dist: d, hops, node }) = heap.pop() {
+        if d > max_cap { break; }
+        if d > dist[node as usize] { continue; }
+        if let Some(&ti) = target_idx_by_node.get(&node) {
+            if result[ti].is_infinite() {
+                result[ti] = d;
+                remaining -= 1;
+                if remaining == 0 { break; }
+            }
+        }
+        if hops >= hop_limit { continue; }
+        for e in &graph.fwd[node as usize] {
+            if e.other == excluded { continue; }
+            if graph.contracted[e.other as usize] { continue; }
+            let nd = d + e.cost;
+            if nd > max_cap { continue; }
+            if nd < dist[e.other as usize] {
+                if dist[e.other as usize] == f32::INFINITY {
+                    touched.push(e.other);
+                }
+                dist[e.other as usize] = nd;
+                heap.push(WSEntry { dist: nd, hops: hops + 1, node: e.other });
+            }
+        }
+    }
+}
+
+fn reset_dist(dist: &mut Vec<f32>, touched: &mut Vec<u32>) {
+    for &t in touched.iter() {
+        dist[t as usize] = f32::INFINITY;
+    }
+    touched.clear();
+}
+
+/// Naive degree-based node ordering (low degree first). Future enhancement:
+/// edge-difference with lazy priority queue updates.
+fn compute_order(graph: &Graph) -> Vec<u32> {
+    let mut order: Vec<(u32, u32)> = (0..graph.n as u32)
+        .map(|v| (v, (graph.fwd[v as usize].len() + graph.rev[v as usize].len()) as u32))
+        .collect();
+    order.sort_unstable_by_key(|x| x.1);
+    order.into_iter().map(|x| x.0).collect()
+}
+
+#[derive(Clone, Copy)]
+struct ShortcutRec {
+    from: u32,
+    to: u32,
+    cost: f32,
+    via: u32,
+}
+
+const MAX_ACTIVE_DEGREE: usize = 64;
+
+fn build_ch(graph: &mut Graph, contract_fraction: f64) -> (Vec<u32>, Vec<bool>, Vec<ShortcutRec>) {
+    let n = graph.n;
+    let order = compute_order(graph);
+    let mut levels = vec![0u32; n];
+    // core[v] = !contracted[v] after build. partial CH query (CH side) では
+    // core ノード同士の edge は level 比較を緩める (上下方向制約を外す)
+    // 必要があるため、tile に明示 bit として書き出す。
+    let mut core = vec![false; n];
+    let limit = ((n as f64 * contract_fraction) as usize).min(n);
+
+    // Pre-allocated scratch for witness searches.
+    let mut dist: Vec<f32> = vec![f32::INFINITY; n];
+    let mut touched: Vec<u32> = Vec::with_capacity(4096);
+    let mut shortcuts: Vec<ShortcutRec> = Vec::new();
+    let mut targets: Vec<u32> = Vec::with_capacity(64);
+    let mut target_caps: Vec<f32> = Vec::with_capacity(64);
+    let mut witness_results: Vec<f32> = Vec::with_capacity(64);
+
+    let t0 = Instant::now();
+    let mut last_report = Instant::now();
+    let mut shortcut_inserts = 0u64;
+    let mut witness_calls = 0u64;
+    let mut skipped_degree = 0u64;
+
+    for (lvl, &v) in order.iter().enumerate() {
+        if lvl >= limit {
+            levels[v as usize] = lvl as u32;
+            // top-fraction (default 5%) は意図的に contract せず core 扱い。
+            // query 側で core-core edge を level 制約なしに relax できるよう
+            // marker を立てる。contracted=false のまま (skipped_degree と同じ)。
+            core[v as usize] = true;
+            continue;
+        }
+        levels[v as usize] = lvl as u32;
+
+        let ins: Vec<Edge> = graph.rev[v as usize]
+            .iter()
+            .filter(|e| !graph.contracted[e.other as usize])
+            .copied()
+            .collect();
+        let outs: Vec<Edge> = graph.fwd[v as usize]
+            .iter()
+            .filter(|e| !graph.contracted[e.other as usize])
+            .copied()
+            .collect();
+
+        if ins.is_empty() || outs.is_empty() {
+            graph.contracted[v as usize] = true;
+            continue;
+        }
+
+        // Naive ordering is degree-based, so we should contract low-degree
+        // nodes first. If active degree is huge (= node accumulated many
+        // shortcuts from earlier contractions), skip contraction and leave
+        // it as "core" — queries will use plain bidi Dijkstra here. This
+        // avoids the classic CH explosion where every (in × out) pair adds
+        // a shortcut and the graph grows to gigabytes.
+        if ins.len() > MAX_ACTIVE_DEGREE || outs.len() > MAX_ACTIVE_DEGREE {
+            skipped_degree += 1;
+            core[v as usize] = true;
+            continue;
+        }
+
+        // For each in-edge u -> v, do ONE multi-target witness search to all
+        // outs. This batches the heap setup cost across N targets.
+        for in_e in &ins {
+            let u = in_e.other;
+            // Build target list (skip u itself) with their shortcut cost caps.
+            targets.clear();
+            target_caps.clear();
+            for out_e in &outs {
+                if out_e.other == u { continue; }
+                targets.push(out_e.other);
+                target_caps.push(in_e.cost + out_e.cost);
+            }
+            if targets.is_empty() { continue; }
+            reset_dist(&mut dist, &mut touched);
+            witness_costs_multi(
+                graph, u, v, &targets, &target_caps, HOP_LIMIT,
+                &mut dist, &mut touched, &mut witness_results,
+            );
+            witness_calls += 1;
+            for (ti, &w) in targets.iter().enumerate() {
+                let sc_cost = target_caps[ti];
+                if witness_results[ti] <= sc_cost { continue; }
+                graph.fwd[u as usize].push(Edge { other: w, cost: sc_cost, via: v as i32 });
+                graph.rev[w as usize].push(Edge { other: u, cost: sc_cost, via: v as i32 });
+                shortcuts.push(ShortcutRec { from: u, to: w, cost: sc_cost, via: v });
+                shortcut_inserts += 1;
+            }
+        }
+
+        graph.contracted[v as usize] = true;
+
+        if last_report.elapsed().as_secs() >= 5 {
+            let pct = (lvl as f64 / n as f64) * 100.0;
+            eprintln!(
+                "  contraction: {:>10}/{} ({:.1}%) shortcuts={} witnesses={} elapsed={:.1}s",
+                lvl + 1, n, pct, shortcut_inserts, witness_calls, t0.elapsed().as_secs_f64()
+            );
+            last_report = Instant::now();
+        }
+    }
+    let core_count = core.iter().filter(|x| **x).count();
+    eprintln!(
+        "  contraction done: shortcuts={} witnesses={} skipped_high_degree={} core={} elapsed={:.1}s (limit={}/{})",
+        shortcut_inserts, witness_calls, skipped_degree, core_count, t0.elapsed().as_secs_f64(), limit, n
+    );
+    (levels, core, shortcuts)
+}
+
+fn write_levels(path: &Path, ids: &[u64], levels: &[u32], core: &[bool]) -> std::io::Result<()> {
+    let f = File::create(path)?;
+    let mut w = BufWriter::with_capacity(8 * 1024 * 1024, f);
+    for (i, &id) in ids.iter().enumerate() {
+        let core_bit = if core[i] { 1 } else { 0 };
+        writeln!(w, "{{\"id\":{},\"level\":{},\"core\":{}}}", id, levels[i], core_bit)?;
+    }
+    w.flush()
+}
+
+fn write_edges(
+    path: &Path,
+    graph: &Graph,
+    shortcuts: &[ShortcutRec],
+) -> std::io::Result<()> {
+    let f = File::create(path)?;
+    let mut w = BufWriter::with_capacity(8 * 1024 * 1024, f);
+    // Originals
+    for u in 0..graph.n {
+        for e in &graph.fwd[u] {
+            if e.via != -1 { continue; }
+            writeln!(
+                w,
+                "{{\"from\":{},\"to\":{},\"cost\":{},\"via\":null}}",
+                graph.ids[u], graph.ids[e.other as usize], e.cost
+            )?;
+        }
+    }
+    // Shortcuts
+    for sc in shortcuts {
+        writeln!(
+            w,
+            "{{\"from\":{},\"to\":{},\"cost\":{},\"via\":{}}}",
+            graph.ids[sc.from as usize],
+            graph.ids[sc.to as usize],
+            sc.cost,
+            graph.ids[sc.via as usize]
+        )?;
+    }
+    w.flush()
+}
+
+fn main() -> std::io::Result<()> {
+    let mut args = std::env::args().skip(1);
+    let mut dir: Option<PathBuf> = None;
+    let mut contract_fraction = 0.95_f64; // skip top 5% (expensive tail)
+    while let Some(a) = args.next() {
+        match a.as_str() {
+            "--dir" => dir = args.next().map(PathBuf::from),
+            "--contract-fraction" => {
+                contract_fraction = args.next()
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .filter(|v| *v > 0.0 && *v <= 1.0)
+                    .unwrap_or(0.95);
+            }
+            "-h" | "--help" => {
+                println!("Usage: ch-preprocess --dir <graphDir> [--contract-fraction 0.95]");
+                println!("  reads <dir>/nodes.ndjson + edges.ndjson");
+                println!("  writes <dir>/ch_levels.ndjson + ch_edges.ndjson");
+                println!("  --contract-fraction (0,1]: portion of nodes to contract (default 0.95,");
+                println!("    leaving top 5% uncontracted to avoid expensive tail)");
+                return Ok(());
+            }
+            other => {
+                eprintln!("unknown arg: {}", other);
+                std::process::exit(1);
+            }
+        }
+    }
+    let dir = dir.unwrap_or_else(|| {
+        eprintln!("--dir required");
+        std::process::exit(1);
+    });
+
+    let t0 = Instant::now();
+
+    eprintln!("[1/4] loading nodes from {}/nodes.ndjson", dir.display());
+    let (ids, coords, id_to_idx) = load_nodes_ndjson(&dir.join("nodes.ndjson"))?;
+    let n = ids.len();
+    eprintln!("  nodes: {} in {:.1}s", n, t0.elapsed().as_secs_f64());
+
+    let mut graph = allocate_graph(n, ids, coords);
+
+    let t1 = Instant::now();
+    eprintln!("[2/4] loading edges from {}/edges.ndjson", dir.display());
+    let e = load_edges_ndjson(&dir.join("edges.ndjson"), &id_to_idx, &mut graph)?;
+    eprintln!("  directed edges: {} in {:.1}s", e, t1.elapsed().as_secs_f64());
+
+    let t2 = Instant::now();
+    eprintln!(
+        "[3/4] building CH (hop_limit={}, contract_fraction={:.2})",
+        HOP_LIMIT, contract_fraction
+    );
+    let (levels, core, shortcuts) = build_ch(&mut graph, contract_fraction);
+    eprintln!(
+        "  shortcuts: {} in {:.1}s",
+        shortcuts.len(),
+        t2.elapsed().as_secs_f64()
+    );
+
+    let t3 = Instant::now();
+    eprintln!("[4/4] writing output");
+    write_levels(&dir.join("ch_levels.ndjson"), &graph.ids, &levels, &core)?;
+    write_edges(&dir.join("ch_edges.ndjson"), &graph, &shortcuts)?;
+    eprintln!("  written in {:.1}s", t3.elapsed().as_secs_f64());
+
+    eprintln!("done in {:.1}s", t0.elapsed().as_secs_f64());
+    let _ = fs::metadata(dir.join("ch_levels.ndjson"))?;
+    Ok(())
+}

--- a/scripts/cycling_ch_tile_split.js
+++ b/scripts/cycling_ch_tile_split.js
@@ -23,10 +23,11 @@ function usage() {
     'Usage: node scripts/cycling_ch_tile_split.js --dir <graphDir>',
     '',
     'Reads nodes.ndjson + ch_levels.ndjson + ch_edges.ndjson and writes:',
-    '  <graphDir>/tiles/{x}_{y}.bin  - binary v2 tile (level + viaId per edge)',
+    '  <graphDir>/tiles/{x}_{y}.bin  - binary v2 tile (level + coreBit + viaId per edge)',
     '  <graphDir>/tile_index.json    - { tiles, cell_deg, bbox, format }',
     '',
-    'v2 tiles preserve CH metadata: nodes carry their hierarchy level,',
+    'v2 tiles preserve CH metadata: nodes carry their hierarchy level',
+    'and a coreBit (1 = uncontracted core, allows lateral relax in query);',
     'edges carry a viaId (0 for original, nonzero for shortcut).'
   ].join('\n');
 }
@@ -97,12 +98,21 @@ async function main() {
   const t1 = Date.now();
   process.stderr.write(`[pass 2/3] reading CH levels from ${levelsPath}\n`);
   let levelCount = 0;
+  let coreCount = 0;
+  // core ノード集合。CH builder (rust-router) の出力 ch_levels.ndjson に
+  // 含まれる core=1 (uncontracted top fraction + degree-skipped) を保持。
+  // tile encoder 側で level の高位ビットに coreBit として詰める。
+  const cores = new Set();
   await streamLines(levelsPath, (line) => {
     const l = JSON.parse(line);
     levels.set(l.id, l.level);
+    if (l.core === 1) {
+      cores.add(l.id);
+      coreCount += 1;
+    }
     levelCount += 1;
   });
-  process.stderr.write(`  levels=${levelCount} in ${Date.now() - t1}ms\n`);
+  process.stderr.write(`  levels=${levelCount} core=${coreCount} in ${Date.now() - t1}ms\n`);
 
   // assemble per-tile node lists now that we know levels
   for (const [id, [lon, lat]] of nodes) {
@@ -112,7 +122,13 @@ async function main() {
       arr = [];
       tileNodes.set(key, arr);
     }
-    arr.push({ id, lon, lat, level: levels.get(id) || 0 });
+    arr.push({
+      id,
+      lon,
+      lat,
+      level: levels.get(id) || 0,
+      core: cores.has(id) ? 1 : 0
+    });
   }
 
   const pushEdge = (key, edge) => {

--- a/tests/cycling_ch_on_view.test.js
+++ b/tests/cycling_ch_on_view.test.js
@@ -17,15 +17,17 @@ function makeView() {
     nodeIdToIndex: new Map(),
     indexToNodeId: [],
     levels: new Map(),
+    cores: new Set(),
     hasCh: false
   };
 }
 
-function addNode(view, id, lon, lat, level) {
+function addNode(view, id, lon, lat, level, core) {
   view.nodes.set(id, [lon, lat]);
   view.nodeIdToIndex.set(id, view.indexToNodeId.length);
   view.indexToNodeId.push(id);
   if (level !== undefined) view.levels.set(id, level);
+  if (core) view.cores.add(id);
 }
 
 function ensure(m, k) {
@@ -123,6 +125,35 @@ test('CH: 無 level (旧形式) は Infinity', () => {
   link(view, 1, 2, 100);
   const r = chQueryOnView(view, 1, 2);
   assert.equal(r.distance, Infinity);
+});
+
+test('CH: core-core lateral relax (level 制約なしで横移動可能)', () => {
+  // 0 (level=10, core=1) - 1 (level=5, core=1) - 2 (level=10, core=0)
+  // 0→1 は level 10→5 で通常なら upward only に違反するが、両端 core なので relax 許可
+  // 2 は core でない (uncontracted top でも degree-skipped でもない通常ノード)
+  const view = makeView();
+  addNode(view, 0, 0, 0, 10, /*core*/ true);
+  addNode(view, 1, 0.001, 0, 5, /*core*/ true);
+  addNode(view, 2, 0.002, 0, 10, /*core*/ false);
+  link(view, 0, 1, 100); // core-core lateral
+  link(view, 1, 2, 100); // core-non_core upward (5→10) OK
+  const r = chQueryOnView(view, 0, 2);
+  assert.equal(r.distance, 200);
+});
+
+test('CH: core 無しで level 10→5 は relax 不可 (制約確認)', () => {
+  // 0 (level=10, core=0) - 1 (level=5, core=0)
+  // 通常 CH 制約で forward 0→1 不可、backward 1→0 も rev edge から見ると同様
+  const view = makeView();
+  addNode(view, 0, 0, 0, 10, /*core*/ false);
+  addNode(view, 1, 0.001, 0, 5, /*core*/ false);
+  link(view, 0, 1, 100);
+  const r = chQueryOnView(view, 0, 1);
+  // forward: 0 (L10) から 1 (L5) は下降 → skip
+  // backward: 1 (L5) から rev edge を見ても from=0 (L10) > to=1 (L5) なので upward OK
+  //   → backward は 0 を settle、forward は 0 を settle、distF=0, distB=100、meet at 0
+  // meeting=0、best=100。距離は OK
+  assert.equal(r.distance, 100);
 });
 
 test('CH と NBA* が同じ最短距離 (synthetic CH-encoded graph)', () => {

--- a/tests/cycling_tile_binary.test.js
+++ b/tests/cycling_tile_binary.test.js
@@ -147,6 +147,33 @@ test('v1 decode は level=0 / viaId=0 を補完して返す (v2 と同一形状)
   assert.equal(r.edges[0].viaId, 0);
 });
 
+test('v2: core=1 ノードは round-trip で core=1 を保持', () => {
+  const nodes = [
+    { id: 1, lon: 135, lat: 34, level: 10, core: 0 },
+    { id: 2, lon: 135.01, lat: 34, level: 20, core: 1 }
+  ];
+  const r = decodeTile(encodeTileV2(nodes, []));
+  assert.equal(r.nodes[0].level, 10);
+  assert.equal(r.nodes[0].core, 0);
+  assert.equal(r.nodes[1].level, 20);
+  assert.equal(r.nodes[1].core, 1);
+});
+
+test('v2: core 省略は core=0 として encode/decode される (旧 ndjson 互換)', () => {
+  const nodes = [{ id: 1, lon: 135, lat: 34, level: 0 }];
+  const r = decodeTile(encodeTileV2(nodes, []));
+  assert.equal(r.nodes[0].core, 0);
+});
+
+test('v2: level 上限 0x7FFFFFFF を超えると例外 (将来用ガード)', () => {
+  const { LEVEL_MAX_V2 } = require('../lib/cycling/tile_binary');
+  const tooLarge = LEVEL_MAX_V2 + 1;
+  assert.throws(
+    () => encodeTileV2([{ id: 1, lon: 0, lat: 0, level: tooLarge, core: 0 }], []),
+    /exceeds LEVEL_MAX_V2/
+  );
+});
+
 test('v2 サイズは v1 比 ~40% 増 (level + viaId 分)', () => {
   const nodes = Array.from({ length: 100 }, (_, i) => ({
     id: i, lon: 135 + i * 0.001, lat: 34, level: i % 16

--- a/tests/cycling_tile_binary.test.js
+++ b/tests/cycling_tile_binary.test.js
@@ -170,8 +170,20 @@ test('v2: level 上限 0x7FFFFFFF を超えると例外 (将来用ガード)', (
   const tooLarge = LEVEL_MAX_V2 + 1;
   assert.throws(
     () => encodeTileV2([{ id: 1, lon: 0, lat: 0, level: tooLarge, core: 0 }], []),
-    /exceeds LEVEL_MAX_V2/
+    /level must be integer/
   );
+});
+
+test('v2: level=undefined / NaN / 小数 / 負数も明示的に例外 (暗黙変換しない)', () => {
+  // フォーマット境界での fail-fast を担保。`>>> 0` の暗黙変換だと
+  // undefined/NaN は 0 に化け、小数は切り捨てられて気付かないため。
+  for (const bad of [undefined, NaN, 3.5, -1]) {
+    assert.throws(
+      () => encodeTileV2([{ id: 1, lon: 0, lat: 0, level: bad, core: 0 }], []),
+      /level must be integer/,
+      `expected throw for level=${String(bad)}`
+    );
+  }
 });
 
 test('v2 サイズは v1 比 ~40% 増 (level + viaId 分)', () => {

--- a/tests/cycling_tile_loader.test.js
+++ b/tests/cycling_tile_loader.test.js
@@ -4,7 +4,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const { TileLoader } = require('../lib/cycling/tile_loader');
-const { encodeTile } = require('../lib/cycling/tile_binary');
+const { encodeTile, encodeTileV2 } = require('../lib/cycling/tile_binary');
 
 function makeMemFetcher(data) {
   return async (key) => (key in data ? data[key] : null);
@@ -157,3 +157,33 @@ test('容量到達 ∧ 他者進行中のとき新規 load は skip', async () =
   gates.get('C').release();
   await pC;
 });
+
+test('v2 tile + enableCh=true: levels と cores が view に反映される', async () => {
+  const buf = encodeTileV2(
+    [
+      { id: 1, lon: 0, lat: 0, level: 10, core: 0 },
+      { id: 2, lon: 0.001, lat: 0, level: 20, core: 1 }
+    ],
+    [{ from: 1, to: 2, toLon: 0.001, toLat: 0, cost: 100, viaId: 0 }]
+  );
+  const loader = new TileLoader(makeMemFetcher({ A: buf }), { enableCh: true });
+  await loader.load('A');
+  assert.equal(loader.view.hasCh, true);
+  assert.equal(loader.view.levels.get(1), 10);
+  assert.equal(loader.view.levels.get(2), 20);
+  assert.equal(loader.view.cores.has(1), false);
+  assert.equal(loader.view.cores.has(2), true);
+});
+
+test('v2 tile + enableCh 既定 (false): hasCh=false、levels/cores は空', async () => {
+  const buf = encodeTileV2(
+    [{ id: 1, lon: 0, lat: 0, level: 10, core: 1 }],
+    []
+  );
+  const loader = new TileLoader(makeMemFetcher({ A: buf }));
+  await loader.load('A');
+  assert.equal(loader.view.hasCh, false);
+  assert.equal(loader.view.levels.size, 0);
+  assert.equal(loader.view.cores.size, 0);
+});
+


### PR DESCRIPTION
## 背景

CodexCLI 診断の根本対処 (PR #72 で停止条件を per-direction に修正済の続編)。

現行 CH preprocessor は naive degree ordering で 95% 縮約 + top 5% (uncontracted core) + degree-skipped (active degree > 64) を core として残す **partial CH** を生成しているが、これらの core ノードに同一 rank の level を割り当ててしまうと、query 側で \`vLevel <= uLevel\` skip により **core 内の lateral 移動が全部禁止** され、core 経由の最短経路が解けない (Codex 指摘)。

## 変更

- **Rust ch-preprocess** (\`rust-router/src/bin/ch_preprocess.rs\`)
  - 各ノードの \`core\` フラグを \`ch_levels.ndjson\` に \`{"id":N,"level":L,"core":0|1}\` として出力
  - top 5% + degree-skipped の両方を core 扱い
- **tile v2 schema** (\`lib/cycling/tile_binary.js\`)
  - ノードの level word の最上位 bit を coreBit として packing
  - level は 31bit = 0x7FFF_FFFF まで (Kansai 7.6M ノードでも余裕)
  - **byte サイズ変更なし** (互換)
- **tile_loader** (\`lib/cycling/tile_loader.js\`)
  - enableCh=true 時に core ノードを \`view.cores Set\` に蓄積
- **chQueryOnView** (\`lib/cycling/tiled_router.js\`)
  - forward/backward の relax で**両端 core なら level 比較 skip を許可** (lateral relax)
  - それ以外は従来通り upward only
- **tile_split** (\`scripts/cycling_ch_tile_split.js\`)
  - ndjson の core フィールドを読み、encodeTileV2 に渡す
  - core 省略は 0 として扱う旧フォーマット互換
- **Tests**
  - tile_binary v2: core round-trip / 省略時 0 / level 上限例外 (3)
  - tile_loader: enableCh+v2 で cores 反映 / 既定 false で空 (2)
  - ch query: core-core lateral relax / core 無し制約確認 (2)

## 互換性

- 既存 v2 タイル (coreBit=0 で encode 済) は新 decoder で core=0 として解釈される (high bit が立っていないため) → 既存挙動と完全互換
- 旧 \`ch_levels.ndjson\` (core フィールド無し) は core=0 として扱われる
- 引き続き \`opts.enableCh=false\` が既定で、本番は NBA*。**回帰リスクなし**

## 次のステップ (別 PR)

v2 タイル再生成 + R2 upload + worker.mjs で enableCh=true で本番 CH 投入。

## Test plan

- [x] \`npm test\` (293/293 pass)
- [x] \`cargo build --release --bin ch-preprocess\` 通る
- [ ] CI 緑後 merge