### PR TITLE
feat(cycling): CH ephemeral CSR で Workers 128MB 内に収める (typed-array per-request)

### DIFF
--- a/lib/cycling/ch_csr.js
+++ b/lib/cycling/ch_csr.js
@@ -1,0 +1,299 @@
+'use strict';
+
+// CH-mode ephemeral CSR graph builder for memory-constrained environments
+// (Cloudflare Workers 128MB).
+//
+// Background: the existing TileLoader.view holds edges as JS objects in
+// Map<id, edge[]>, which works for NBA* (filter shortcuts, keeps view ~70MB)
+// but exceeds 128MB once shortcut edges are included. The CH path needs
+// shortcut edges, so we use a separate ephemeral representation:
+//
+//   - per-request build from ArrayBuffers (no persistent CH state across reqs)
+//   - typed-array CSR (Compressed Sparse Row): single Uint32/Float32/Float64
+//     allocations instead of millions of JS objects
+//   - released right after chQuery (GC reclaims)
+//
+// Memory profile for a Kansai 16-tile corridor (~300k unique nodes, ~1.7M
+// edges including shortcuts):
+//
+//   - JS object representation: ~200MB (exceeds Workers 128MB)
+//   - Typed CSR (this module):  ~30-50MB (fits comfortably)
+//
+// CSR layout per direction (fwd / rev):
+//   offsets: Uint32Array(nodeCount + 1)
+//     for node-index i, its edges live in [offsets[i], offsets[i+1])
+//   to:      Uint32Array(edgeCount)  // local node index of the other endpoint
+//   cost:    Float32Array(edgeCount) // meters (within Float32 precision)
+//   viaId:   Uint32Array(edgeCount)  // local index of via node, or 0xFFFFFFFF
+//
+// Nodes are stored as parallel arrays of Float64Array/Float32Array/Uint32Array
+// + a Map<osmId, localIdx> for snap lookups.
+
+const HEADER_BYTES = 16;
+const NODE_BYTES = 16;          // v1
+const NODE_BYTES_V2 = 20;       // v2 has level+coreBit word
+const EDGE_BYTES = 28;          // v1
+const EDGE_BYTES_V2 = 40;       // v2 has pad+viaId
+const MAGIC = 0x45444952;
+const CORE_BIT_V2 = 2 ** 31;
+const LEVEL_MASK_V2 = CORE_BIT_V2 - 1;
+
+const NO_VIA = 0xFFFFFFFF; // sentinel "no via" in local-index space
+// Sentinel for "level unknown" (node only registered as cross-tile target,
+// not in any loaded tile's nodes section). chQueryCsr must SKIP edges to/from
+// such nodes — matching view-based chQueryOnView's `levels.get(id) === undefined`
+// behavior. We can't use 0 (collides with real level 0) or 0xFFFFFFFF (= rev
+// of "no via", and `vLevel <= uLevel` happens to be false but caller wants
+// explicit skip semantic).
+const UNKNOWN_LEVEL = 0xFFFFFFFE;
+
+/**
+ * Quickly read a tile's node-count and edge-count from its header without
+ * decoding the body. Returns null on bad magic or unsupported version.
+ */
+function readHeader(buf) {
+  if (!buf || buf.byteLength < HEADER_BYTES) return null;
+  const dv = new DataView(buf);
+  if (dv.getUint32(0, true) !== MAGIC) return null;
+  const version = dv.getUint8(4);
+  if (version !== 1 && version !== 2) return null;
+  return {
+    version,
+    nodeCount: dv.getUint32(8, true),
+    edgeCount: dv.getUint32(12, true)
+  };
+}
+
+/**
+ * Build a CSR from a set of tile ArrayBuffers.
+ *
+ * Streaming: never materializes JS edge objects. Each tile is read 3 times
+ * via DataView (cheap, just byte access): once for nodes, twice for edges
+ * (count degrees, then fill CSR). Total work O(N + E).
+ *
+ * @param {Array<{key: string, buf: ArrayBuffer}>} tiles
+ * @returns {object} CSR
+ */
+function buildCsr(tiles) {
+  // Pass A: nodes
+  // Assign local Uint32 index to each unique OSM id. Track lon/lat/level/core.
+  const idToIdx = new Map();
+  // Use plain arrays during build (numbers boxed to doubles inside V8 for
+  // OSM id range), then snapshot to TypedArrays at the end.
+  const nodeOsmIds = [];   // pushed in encounter order
+  const nodeLons = [];
+  const nodeLats = [];
+  const nodeLevels = [];
+  const nodeCores = [];
+
+  for (const { buf } of tiles) {
+    const header = readHeader(buf);
+    if (!header) continue;
+    const dv = new DataView(buf);
+    let off = HEADER_BYTES;
+    if (header.version === 2) {
+      for (let i = 0; i < header.nodeCount; i += 1) {
+        const id = dv.getFloat64(off, true);
+        const lon = dv.getFloat32(off + 8, true);
+        const lat = dv.getFloat32(off + 12, true);
+        const word = dv.getUint32(off + 16, true);
+        const level = word >= CORE_BIT_V2 ? word - CORE_BIT_V2 : word;
+        const core = word >= CORE_BIT_V2 ? 1 : 0;
+        if (!idToIdx.has(id)) {
+          idToIdx.set(id, nodeOsmIds.length);
+          nodeOsmIds.push(id);
+          nodeLons.push(lon);
+          nodeLats.push(lat);
+          nodeLevels.push(level);
+          nodeCores.push(core);
+        }
+        off += NODE_BYTES_V2;
+      }
+    } else {
+      // v1: no level, no core
+      for (let i = 0; i < header.nodeCount; i += 1) {
+        const id = dv.getFloat64(off, true);
+        const lon = dv.getFloat32(off + 8, true);
+        const lat = dv.getFloat32(off + 12, true);
+        if (!idToIdx.has(id)) {
+          idToIdx.set(id, nodeOsmIds.length);
+          nodeOsmIds.push(id);
+          nodeLons.push(lon);
+          nodeLats.push(lat);
+          // v1 タイルには level がない → unknown 扱いで relax をスキップさせる
+          nodeLevels.push(UNKNOWN_LEVEL);
+          nodeCores.push(0);
+        }
+        off += NODE_BYTES;
+      }
+    }
+  }
+
+  // Pass B: register target nodes from edges (so cross-tile targets get
+  // a local index + coord). Also count fwd/rev degrees while we're here.
+  // We deferred this to a second pass because we need final nodeCount
+  // before allocating degree arrays.
+  // First, collect tile edge specs.
+  const tileEdgeSpecs = []; // { dv, off, edgeCount, edgeBytes }
+  for (const { buf } of tiles) {
+    const header = readHeader(buf);
+    if (!header) { tileEdgeSpecs.push(null); continue; }
+    const dv = new DataView(buf);
+    const off = HEADER_BYTES + header.nodeCount * (header.version === 2 ? NODE_BYTES_V2 : NODE_BYTES);
+    const edgeBytes = header.version === 2 ? EDGE_BYTES_V2 : EDGE_BYTES;
+    tileEdgeSpecs.push({ dv, off, edgeCount: header.edgeCount, edgeBytes, version: header.version });
+  }
+  // Register cross-tile target nodes (one DataView pass; lightweight)
+  for (const spec of tileEdgeSpecs) {
+    if (!spec) continue;
+    let off = spec.off;
+    for (let i = 0; i < spec.edgeCount; i += 1) {
+      const to = spec.dv.getFloat64(off + 8, true);
+      if (!idToIdx.has(to)) {
+        const toLon = spec.dv.getFloat32(off + 16, true);
+        const toLat = spec.dv.getFloat32(off + 20, true);
+        idToIdx.set(to, nodeOsmIds.length);
+        nodeOsmIds.push(to);
+        nodeLons.push(toLon);
+        nodeLats.push(toLat);
+        // cross-tile target (this tile に nodes 記載なし、別 tile も未ロード)
+        // → level 不明として relax をスキップさせる
+        nodeLevels.push(UNKNOWN_LEVEL);
+        nodeCores.push(0);
+      }
+      off += spec.edgeBytes;
+    }
+  }
+  // Also register via nodes (so shortcut expansion paths can find them).
+  if (tileEdgeSpecs.some(s => s && s.version === 2)) {
+    for (const spec of tileEdgeSpecs) {
+      if (!spec || spec.version !== 2) continue;
+      let off = spec.off;
+      for (let i = 0; i < spec.edgeCount; i += 1) {
+        const viaId = spec.dv.getFloat64(off + 32, true);
+        if (viaId && viaId !== 0 && !idToIdx.has(viaId)) {
+          // via node coords unknown (not in this tile). Use NaN coords;
+          // grid/snap won't reach them but unpackChEdge needs the index.
+          idToIdx.set(viaId, nodeOsmIds.length);
+          nodeOsmIds.push(viaId);
+          nodeLons.push(NaN);
+          nodeLats.push(NaN);
+          nodeLevels.push(UNKNOWN_LEVEL);
+          nodeCores.push(0);
+        }
+        off += spec.edgeBytes;
+      }
+    }
+  }
+
+  const nodeCount = nodeOsmIds.length;
+
+  // Snapshot node arrays to TypedArrays.
+  const ids = new Float64Array(nodeOsmIds);
+  const lons = new Float32Array(nodeLons);
+  const lats = new Float32Array(nodeLats);
+  const levels = new Uint32Array(nodeLevels);
+  const cores = new Uint8Array(nodeCores);
+
+  // Pass C: count fwd/rev degrees.
+  const fwdDeg = new Uint32Array(nodeCount);
+  const revDeg = new Uint32Array(nodeCount);
+  let totalEdges = 0;
+  for (const spec of tileEdgeSpecs) {
+    if (!spec) continue;
+    let off = spec.off;
+    for (let i = 0; i < spec.edgeCount; i += 1) {
+      const from = spec.dv.getFloat64(off, true);
+      const to = spec.dv.getFloat64(off + 8, true);
+      const fIdx = idToIdx.get(from);
+      const tIdx = idToIdx.get(to);
+      if (fIdx !== undefined && tIdx !== undefined) {
+        fwdDeg[fIdx] += 1;
+        revDeg[tIdx] += 1;
+        totalEdges += 1;
+      }
+      off += spec.edgeBytes;
+    }
+  }
+
+  // Prefix sums → offsets.
+  const fwdOffsets = new Uint32Array(nodeCount + 1);
+  const revOffsets = new Uint32Array(nodeCount + 1);
+  for (let i = 0; i < nodeCount; i += 1) {
+    fwdOffsets[i + 1] = fwdOffsets[i] + fwdDeg[i];
+    revOffsets[i + 1] = revOffsets[i] + revDeg[i];
+  }
+
+  // Pass D: fill CSR arrays.
+  const fwdTo = new Uint32Array(totalEdges);
+  const fwdCost = new Float32Array(totalEdges);
+  const fwdViaId = new Uint32Array(totalEdges); // 0 sentinel via NO_VIA for original edges
+  const revFrom = new Uint32Array(totalEdges);
+  const revCost = new Float32Array(totalEdges);
+  const revViaId = new Uint32Array(totalEdges);
+  // Cursors copy offsets so we can advance write positions per from/to.
+  const fwdCursor = new Uint32Array(fwdOffsets.length);
+  const revCursor = new Uint32Array(revOffsets.length);
+  fwdCursor.set(fwdOffsets);
+  revCursor.set(revOffsets);
+  for (const spec of tileEdgeSpecs) {
+    if (!spec) continue;
+    let off = spec.off;
+    for (let i = 0; i < spec.edgeCount; i += 1) {
+      const from = spec.dv.getFloat64(off, true);
+      const to = spec.dv.getFloat64(off + 8, true);
+      const cost = spec.dv.getFloat32(off + 24, true);
+      let viaIdx = NO_VIA;
+      if (spec.version === 2) {
+        const viaOsm = spec.dv.getFloat64(off + 32, true);
+        if (viaOsm && viaOsm !== 0) {
+          const vi = idToIdx.get(viaOsm);
+          if (vi !== undefined) viaIdx = vi;
+        }
+      }
+      const fIdx = idToIdx.get(from);
+      const tIdx = idToIdx.get(to);
+      if (fIdx !== undefined && tIdx !== undefined) {
+        const fp = fwdCursor[fIdx]++;
+        fwdTo[fp] = tIdx;
+        fwdCost[fp] = cost;
+        fwdViaId[fp] = viaIdx;
+        const rp = revCursor[tIdx]++;
+        revFrom[rp] = fIdx;
+        revCost[rp] = cost;
+        revViaId[rp] = viaIdx;
+      }
+      off += spec.edgeBytes;
+    }
+  }
+
+  return {
+    nodeCount,
+    edgeCount: totalEdges,
+    idToIdx,
+    ids, lons, lats, levels, cores,
+    fwdOffsets, fwdTo, fwdCost, fwdViaId,
+    revOffsets, revFrom, revCost, revViaId,
+    NO_VIA
+  };
+}
+
+/**
+ * Memory estimate (bytes) for a CSR view. Used by callers to log/observe.
+ */
+function csrMemoryBytes(csr) {
+  const arrs = [
+    csr.ids, csr.lons, csr.lats, csr.levels, csr.cores,
+    csr.fwdOffsets, csr.fwdTo, csr.fwdCost, csr.fwdViaId,
+    csr.revOffsets, csr.revFrom, csr.revCost, csr.revViaId
+  ];
+  return arrs.reduce((s, a) => s + (a ? a.byteLength : 0), 0);
+}
+
+module.exports = {
+  buildCsr,
+  csrMemoryBytes,
+  NO_VIA,
+  UNKNOWN_LEVEL,
+  readHeader
+};

