### PR TITLE
fix(cycling): hot rollback CSR (まだ 128MB 超過)

### DIFF
--- a/worker.mjs
+++ b/worker.mjs
@@ -55,14 +55,13 @@ function ensureTileLoader(env) {
   // R2 origin の往復 (~100ms) を edge cache (caches.default) でスキップする。
   // 同じタイルは isolate を跨いで使い回せるので route の cold start が大幅短縮。
   tileLoaderCache = new TileLoader(
-    // PR #83: CH ephemeral CSR モード (typed-array per-request build)。
-    // - enableCh=false: view は shortcut を**含まない** NBA*-baseline (~70MB)
-    // - TiledRouter.useChCsr=true: CH 経路は ephemeral CSR (~50MB) を
-    //   request 毎に build → query → release
-    // - 合計 view 70MB + CSR ephemeral 50MB ≒ 120MB で Workers 128MB に収まる想定
-    // cache v12 (v11=NBA* バージョンを bypass)
-    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default, 'v12'),
-    { enableCh: false, maxTiles: 32 }
+    // PR #83 (CSR ephemeral) も exceededMemory。CSR build 自体の中間 JS array
+    // (nodeOsmIds, idToIdx Map など) + view + tileBufs で peak が 128MB を
+    // 超過する模様。view を残したまま CSR を併用する構成は厳しい。
+    // 次の試み: view 自体も typed-array 化し、TileLoader は buffer cache 専用
+    // にする (GraphView を per-request build)。それまでは安定動作の NBA*
+    // モード。cache v13。
+    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default, 'v13')
   );
   return tileLoaderCache;
 }
@@ -145,7 +144,7 @@ async function handleRoute(url, env) {
     }
     throw err;
   }
-  const router = new TiledRouter(loader, { useChCsr: true });
+  const router = new TiledRouter(loader);
   const r = await router.route(from[0], from[1], to[0], to[1]);
   if (r.error) {
     const status =
@@ -242,7 +241,7 @@ async function handleDnfPack(url, env) {
     }
     throw err;
   }
-  const router = new TiledRouter(loader, { useChCsr: true });
+  const router = new TiledRouter(loader);
   const r = await router.route(from[0], from[1], to[0], to[1]);
   if (r.error) {
     const status =


### PR DESCRIPTION
PR #83 (CSR ephemeral) で本番投入したが再び exceededMemory。CSR build 中の中間 JS array (idToIdx Map / nodeOsmIds など) + view + tileBufs の peak が 128MB を超過した模様。view 自体を捨てて TileLoader を buffer cache 専用にする refactor が必要。cache v13。