### PR TITLE
fix(cycling): CH 緊急 rollback (Workers exceededMemory 判明、CPU でなくメモリ超過)

### DIFF
--- a/worker.mjs
+++ b/worker.mjs
@@ -55,15 +55,14 @@ function ensureTileLoader(env) {
   // R2 origin の往復 (~100ms) を edge cache (caches.default) でスキップする。
   // 同じタイルは isolate を跨いで使い回せるので route の cold start が大幅短縮。
   tileLoaderCache = new TileLoader(
-    // PR #77: CH 再投入 with **超タイトな defensive caps + テレメトリ**。
-    // SETTLED_CAP=5000 / POPS_CAP=30000 / TIME_BUDGET_MS=800 でどんな
-    // pathological case でも 1 秒以内に Infinity を返し NBA* fallback に
-    // 逃がす。chQuery の各種 timing は console.log でテレメトリ出力し
-    // wrangler tail で production の実態を観測する (CH 完走率 / 平均 chMs
-    // / fallback 比率)。
-    // cache v6 で前 v5 (NBA* 応答) を bypass。
-    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default, 'v6'),
-    { enableCh: true }
+    // PR #77 で CH 再投入 → wrangler tail で `outcome: exceededMemory` が
+    // 確認できた (128MB 制限超過; CPU ではなくメモリが原因だった)。
+    // CH 有効時は shortcut edge が view に追加され、shortcut/original = 1:1
+    // 程度のため adjacency list が倍化する。これと隣接 Map (levels/cores)
+    // とで Workers メモリ予算を超過する。
+    // 根本対処 (typed-array adjacency 化 / shortcut の lazy 解決 等) は
+    // 別 PR。本コミットでは緊急 rollback として enableCh を外し v7 にする。
+    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default, 'v7')
   );
   return tileLoaderCache;
 }


### PR DESCRIPTION
## 重大な原因判明

PR #77 で defensive caps + テレメトリで CH 再投入 → \`wrangler tail\` で実態確認:

\`\`\`json
{
  "outcome": "exceededMemory",
  "exceptions": [...],
  "response": { "status": 503 }
}
\`\`\`

**CPU 1102 ではなく Workers 128MB メモリ上限超過** だった。Cloudflare の Workers エラー表示は CPU/メモリどちらも 1102 を返すため、これまで CPU 問題と誤認していた。

## 原因

CH 有効時、v2 タイルの shortcut edge (viaId != 0) が view に追加され、adjacency list が倍化する。3km route corridor 16 タイルで:

- 原始 edge: ~1M
- shortcut edge: ~1M (Rust CH preprocessor 出力: 18M shortcuts / 16M original ≒ 1:1)
- **合計 ~2M edges**
- JS object 表現 (\`{from, to, toLon, toLat, cost, viaId}\`) で 1 edge ~100B → **~200MB**
- 加えて levels/cores Map (~10MB)
- chQuery 内の distF/distB/parentF/parentB Map 等 (~数 MB)

→ Workers 128MB 上限を超過。

## 重要な教訓

defensive caps (SETTLED_CAP / POPS_CAP / TIME_BUDGET_MS) は **CPU 計算量** の cap で、**メモリ** の cap ではない。view へのタイルロード自体がメモリを食うため、chQuery が始まる前に既に高メモリ状態 → どんな caps でも超過する。

## 変更

- \`worker.mjs\`: \`enableCh: true\` → 削除、cache version v6 → **v7** へ bump

## 根本対処 (別 PR で検討)

- typed-array adjacency 化 (1 edge を ~28B に圧縮、~3.5x 縮小)
- v2 タイル decode 時に shortcut を別ストアに分離し、chQuery 経路でのみ参照 (NBA* は原始のみ)
- view クリア頻度を上げる (maxTiles を 128 → 32 に)
- TileLoader を per-request にする (per-isolate 共有を諦める)
- decode を必要なフィールドだけに絞る

## Test plan

- [x] \`npm test\` (306/306 pass)
- [ ] admin merge 後 production \`alg=nba\` 200 復旧確認