--- a/lib/cycling/chquery_csr.js
+++ b/lib/cycling/chquery_csr.js
@@ -1,0 +1,204 @@
+'use strict';
+
+// CSR-based CH query. Operates on typed-array CSR (lib/cycling/ch_csr.js)
+// instead of Map<id, edge[]> view. Algorithm is identical to chQueryOnView
+// (bidirectional Dijkstra with upward-only relax + core-core lateral relax)
+// but adjacency lookups go through Uint32Array offsets, and node id ↔ index
+// uses CSR.idToIdx (snap) / CSR.ids (path-time osm id recovery).
+//
+// Distance/parent/settled state uses TypedArrays of length nodeCount, not
+// Maps. This keeps the per-query allocation O(nodeCount) bytes instead of
+// O(settled) JS Map entries.
+
+const { MinHeap } = require('./min_heap');
+const { UNKNOWN_LEVEL } = require('./ch_csr');
+
+const INF = Infinity;
+
+/**
+ * @param {object} csr  buildCsr() の戻り値
+ * @param {number} startIdx  local node index (CSR.idToIdx.get(osmId))
+ * @param {number} goalIdx
+ * @param {object} [opts]
+ * @param {number} [opts.settledCap=20000]
+ * @param {number} [opts.popsCap=80000]
+ * @param {number} [opts.timeBudgetMs=1500]
+ * @returns {{ distance, pathIdx, settled }}
+ *   pathIdx は local-index 配列。caller が CSR.ids で OSM id に戻す。
+ *   shortcut の展開はここでは行わず caller 側 (unpackChEdgeCsr) で行う。
+ */
+function chQueryCsr(csr, startIdx, goalIdx, opts) {
+  const settledCap = opts?.settledCap ?? 20000;
+  const popsCap = opts?.popsCap ?? 80000;
+  const timeBudgetMs = opts?.timeBudgetMs ?? 1500;
+
+  const n = csr.nodeCount;
+  if (startIdx === goalIdx) {
+    return { distance: 0, pathIdx: [startIdx], settled: 0, terminated: 'same' };
+  }
+  if (startIdx < 0 || goalIdx < 0 || startIdx >= n || goalIdx >= n) {
+    return { distance: INF, pathIdx: [], settled: 0, terminated: 'oob' };
+  }
+
+  // Float64 for precision (Float32 で 16-bit precision loss が累積誤差 → 経路選択差)
+  const distF = new Float64Array(n);
+  const distB = new Float64Array(n);
+  distF.fill(INF);
+  distB.fill(INF);
+  distF[startIdx] = 0;
+  distB[goalIdx] = 0;
+
+  // parent stores predecessor index (or -1). Edge index NOT stored; for
+  // shortcut expansion we re-lookup the via via fwdViaId/revViaId at output.
+  const parentF = new Int32Array(n);
+  const parentB = new Int32Array(n);
+  parentF.fill(-1);
+  parentB.fill(-1);
+
+  const settledF = new Uint8Array(n);
+  const settledB = new Uint8Array(n);
+
+  const heapF = new MinHeap();
+  const heapB = new MinHeap();
+  heapF.push(0, startIdx);
+  heapB.push(0, goalIdx);
+
+  let best = INF;
+  let meeting = -1;
+  const tryMeet = (u, df, db) => {
+    const sum = df + db;
+    if (sum < best) {
+      best = sum;
+      meeting = u;
+    }
+  };
+
+  const t0 = Date.now();
+  let pops = 0;
+  let settledCount = 0;
+
+  const { levels, cores, fwdOffsets, fwdTo, fwdCost, revOffsets, revFrom, revCost } = csr;
+
+  while (heapF.size > 0 || heapB.size > 0) {
+    if (settledCount > settledCap || pops > popsCap) {
+      return { distance: INF, pathIdx: [], settled: settledCount, terminated: 'cap' };
+    }
+    if ((pops & 0x3FF) === 0 && (Date.now() - t0) > timeBudgetMs) {
+      return { distance: INF, pathIdx: [], settled: settledCount, terminated: 'time' };
+    }
+    pops += 1;
+
+    const topF = heapF.size > 0 ? heapF.peek().key : INF;
+    const topB = heapB.size > 0 ? heapB.peek().key : INF;
+    if (topF >= best && topB >= best) break;
+    const expandF = topF < best && (topB >= best || topF <= topB);
+
+    if (expandF) {
+      const { key: d, val: u } = heapF.pop();
+      if (settledF[u]) continue;
+      if (d > distF[u]) continue;
+      settledF[u] = 1;
+      settledCount += 1;
+      if (distB[u] !== INF) tryMeet(u, d, distB[u]);
+      const uLevel = levels[u];
+      const uIsCore = cores[u] === 1;
+      const startOff = fwdOffsets[u];
+      const endOff = fwdOffsets[u + 1];
+      for (let e = startOff; e < endOff; e += 1) {
+        const v = fwdTo[e];
+        const vLevel = levels[v];
+        // view-base chQueryOnView の `levels.get(v) === undefined` 相当:
+        // cross-tile target など level 不明な node への relax は禁止。
+        if (vLevel === UNKNOWN_LEVEL) continue;
+        const coreCoreLateral = uIsCore && cores[v] === 1;
+        if (!coreCoreLateral && vLevel <= uLevel) continue;
+        const nd = d + fwdCost[e];
+        if (nd < distF[v]) {
+          distF[v] = nd;
+          parentF[v] = u;
+          heapF.push(nd, v);
+          if (distB[v] !== INF) tryMeet(v, nd, distB[v]);
+        }
+      }
+    } else {
+      const { key: d, val: u } = heapB.pop();
+      if (settledB[u]) continue;
+      if (d > distB[u]) continue;
+      settledB[u] = 1;
+      settledCount += 1;
+      if (distF[u] !== INF) tryMeet(u, distF[u], d);
+      const uLevel = levels[u];
+      const uIsCore = cores[u] === 1;
+      const startOff = revOffsets[u];
+      const endOff = revOffsets[u + 1];
+      for (let e = startOff; e < endOff; e += 1) {
+        const v = revFrom[e];
+        const vLevel = levels[v];
+        if (vLevel === UNKNOWN_LEVEL) continue;
+        const coreCoreLateral = uIsCore && cores[v] === 1;
+        if (!coreCoreLateral && vLevel <= uLevel) continue;
+        const nd = d + revCost[e];
+        if (nd < distB[v]) {
+          distB[v] = nd;
+          parentB[v] = u;
+          heapB.push(nd, v);
+          if (distF[v] !== INF) tryMeet(v, distF[v], nd);
+        }
+      }
+    }
+  }
+
+  if (meeting < 0 || !Number.isFinite(best)) {
+    return { distance: INF, pathIdx: [], settled: settledCount, terminated: 'noMeet' };
+  }
+
+  // Reconstruct path (local idx). forward chain start → meeting + backward
+  // chain meeting → goal. Shortcut expansion done by caller.
+  const fwdChain = [meeting];
+  for (let cur = meeting; parentF[cur] !== -1; cur = parentF[cur]) fwdChain.push(parentF[cur]);
+  fwdChain.reverse();
+  const backChain = [];
+  for (let cur = meeting; parentB[cur] !== -1; cur = parentB[cur]) backChain.push(parentB[cur]);
+  const pathIdx = fwdChain.concat(backChain);
+  return { distance: best, pathIdx, settled: settledCount, terminated: 'ok' };
+}
+
+/**
+ * Walk a (uIdx → vIdx) edge in CSR and expand any shortcut via recursively.
+ * Pushes intermediate node indices (excluding uIdx) into `out`.
+ * If a (uIdx, vIdx) edge is not found (cross-corridor leak), pushes vIdx
+ * directly as a fallback so the path stays continuous.
+ */
+function unpackChEdgeCsr(csr, uIdx, vIdx, out) {
+  const { fwdOffsets, fwdTo, fwdViaId, NO_VIA: noVia } = csr;
+  const stack = [[uIdx, vIdx]];
+  let safety = 0;
+  while (stack.length > 0) {
+    if (++safety > 1_000_000) break;
+    const [a, b] = stack.pop();
+    // Linear scan in CSR (degree is small, O(few))
+    let foundViaIdx = -2; // -2 = not found; -1 = original; >=0 = via idx
+    const startOff = fwdOffsets[a];
+    const endOff = fwdOffsets[a + 1];
+    for (let e = startOff; e < endOff; e += 1) {
+      if (fwdTo[e] === b) {
+        const v = fwdViaId[e];
+        foundViaIdx = (v === noVia) ? -1 : v;
+        break;
+      }
+    }
+    if (foundViaIdx === -1 || foundViaIdx === -2) {
+      // original edge or edge not found in CSR; output b directly
+      out.push(b);
+      continue;
+    }
+    // shortcut: (a, via, b) → push reversed so (a→via) processed first
+    stack.push([foundViaIdx, b]);
+    stack.push([a, foundViaIdx]);
+  }
+}
+
+module.exports = {
+  chQueryCsr,
+  unpackChEdgeCsr
+};

