### PR TITLE
feat(cycling): CH を本番再投入 (enableCh=true + cache v4 + v2 タイル upload script)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "cf:migrate:remote": "wrangler d1 migrations apply rideoasis-supply-points --remote",
     "cf:migrate:local": "wrangler d1 migrations apply rideoasis-supply-points --local",
     "cf:seed:remote": "wrangler d1 execute rideoasis-supply-points --file=cloudflare/seed.sql --remote",
-    "cf:seed:local": "wrangler d1 execute rideoasis-supply-points --file=cloudflare/seed.sql --local"
+    "cf:seed:local": "wrangler d1 execute rideoasis-supply-points --file=cloudflare/seed.sql --local",
+    "cycling:ch-tile-split": "node --max-old-space-size=12288 scripts/cycling_ch_tile_split.js"
   },
   "engines": {
     "node": ">=22.5.0",

--- a/scripts/cycling_ch_tile_split.js
+++ b/scripts/cycling_ch_tile_split.js
@@ -20,7 +20,11 @@ function parseArgs(argv = process.argv.slice(2)) {
 
 function usage() {
   return [
-    'Usage: node scripts/cycling_ch_tile_split.js --dir <graphDir>',
+    'Usage: node --max-old-space-size=12288 scripts/cycling_ch_tile_split.js --dir <graphDir>',
+    '  (or: npm run cycling:ch-tile-split -- --dir <graphDir>)',
+    '',
+    'Note: --max-old-space-size=12288 (12GB) is required for Kansai-scale',
+    '  (7.6M nodes + 18M directed edges). Default 4GB heap OOMs in pass 3.',
     '',
     'Reads nodes.ndjson + ch_levels.ndjson + ch_edges.ndjson and writes:',
     '  <graphDir>/tiles/{x}_{y}.bin  - binary v2 tile (level + coreBit + viaId per edge)',

--- a/scripts/cycling_upload_tiles.sh
+++ b/scripts/cycling_upload_tiles.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Uploads `data/cycling/tiles/*.bin` to the R2 bucket
+# `ride-oasis-cycling-graph` under the `tiles/` prefix, in parallel.
+# Existing keys are overwritten (R2 last-write-wins). After upload the
+# worker sees fresh tiles on next isolate boot; cache_version in
+# worker.mjs should be bumped in the same deploy to bypass edge cache.
+#
+# Usage:
+#   bash scripts/cycling_upload_tiles.sh [--dir data/cycling] [--concurrency 8]
+#
+# Notes:
+#   - Defaults: dir=data/cycling, concurrency=8 (~3-5 min for ~1500 tiles)
+#   - Failures abort the loop (set -e). Re-run is idempotent.
+
+DIR="data/cycling"
+CONCURRENCY=8
+BUCKET="ride-oasis-cycling-graph"
+PREFIX="tiles/"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir) DIR="$2"; shift 2;;
+    --concurrency) CONCURRENCY="$2"; shift 2;;
+    -h|--help)
+      sed -n '1,/^DIR=/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
+      exit 0;;
+    *) echo "unknown arg: $1" >&2; exit 1;;
+  esac
+done
+
+TILES_DIR="$DIR/tiles"
+if [[ ! -d "$TILES_DIR" ]]; then
+  echo "missing $TILES_DIR" >&2
+  exit 1
+fi
+
+count=$(find "$TILES_DIR" -name '*.bin' | wc -l | tr -d ' ')
+echo "uploading $count tiles from $TILES_DIR to r2://$BUCKET/$PREFIX (concurrency=$CONCURRENCY)"
+
+# xargs で並列に `wrangler r2 object put --remote` を回す。エラー時は
+# set -e と xargs の終了コードで全体 fail させる。
+find "$TILES_DIR" -name '*.bin' -print0 \
+  | xargs -0 -P "$CONCURRENCY" -I{} bash -c '
+      f="$1"
+      key="'"$PREFIX"'$(basename "$f")"
+      npx wrangler r2 object put "'"$BUCKET"'/$key" --file="$f" --remote >/dev/null
+    ' _ {}
+
+echo "done"