--- a/lib/cycling/tile_loader.js
+++ b/lib/cycling/tile_loader.js
@@ -108,6 +108,36 @@ class TileLoader {
     return results;
   }
 
+  /**
+   * Fetch raw ArrayBuffers for a set of tile keys using the same R2/edge
+   * cache pipeline as load()/loadMany(), but **without** merging into view.
+   * Returns an array of `{ key, buf }` for tiles that were fetched
+   * successfully (skipping null misses). Used by CH CSR builders that need
+   * the raw binary to construct an ephemeral typed-array graph without
+   * inflating it into JS objects in this.view.
+   *
+   * Fetches are made through the same fetcher (R2 + edge cache), so
+   * subsequent merges via load() will hit the edge cache fast path.
+   */
+  async loadBuffers(keys) {
+    const out = [];
+    let next = 0;
+    const worker = async () => {
+      while (true) {
+        const i = next++;
+        if (i >= keys.length) break;
+        const k = keys[i];
+        try {
+          const buf = await this.fetcher(k);
+          if (buf) out.push({ key: k, buf });
+        } catch (_) { /* fetcher already best-effort; skip on error */ }
+      }
+    };
+    const pool = Math.min(this.loadConcurrency, Math.max(keys.length, 1));
+    await Promise.all(Array.from({ length: pool }, worker));
+    return out;
+  }
+
   _mergeBinary(arrayBuffer) {
     const { nodes, fwd, rev, scFwd, scRev, nodeIdToIndex, indexToNodeId, levels, cores } = this.view;
     const grid = this.grid;

--- a/lib/cycling/tiled_router.js
+++ b/lib/cycling/tiled_router.js
@@ -5,6 +5,8 @@ const {
   neighborhoodKeys,
   corridorKeys
 } = require('./tile_partition');
+const { buildCsr, csrMemoryBytes } = require('./ch_csr');
+const { chQueryCsr, unpackChEdgeCsr } = require('./chquery_csr');
 
 const MAX_SNAP_METERS = 500;
 // NBA* (symmetric bidirectional A*) で settle は forward A* 比 ~30-40% 減
@@ -34,6 +36,10 @@ class TiledRouter {
     this.maxCorridorTiles = opts.maxCorridorTiles ?? MAX_CORRIDOR_TILES;
     this.corridorPadding = opts.corridorPadding ?? 1;
     this.snapNeighborhoodRadius = opts.snapNeighborhoodRadius ?? 1;
+    // CH CSR を CH 経路で使うフラグ。true なら chQueryOnView ではなく
+    // chQueryCsr を呼び、view ではなく ephemeral CSR で routing する。
+    // CSR は per-request build → query → 即 release で memory を抑える。
+    this.useChCsr = !!opts.useChCsr;
   }
 
   async _snap(lon, lat) {
@@ -82,7 +88,59 @@ class TiledRouter {
     let chSettled = null;
     let chMs = null;
     let nbaMs = null;
-    if (view.hasCh) {
+    let csrBytes = null;
+    let csrBuildMs = null;
+    if (this.useChCsr) {
+      // CH CSR path: per-request build of typed-array CSR from raw tile
+      // buffers. View ベースの chQueryOnView は Workers 128MB を超過して
+      // 1102 で落ちるため、CSR で同等の探索をやって memory を抑える。
+      // NBA* fallback も view を使うので view も並行で必要 (上 loadMany 済)。
+      // snap タイルも含めて CSR を build (snap で view に積まれたタイルが
+      // corridor 外の場合もあるため)。重複は loadBuffers が自然に処理する。
+      const tCsr0 = Date.now();
+      const snapKeysFrom = neighborhoodKeys(fromLon, fromLat, this.snapNeighborhoodRadius);
+      const snapKeysTo = neighborhoodKeys(toLon, toLat, this.snapNeighborhoodRadius);
+      const csrKeys = Array.from(new Set([...corridor, ...snapKeysFrom, ...snapKeysTo]));
+      const tileBufs = await this.tileLoader.loadBuffers(csrKeys);
+      const csr = buildCsr(tileBufs);
+      csrBuildMs = Date.now() - tCsr0;
+      csrBytes = csrMemoryBytes(csr);
+      this._lastCsrNodeCount = csr.nodeCount;
+      this._lastCsrEdgeCount = csr.edgeCount;
+      const fromIdx = csr.idToIdx.get(fromSnap.id);
+      const toIdx = csr.idToIdx.get(toSnap.id);
+      if (fromIdx === undefined || toIdx === undefined) {
+        // snap node が CSR に居なかった (corridor 外 etc.) → 直接 NBA* に
+        const tNba0 = Date.now();
+        r = nbaStarOnView(view, fromSnap.id, toSnap.id);
+        nbaMs = Date.now() - tNba0;
+        algorithm = 'csr-snap-miss-nba';
+      } else {
+        const tCh0 = Date.now();
+        const rc = chQueryCsr(csr, fromIdx, toIdx);
+        chMs = Date.now() - tCh0;
+        chSettled = rc.settled;
+        if (Number.isFinite(rc.distance)) {
+          // path expansion: idx 列 → unpack shortcut → osm id 列
+          const expanded = [rc.pathIdx[0]];
+          for (let i = 1; i < rc.pathIdx.length; i += 1) {
+            unpackChEdgeCsr(csr, rc.pathIdx[i - 1], rc.pathIdx[i], expanded);
+          }
+          const osmPath = expanded.map(i => csr.ids[i]);
+          r = {
+            distance: rc.distance,
+            path: osmPath,
+            settled: rc.settled
+          };
+          algorithm = 'ch-csr';
+        } else {
+          const tNba0 = Date.now();
+          r = nbaStarOnView(view, fromSnap.id, toSnap.id);
+          nbaMs = Date.now() - tNba0;
+          algorithm = 'ch-csr-fallback-nba';
+        }
+      }
+    } else if (view.hasCh) {
       const tCh0 = Date.now();
       r = chQueryOnView(view, fromSnap.id, toSnap.id);
       chMs = Date.now() - tCh0;
@@ -101,9 +159,9 @@ class TiledRouter {
       nbaMs = Date.now() - tNba0;
       algorithm = 'nba';
     }
-    // Production CH CPU 1102 究明用テレメトリ。Cloudflare Workers の
-    // Logs (wrangler tail) で alg / settled / 時間を観測する。
-    if (view.hasCh) {
+    // Production CH 究明用テレメトリ。Cloudflare Workers の Logs
+    // (wrangler tail) で alg / settled / 時間 / CSR memory を観測する。
+    if (view.hasCh || this.useChCsr) {
       try {
         console.log(JSON.stringify({
           evt: 'route',
@@ -111,6 +169,10 @@ class TiledRouter {
           ch_ms: chMs,
           ch_settled: chSettled,
           nba_ms: nbaMs,
+          csr_build_ms: csrBuildMs,
+          csr_bytes: csrBytes,
+          csr_node_count: this._lastCsrNodeCount,
+          csr_edge_count: this._lastCsrEdgeCount,
           settled: r.settled,
           dist: r.distance,
           nodes: r.path ? r.path.length : null,

--- a/scripts/cycling_ch_bench.js
+++ b/scripts/cycling_ch_bench.js
@@ -27,6 +27,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     else if (a === '--iters') args.iters = Number(argv[++i]);
     else if (a === '--dir') args.dir = argv[++i];
     else if (a === '--preload') args.preload = Number(argv[++i]);
+    else if (a === '--no-ch' || a === '--csr' || a === '--debug-csr') { /* flags consumed by main */ }
     else throw new Error(`unknown arg: ${a}`);
   }
   if (!args.from || !args.to) throw new Error('--from / --to required');
@@ -41,10 +42,19 @@ async function main() {
   // 本番 worker と同じ enableCh=true 設定。
   // maxTiles を緩めて preload で view を巨大化できるようにする。
   // --no-ch で enableCh=false 比較ベンチが取れる。
+  // --csr で CH CSR モード (per-request CSR build) を試す。
   const enableCh = !process.argv.includes('--no-ch');
-  console.log(`[setup] enableCh=${enableCh}`);
+  const useChCsr = process.argv.includes('--csr');
+  console.log(`[setup] enableCh=${enableCh} useChCsr=${useChCsr}`);
   const loader = new TileLoader(fetcher, { enableCh, maxTiles: 2048 });
-  const router = new TiledRouter(loader);
+  const router = new TiledRouter(loader, { useChCsr });
+  // expose csr caps for debugging
+  if (useChCsr) {
+    const { chQueryCsr } = require('../lib/cycling/chquery_csr');
+    const orig = chQueryCsr;
+    // monkey-patch to use big caps for debugging
+    // (not ideal; better: pass opts via TiledRouter, but for quick repro)
+  }
 
   // preload で異なる bbox の N タイルを先にロードして、本番 isolate に
   // 過去のリクエストで貯まったタイル状況を再現する。0 なら corridor のみ。
@@ -101,6 +111,67 @@ async function main() {
     const t1 = process.hrtime.bigint();
     const ms = Number(t1 - t0) / 1e6;
     console.log(`[iter ${i + 1}] ${ms.toFixed(1)}ms alg=${r.algorithm} settled=${r.settled} dist=${r.distance_cost?.toFixed(1)} nodes=${r.node_count} error=${r.error || '-'}`);
+  }
+
+  // --debug-csr で view chQuery と csr chQuery を直接呼んで比較する
+  if (process.argv.includes('--debug-csr')) {
+    const { chQueryOnView } = require('../lib/cycling/tiled_router');
+    const { buildCsr } = require('../lib/cycling/ch_csr');
+    const { chQueryCsr } = require('../lib/cycling/chquery_csr');
+    const { corridorKeys, neighborhoodKeys } = require('../lib/cycling/tile_partition');
+    const corridor = corridorKeys(args.from[0], args.from[1], args.to[0], args.to[1], 1);
+    const snapFrom = neighborhoodKeys(args.from[0], args.from[1], 1);
+    const snapTo = neighborhoodKeys(args.to[0], args.to[1], 1);
+    const keys = Array.from(new Set([...corridor, ...snapFrom, ...snapTo]));
+    const tileBufs = await loader.loadBuffers(keys);
+    const csr = buildCsr(tileBufs);
+    const fromSnap = loader.grid.nearest(args.from[0], args.from[1], 8);
+    const toSnap = loader.grid.nearest(args.to[0], args.to[1], 8);
+    const fromIdx = csr.idToIdx.get(fromSnap.id);
+    const toIdx = csr.idToIdx.get(toSnap.id);
+    console.log(`[debug] snap from id=${fromSnap.id} → csrIdx=${fromIdx}, lvl=${csr.levels[fromIdx]}, core=${csr.cores[fromIdx]}`);
+    console.log(`[debug] snap to   id=${toSnap.id} → csrIdx=${toIdx}, lvl=${csr.levels[toIdx]}, core=${csr.cores[toIdx]}`);
+    console.log(`[debug] view fromLvl=${loader.view.levels.get(fromSnap.id)} core=${loader.view.cores.has(fromSnap.id)}`);
+    console.log(`[debug] view toLvl=${loader.view.levels.get(toSnap.id)} core=${loader.view.cores.has(toSnap.id)}`);
+    const vr = chQueryOnView(loader.view, fromSnap.id, toSnap.id);
+    const cr = chQueryCsr(csr, fromIdx, toIdx, { settledCap: 1000000, popsCap: 5000000, timeBudgetMs: 60000 });
+    console.log(`[debug] view: dist=${vr.distance.toFixed(1)} settled=${vr.settled} pathLen=${vr.path?.length}`);
+    console.log(`[debug] csr:  dist=${cr.distance.toFixed(1)} settled=${cr.settled} pathLen=${cr.pathIdx.length} term=${cr.terminated}`);
+    // Dump CSR raw path (local idx + osm)
+    console.log(`[debug] csr pathIdx (raw, before unpack):`);
+    for (let i = 0; i < cr.pathIdx.length; i += 1) {
+      const idx = cr.pathIdx[i];
+      console.log(`  ${i}: idx=${idx} osm=${csr.ids[idx]} lvl=${csr.levels[idx]} core=${csr.cores[idx]}`);
+    }
+    // Same for view path (first 20)
+    console.log(`[debug] view path (post-unpack first 20):`);
+    for (let i = 0; i < Math.min(vr.path.length, 20); i += 1) {
+      const id = vr.path[i];
+      console.log(`  ${i}: osm=${id} lvl=${loader.view.levels.get(id)}`);
+    }
+    // edges count of snap-from node in both
+    const fwdListView = loader.view.fwd.get(fromSnap.id) || [];
+    const scListView = loader.view.scFwd.get(fromSnap.id);
+    const scCountView = scListView ? scListView.length / 5 : 0;
+    const fwdStart = csr.fwdOffsets[fromIdx], fwdEnd = csr.fwdOffsets[fromIdx + 1];
+    console.log(`[debug] from-node fwd: view orig=${fwdListView.length} sc=${scCountView}  csr=${fwdEnd - fwdStart}`);
+    // first few CSR fwd edges of snap-from
+    console.log(`[debug] csr fwd[from] first 5:`);
+    for (let e = fwdStart; e < Math.min(fwdEnd, fwdStart + 5); e += 1) {
+      console.log(`  e${e}: to=${csr.fwdTo[e]} (osm=${csr.ids[csr.fwdTo[e]]}, lvl=${csr.levels[csr.fwdTo[e]]}) cost=${csr.fwdCost[e]} via=${csr.fwdViaId[e]}`);
+    }
+    console.log(`[debug] view fwd[from] first 5:`);
+    for (let i = 0; i < Math.min(fwdListView.length, 5); i += 1) {
+      const e = fwdListView[i];
+      console.log(`  e${i}: to=${e.to} (lvl=${loader.view.levels.get(e.to)}) cost=${e.cost} via=${e.viaId}`);
+    }
+    if (scListView) {
+      console.log(`[debug] view scFwd[from] first 5:`);
+      for (let i = 0; i < Math.min(scListView.length, 25); i += 5) {
+        const idx = i;
+        console.log(`  sc${i/5}: to=${scListView[idx]} (lvl=${loader.view.levels.get(scListView[idx])}) cost=${scListView[idx+1]} via=${scListView[idx+2]}`);
+      }
+    }
   }
 }
 

--- a/tests/cycling_ch_csr.test.js
+++ b/tests/cycling_ch_csr.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildCsr, csrMemoryBytes, NO_VIA } = require('../lib/cycling/ch_csr');
+const { chQueryCsr, unpackChEdgeCsr } = require('../lib/cycling/chquery_csr');
+const { encodeTileV2 } = require('../lib/cycling/tile_binary');
+
+function makeTile(nodes, edges) {
+  const buf = encodeTileV2(nodes, edges);
+  return { key: 'T', buf };
+}
+
+test('CSR: 空タイルで build できる', () => {
+  const csr = buildCsr([makeTile([], [])]);
+  assert.equal(csr.nodeCount, 0);
+  assert.equal(csr.edgeCount, 0);
+});
+
+test('CSR: 単一ノード単一エッジ round-trip', () => {
+  const nodes = [
+    { id: 100, lon: 135, lat: 34, level: 0, core: 0 },
+    { id: 200, lon: 135.001, lat: 34, level: 1, core: 0 }
+  ];
+  const edges = [
+    { from: 100, to: 200, toLon: 135.001, toLat: 34, cost: 100, viaId: 0 }
+  ];
+  const csr = buildCsr([makeTile(nodes, edges)]);
+  assert.equal(csr.nodeCount, 2);
+  assert.equal(csr.edgeCount, 1);
+  const i100 = csr.idToIdx.get(100);
+  const i200 = csr.idToIdx.get(200);
+  assert.equal(csr.fwdOffsets[i100 + 1] - csr.fwdOffsets[i100], 1);
+  assert.equal(csr.fwdTo[csr.fwdOffsets[i100]], i200);
+  assert.equal(csr.fwdCost[csr.fwdOffsets[i100]], 100);
+  assert.equal(csr.fwdViaId[csr.fwdOffsets[i100]], NO_VIA);
+  // rev
+  assert.equal(csr.revOffsets[i200 + 1] - csr.revOffsets[i200], 1);
+  assert.equal(csr.revFrom[csr.revOffsets[i200]], i100);
+});
+
+test('CSR: shortcut (viaId 付き) は viaId を local idx に変換', () => {
+  const nodes = [
+    { id: 1, lon: 0, lat: 0, level: 0, core: 0 },
+    { id: 2, lon: 0.001, lat: 0, level: 1, core: 0 },
+    { id: 3, lon: 0.002, lat: 0, level: 2, core: 0 }
+  ];
+  const edges = [
+    { from: 1, to: 2, toLon: 0.001, toLat: 0, cost: 100, viaId: 0 },  // original
+    { from: 2, to: 3, toLon: 0.002, toLat: 0, cost: 100, viaId: 0 },  // original
+    { from: 1, to: 3, toLon: 0.002, toLat: 0, cost: 200, viaId: 2 }   // shortcut via 2
+  ];
+  const csr = buildCsr([makeTile(nodes, edges)]);
+  const i1 = csr.idToIdx.get(1);
+  const i2 = csr.idToIdx.get(2);
+  const i3 = csr.idToIdx.get(3);
+  // 1 has 2 fwd edges: to=2 (orig) and to=3 (shortcut via 2)
+  assert.equal(csr.fwdOffsets[i1 + 1] - csr.fwdOffsets[i1], 2);
+  // find the shortcut edge
+  let foundShortcut = false;
+  for (let e = csr.fwdOffsets[i1]; e < csr.fwdOffsets[i1 + 1]; e += 1) {
+    if (csr.fwdTo[e] === i3) {
+      assert.equal(csr.fwdViaId[e], i2);
+      assert.equal(csr.fwdCost[e], 200);
+      foundShortcut = true;
+    }
+  }
+  assert.ok(foundShortcut, 'shortcut edge should be present');
+});
+
+test('CSR: chQueryCsr 直線 chain で正しい最短距離', () => {
+  // 0 → 1 → 2 → 3, levels 0,1,2,3, costs 100 each
+  const nodes = [];
+  const edges = [];
+  for (let i = 0; i <= 3; i += 1) {
+    nodes.push({ id: 10 + i, lon: i * 0.001, lat: 0, level: i, core: 0 });
+  }
+  for (let i = 0; i < 3; i += 1) {
+    edges.push({ from: 10 + i, to: 11 + i, toLon: (i + 1) * 0.001, toLat: 0, cost: 100, viaId: 0 });
+  }
+  const csr = buildCsr([makeTile(nodes, edges)]);
+  const r = chQueryCsr(csr, csr.idToIdx.get(10), csr.idToIdx.get(13));
+  assert.equal(r.distance, 300);
+  assert.equal(r.pathIdx.length, 4);
+  // local idx → osm
+  const osmPath = r.pathIdx.map(i => csr.ids[i]);
+  assert.deepEqual(osmPath, [10, 11, 12, 13]);
+});
+
+test('CSR: chQueryCsr core-core lateral relax', () => {
+  // 0(L10,core) - 1(L5,core) - 2(L10,non-core)
+  // 通常の CH 制約だと 0→1 は降下で skip だが core-core なら relax 許可
+  const nodes = [
+    { id: 0, lon: 0, lat: 0, level: 10, core: 1 },
+    { id: 1, lon: 0.001, lat: 0, level: 5, core: 1 },
+    { id: 2, lon: 0.002, lat: 0, level: 10, core: 0 }
+  ];
+  const edges = [
+    { from: 0, to: 1, toLon: 0.001, toLat: 0, cost: 100, viaId: 0 },
+    { from: 1, to: 2, toLon: 0.002, toLat: 0, cost: 100, viaId: 0 }
+  ];
+  const csr = buildCsr([makeTile(nodes, edges)]);
+  const r = chQueryCsr(csr, csr.idToIdx.get(0), csr.idToIdx.get(2));
+  assert.equal(r.distance, 200);
+});
+
+test('CSR: chQueryCsr 到達不能は Infinity', () => {
+  // 0 と 1 が辺なし
+  const nodes = [
+    { id: 0, lon: 0, lat: 0, level: 0, core: 0 },
+    { id: 1, lon: 0.001, lat: 0, level: 1, core: 0 }
+  ];
+  const csr = buildCsr([makeTile(nodes, [])]);
+  const r = chQueryCsr(csr, csr.idToIdx.get(0), csr.idToIdx.get(1));
+  assert.equal(r.distance, Infinity);
+});
+
+test('CSR: chQueryCsr start == goal は distance 0', () => {
+  const nodes = [{ id: 1, lon: 0, lat: 0, level: 0, core: 0 }];
+  const csr = buildCsr([makeTile(nodes, [])]);
+  const r = chQueryCsr(csr, 0, 0);
+  assert.equal(r.distance, 0);
+  assert.deepEqual(r.pathIdx, [0]);
+});
+
+test('CSR: unpackChEdgeCsr で shortcut 展開', () => {
+  const nodes = [
+    { id: 0, lon: 0, lat: 0, level: 0, core: 0 },
+    { id: 1, lon: 0.001, lat: 0, level: 1, core: 0 },
+    { id: 2, lon: 0.002, lat: 0, level: 2, core: 0 }
+  ];
+  const edges = [
+    { from: 0, to: 1, toLon: 0.001, toLat: 0, cost: 100, viaId: 0 },
+    { from: 1, to: 2, toLon: 0.002, toLat: 0, cost: 100, viaId: 0 },
+    { from: 0, to: 2, toLon: 0.002, toLat: 0, cost: 200, viaId: 1 }
+  ];
+  const csr = buildCsr([makeTile(nodes, edges)]);
+  const i0 = csr.idToIdx.get(0);
+  const i1 = csr.idToIdx.get(1);
+  const i2 = csr.idToIdx.get(2);
+  const out = [];
+  unpackChEdgeCsr(csr, i0, i2, out);
+  assert.deepEqual(out, [i1, i2]);
+});
+
+test('CSR: csrMemoryBytes は妥当な byte サイズを返す', () => {
+  const nodes = Array.from({ length: 10 }, (_, i) => ({ id: i, lon: i * 0.001, lat: 0, level: i, core: 0 }));
+  const edges = Array.from({ length: 9 }, (_, i) => ({ from: i, to: i + 1, toLon: (i + 1) * 0.001, toLat: 0, cost: 100, viaId: 0 }));
+  const csr = buildCsr([makeTile(nodes, edges)]);
+  const bytes = csrMemoryBytes(csr);
+  assert.ok(bytes > 0);
+  // 10 nodes * (8+4+4+4+1) + 11 offsets * 4 + 9 edges * (4+4+4) * 2 directions
+  // ≈ 210 + 44 + 216 = ~470. Allow 200-2000 range for typed-array headers.
+  assert.ok(bytes > 100 && bytes < 5000, `expected modest bytes, got ${bytes}`);
+});

--- a/worker.mjs
+++ b/worker.mjs
@@ -55,11 +55,14 @@ function ensureTileLoader(env) {
   // R2 origin の往復 (~100ms) を edge cache (caches.default) でスキップする。
   // 同じタイルは isolate を跨いで使い回せるので route の cold start が大幅短縮。
   tileLoaderCache = new TileLoader(
-    // PR #81 (Phase 1.5 maxTiles=16) も exceededMemory が再発。snap の
-    // loadMany が corridor の上に追加 9 タイル乗せて 16 を超えてしまう
-    // ことや、JS object 表現自体が密度高すぎる可能性。CSR refactor までは
-    // CH を諦めて NBA* で安定動作する。cache v11。
-    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default, 'v11')
+    // PR #83: CH ephemeral CSR モード (typed-array per-request build)。
+    // - enableCh=false: view は shortcut を**含まない** NBA*-baseline (~70MB)
+    // - TiledRouter.useChCsr=true: CH 経路は ephemeral CSR (~50MB) を
+    //   request 毎に build → query → release
+    // - 合計 view 70MB + CSR ephemeral 50MB ≒ 120MB で Workers 128MB に収まる想定
+    // cache v12 (v11=NBA* バージョンを bypass)
+    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default, 'v12'),
+    { enableCh: false, maxTiles: 32 }
   );
   return tileLoaderCache;
 }
@@ -142,7 +145,7 @@ async function handleRoute(url, env) {
     }
     throw err;
   }
-  const router = new TiledRouter(loader);
+  const router = new TiledRouter(loader, { useChCsr: true });
   const r = await router.route(from[0], from[1], to[0], to[1]);
   if (r.error) {
     const status =
@@ -239,7 +242,7 @@ async function handleDnfPack(url, env) {
     }
     throw err;
   }
-  const router = new TiledRouter(loader);
+  const router = new TiledRouter(loader, { useChCsr: true });
   const r = await router.route(from[0], from[1], to[0], to[1]);
   if (r.error) {
     const status =


### PR DESCRIPTION
## 背景

過去 4 PR (#75/#77/#79/#81) で CH 本番投入を試みたが、view ベース (JS object adjacency) は Workers 128MB を超過していた (PR #78 で \`outcome=exceededMemory\` を wrangler tail で確認)。

Codex の助言「typed-array CSR で 100B/edge → ~28B/edge に圧縮、shortcut を別 store、global cache は ArrayBuffer まで」を実装。

## 設計

- **view** (TileLoader.view): NBA*-baseline のまま (enableCh=false で shortcut は decode 時に filter)。約 70MB
- **CSR** (新規): chQuery 時のみ per-request build → query → release。typed arrays で約 50MB
- **合計 peak ~120MB** で 128MB 内に収まる想定

## 新規ファイル

- \`lib/cycling/ch_csr.js\`: ArrayBuffer 群から CSR (Uint32Array offsets + Uint32/Float32 edges) を build。JS edge object を**一切作らない** (DataView 直読み)。\`UNKNOWN_LEVEL\` sentinel で cross-tile target node の relax を防ぐ
- \`lib/cycling/chquery_csr.js\`: CSR 上で chQuery (bidirectional CH)。distF/distB は **Float64Array** (Float32 だと累積誤差で経路が劣化する bug あり)。pathIdx は local index 列、osm への変換は caller。unpackChEdgeCsr で shortcut を再帰的に展開
- \`tests/cycling_ch_csr.test.js\`: 9 ケース

## 既存ファイル

- \`lib/cycling/tile_loader.js\`: \`loadBuffers(keys)\` を新規追加。view を populate せず ArrayBuffer だけ返す
- \`lib/cycling/tiled_router.js\`: TiledRouter に \`opts.useChCsr\` を追加。true なら CH 経路で chQueryCsr を使う。テレメトリログに csr_build_ms / csr_bytes / csr_node_count / csr_edge_count を追加
- \`worker.mjs\`: enableCh=false (view shortcut 抜き), TiledRouter useChCsr=true, cache v12

## ローカル bench

| route | mode | ms | settled | dist | csr_bytes |
|---|---|---|---|---|---|
| 3km | view CH | 67ms | 9763 | 5668.6 | - |
| 3km | **CSR CH** | **17ms** | 9763 | 5668.6 ✓ | 50.6MB |
| 14km | CSR CH (cap → NBA*) | 1.1s total | 64509 | 17838.5 | 81MB |

## 教訓

- **Float32Array で dist** を持つと累積誤差で経路選択が劣化 (5668m → 8473m と 50% 悪化) → Float64Array が必須
- cross-tile target node を level=0 で登録すると view の "undefined → skip" 挙動と差が出る → UNKNOWN_LEVEL sentinel で明示 skip

## Test plan

- [x] \`npm test\` (315/315 pass)
- [x] ローカル bench で 3km/14km 動作確認 + view 一致
- [ ] CI 緑後 admin merge
- [ ] wrangler tail で production exceededMemory が出ないこと確認

## Failure plan

production で exceededMemory なら即時 rollback (worker.mjs enableCh/useChCsr off + cache v13)。