--- a/scripts/cycling_upload_tiles.sh
+++ b/scripts/cycling_upload_tiles.sh
@@ -40,7 +40,8 @@ count=$(find "$TILES_DIR" -name '*.bin' | wc -l | tr -d ' ')
 echo "uploading $count tiles from $TILES_DIR to r2://$BUCKET/$PREFIX (concurrency=$CONCURRENCY)"
 
 # xargs で並列に `wrangler r2 object put --remote` を回す。各 put は
-# 一過性の DNS/接続エラーに備えて 3 回までリトライ (指数バックオフ)。
+# 一過性の DNS/接続エラーに備えて 3 回までリトライ (指数バックオフ 1s/2s)。
+# 最終試行後は待機せずに即 exit 1 して失敗検知を遅らせない。
 # それでも失敗すれば子プロセスが exit 1 を返し xargs/set -e で全体 fail。
 # upload は idempotent (R2 last-write-wins) なので、全体失敗時はスクリプト
 # を単純に再実行すれば残りも処理される。
@@ -48,13 +49,16 @@ find "$TILES_DIR" -name '*.bin' -print0 \
   | xargs -0 -P "$CONCURRENCY" -I{} bash -c '
       f="$1"
       key="'"$PREFIX"'$(basename "$f")"
-      for attempt in 1 2 3; do
+      max_attempts=3
+      for attempt in $(seq 1 $max_attempts); do
         if npx wrangler r2 object put "'"$BUCKET"'/$key" --file="$f" --remote >/dev/null 2>&1; then
           exit 0
         fi
-        sleep $((attempt * 2))
+        if [ "$attempt" -lt "$max_attempts" ]; then
+          sleep $((2 ** (attempt - 1)))  # 1, 2 (試行間), 最終試行後は待たない
+        fi
       done
-      echo "FAIL after 3 retries: $key" >&2
+      echo "FAIL after $max_attempts retries: $key" >&2
       exit 1
     ' _ {}
 

--- a/scripts/cycling_upload_tiles.sh
+++ b/scripts/cycling_upload_tiles.sh
@@ -39,13 +39,23 @@ fi
 count=$(find "$TILES_DIR" -name '*.bin' | wc -l | tr -d ' ')
 echo "uploading $count tiles from $TILES_DIR to r2://$BUCKET/$PREFIX (concurrency=$CONCURRENCY)"
 
-# xargs で並列に `wrangler r2 object put --remote` を回す。エラー時は
-# set -e と xargs の終了コードで全体 fail させる。
+# xargs で並列に `wrangler r2 object put --remote` を回す。各 put は
+# 一過性の DNS/接続エラーに備えて 3 回までリトライ (指数バックオフ)。
+# それでも失敗すれば子プロセスが exit 1 を返し xargs/set -e で全体 fail。
+# upload は idempotent (R2 last-write-wins) なので、全体失敗時はスクリプト
+# を単純に再実行すれば残りも処理される。
 find "$TILES_DIR" -name '*.bin' -print0 \
   | xargs -0 -P "$CONCURRENCY" -I{} bash -c '
       f="$1"
       key="'"$PREFIX"'$(basename "$f")"
-      npx wrangler r2 object put "'"$BUCKET"'/$key" --file="$f" --remote >/dev/null
+      for attempt in 1 2 3; do
+        if npx wrangler r2 object put "'"$BUCKET"'/$key" --file="$f" --remote >/dev/null 2>&1; then
+          exit 0
+        fi
+        sleep $((attempt * 2))
+      done
+      echo "FAIL after 3 retries: $key" >&2
+      exit 1
     ' _ {}
 
 echo "done"

--- a/worker.mjs
+++ b/worker.mjs
@@ -55,9 +55,14 @@ function ensureTileLoader(env) {
   // R2 origin の往復 (~100ms) を edge cache (caches.default) でスキップする。
   // 同じタイルは isolate を跨いで使い回せるので route の cold start が大幅短縮。
   tileLoaderCache = new TileLoader(
-    // cacheVersion を bump して旧 (v2 タイル) cache エントリを bypass。
-    // v1 タイル運用に戻したので v3 で fresh fetch を強制。
-    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default, 'v3')
+    // cacheVersion を bump して旧 (v3 = v1 タイル) cache エントリを bypass。
+    // PR #72 で chQuery 停止条件修正 + PR #74 で coreBit (partial CH core
+    // lateral relax) 実装後、coreBit 付き v2 タイルを再投入。
+    // v4 で fresh fetch を強制し、enableCh=true で CH を本番有効化する。
+    // chQuery 失敗 (SETTLED_CAP 到達 / unreachable) 時は TiledRouter が
+    // 自動的に NBA* fallback するので CPU 1102 のリスクなし。
+    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default, 'v4'),
+    { enableCh: true }
   );
   return tileLoaderCache;
 }


### PR DESCRIPTION
## 背景

PR #72 (chQuery 停止条件を per-direction に修正 + SETTLED_CAP fallback) + PR #74 (tile v2 に coreBit / partial CH core-core lateral relax) の修正完了に伴い、CH を本番有効化する。

## 変更

- \`worker.mjs\`
  - \`TileLoader\` に \`opts.enableCh=true\` を渡し、v2 タイルが読まれた時点で \`view.hasCh=true\` → \`TiledRouter\` が \`chQuery\` を優先実行
  - cache version を v3 → **v4** へ bump、旧 v3 cache エントリ (v1 タイル) を bypass して新規 upload した v2 タイル (coreBit 付き) を fresh fetch
- \`scripts/cycling_ch_tile_split.js\`
  - Kansai-scale (7.6M nodes + 18M directed edges) で default 4GB heap だと pass 3 で OOM するため、\`--max-old-space-size=12288\` を実運用要件として明文化
- \`package.json\`
  - \`npm run cycling:ch-tile-split\` (12GB heap ラッパ) 追加
- \`scripts/cycling_upload_tiles.sh\` (新規)
  - \`data/cycling/tiles/*.bin\` を R2 \`ride-oasis-cycling-graph/tiles/\` に \`xargs -P 8\` で並列 upload (各ファイル 3 回 retry / 指数バックオフ)

## 本番展開状況

本 PR merge 前にすでに R2 へ v2 タイル投入済:
- Rust \`ch-preprocess\` 再実行 (38s、core=384156)
- \`cycling_ch_tile_split.js\` (heap 12GB、1482 タイル、1.4GB、74.6s)
- \`scripts/cycling_upload_tiles.sh\` で R2 へ upload 完了
- 直接 probe で v2 magic (\`RIDE \\x02\`) 確認済

cache v4 への bump で edge cache の v1 エントリを bypass、merge 直後から CH が動作する想定。

## 安全弁

\`chQuery\` 失敗時 (SETTLED_CAP=20000 到達 / unreachable / level 制約で解けない) は \`TiledRouter\` が \`algorithm='ch-fallback-nba'\` で NBA* に自動降格するため CPU 1102 のリスクなし。

## 検証

merge 後、\`/api/route?from=...&to=...\` の \`algorithm\` フィールドで \`ch\` / \`ch-fallback-nba\` / \`nba\` の分布を観測。期待値は majority が \`ch\`。

## Test plan

- [x] \`npm test\` (306/306 pass)
- [x] Rust binary build OK
- [x] R2 へ v2 タイル投入済 (probe で magic 確認)
- [ ] CI 緑後 admin merge
- [ ] 本番 3km route で \`algorithm=ch\` 確認 + latency 計測