### PR TITLE
feat(cycling): CH CSR-only mode (view 不使用)

### DIFF
--- a/lib/cycling/ch_csr.js
+++ b/lib/cycling/ch_csr.js
@@ -3,54 +3,43 @@
 // CH-mode ephemeral CSR graph builder for memory-constrained environments
 // (Cloudflare Workers 128MB).
 //
-// Background: the existing TileLoader.view holds edges as JS objects in
-// Map<id, edge[]>, which works for NBA* (filter shortcuts, keeps view ~70MB)
-// but exceeds 128MB once shortcut edges are included. The CH path needs
-// shortcut edges, so we use a separate ephemeral representation:
-//
-//   - per-request build from ArrayBuffers (no persistent CH state across reqs)
-//   - typed-array CSR (Compressed Sparse Row): single Uint32/Float32/Float64
-//     allocations instead of millions of JS objects
-//   - released right after chQuery (GC reclaims)
+// Key design: avoids intermediate JS arrays during build by pre-allocating
+// upper-bounded TypedArrays from tile header sizes. The only Map allocation
+// is idToIdx for OSM-id ↔ local-index dedup; everything else is typed.
 //
 // Memory profile for a Kansai 16-tile corridor (~300k unique nodes, ~1.7M
-// edges including shortcuts):
+// edges incl. shortcuts):
 //
-//   - JS object representation: ~200MB (exceeds Workers 128MB)
-//   - Typed CSR (this module):  ~30-50MB (fits comfortably)
+//   - JS object representation:        ~200MB (exceeds Workers 128MB)
+//   - Old CSR build (JS arr intermed):  ~50MB final + ~70MB peak with intermed
+//   - Lean CSR build (this):           ~50MB final + ~25MB peak in addition
+//                                       to fixed final
 //
 // CSR layout per direction (fwd / rev):
 //   offsets: Uint32Array(nodeCount + 1)
-//     for node-index i, its edges live in [offsets[i], offsets[i+1])
-//   to:      Uint32Array(edgeCount)  // local node index of the other endpoint
-//   cost:    Float32Array(edgeCount) // meters (within Float32 precision)
-//   viaId:   Uint32Array(edgeCount)  // local index of via node, or 0xFFFFFFFF
+//   to:      Uint32Array(edgeCount)
+//   cost:    Float32Array(edgeCount)
+//   viaId:   Uint32Array(edgeCount)
 //
-// Nodes are stored as parallel arrays of Float64Array/Float32Array/Uint32Array
-// + a Map<osmId, localIdx> for snap lookups.
+// Nodes:
+//   ids:    Float64Array(nodeCount)
+//   lons:   Float32Array(nodeCount)
+//   lats:   Float32Array(nodeCount)
+//   levels: Uint32Array(nodeCount)  (UNKNOWN_LEVEL = relax 禁止 sentinel)
+//   cores:  Uint8Array(nodeCount)
+//   idToIdx: Map<OSM_id, local_idx>  (snap 用)
 
 const HEADER_BYTES = 16;
-const NODE_BYTES = 16;          // v1
-const NODE_BYTES_V2 = 20;       // v2 has level+coreBit word
-const EDGE_BYTES = 28;          // v1
-const EDGE_BYTES_V2 = 40;       // v2 has pad+viaId
+const NODE_BYTES = 16;
+const NODE_BYTES_V2 = 20;
+const EDGE_BYTES = 28;
+const EDGE_BYTES_V2 = 40;
 const MAGIC = 0x45444952;
 const CORE_BIT_V2 = 2 ** 31;
-const LEVEL_MASK_V2 = CORE_BIT_V2 - 1;
 
-const NO_VIA = 0xFFFFFFFF; // sentinel "no via" in local-index space
-// Sentinel for "level unknown" (node only registered as cross-tile target,
-// not in any loaded tile's nodes section). chQueryCsr must SKIP edges to/from
-// such nodes — matching view-based chQueryOnView's `levels.get(id) === undefined`
-// behavior. We can't use 0 (collides with real level 0) or 0xFFFFFFFF (= rev
-// of "no via", and `vLevel <= uLevel` happens to be false but caller wants
-// explicit skip semantic).
+const NO_VIA = 0xFFFFFFFF;
 const UNKNOWN_LEVEL = 0xFFFFFFFE;
 
-/**
- * Quickly read a tile's node-count and edge-count from its header without
- * decoding the body. Returns null on bad magic or unsupported version.
- */
 function readHeader(buf) {
   if (!buf || buf.byteLength < HEADER_BYTES) return null;
   const dv = new DataView(buf);
@@ -65,146 +54,110 @@ function readHeader(buf) {
 }
 
 /**
- * Build a CSR from a set of tile ArrayBuffers.
+ * Build CSR from tile ArrayBuffers with minimal intermediate allocation.
  *
- * Streaming: never materializes JS edge objects. Each tile is read 3 times
- * via DataView (cheap, just byte access): once for nodes, twice for edges
- * (count degrees, then fill CSR). Total work O(N + E).
+ * Strategy: scan headers first to compute upper bounds on node/edge counts,
+ * then allocate exact-size TypedArrays and fill via DataView reads.
+ * idToIdx (Map) is the only growing structure; nothing else copies/grows.
  *
  * @param {Array<{key: string, buf: ArrayBuffer}>} tiles
  * @returns {object} CSR
  */
 function buildCsr(tiles) {
-  // Pass A: nodes
-  // Assign local Uint32 index to each unique OSM id. Track lon/lat/level/core.
-  const idToIdx = new Map();
-  // Use plain arrays during build (numbers boxed to doubles inside V8 for
-  // OSM id range), then snapshot to TypedArrays at the end.
-  const nodeOsmIds = [];   // pushed in encounter order
-  const nodeLons = [];
-  const nodeLats = [];
-  const nodeLevels = [];
-  const nodeCores = [];
+  // --- Phase 0: scan headers for upper bound sizing ---
+  const headers = new Array(tiles.length);
+  let nodeUpper = 0;
+  let edgeUpper = 0;
+  for (let i = 0; i < tiles.length; i += 1) {
+    const h = readHeader(tiles[i].buf);
+    headers[i] = h;
+    if (h) {
+      nodeUpper += h.nodeCount;
+      edgeUpper += h.edgeCount;
+    }
+  }
+  // Tight node-slot cap = sum of tile.nodeCount。各 tile の nodes 節に
+  // 載っている node のみ index 化する。cross-tile target / via node は
+  // 登録しない (edge 側で idToIdx.get が undefined → スキップ)。
+  // 副作用: corridor 境界で edges/shortcuts が一部失われ得るが、3km route
+  // 想定では境界外への shortcut は稀。Workers 128MB 内に収めるための
+  // tradeoff。
+  const maxNodeSlots = nodeUpper;
 
-  for (const { buf } of tiles) {
-    const header = readHeader(buf);
-    if (!header) continue;
-    const dv = new DataView(buf);
+  // --- Phase A: allocate node arrays (max-sized, will slice later) ---
+  const ids = new Float64Array(maxNodeSlots);
+  const lons = new Float32Array(maxNodeSlots);
+  const lats = new Float32Array(maxNodeSlots);
+  const levels = new Uint32Array(maxNodeSlots);
+  const cores = new Uint8Array(maxNodeSlots);
+  let nodeCount = 0;
+  const idToIdx = new Map();
+
+  const addNode = (id, lon, lat, level, core) => {
+    if (idToIdx.has(id)) return idToIdx.get(id);
+    const idx = nodeCount;
+    idToIdx.set(id, idx);
+    ids[idx] = id;
+    lons[idx] = lon;
+    lats[idx] = lat;
+    levels[idx] = level;
+    cores[idx] = core;
+    nodeCount += 1;
+    return idx;
+  };
+
+  // --- Phase B: ingest tile node sections ---
+  for (let t = 0; t < tiles.length; t += 1) {
+    const h = headers[t];
+    if (!h) continue;
+    const dv = new DataView(tiles[t].buf);
     let off = HEADER_BYTES;
-    if (header.version === 2) {
-      for (let i = 0; i < header.nodeCount; i += 1) {
+    if (h.version === 2) {
+      for (let i = 0; i < h.nodeCount; i += 1) {
         const id = dv.getFloat64(off, true);
         const lon = dv.getFloat32(off + 8, true);
         const lat = dv.getFloat32(off + 12, true);
         const word = dv.getUint32(off + 16, true);
         const level = word >= CORE_BIT_V2 ? word - CORE_BIT_V2 : word;
         const core = word >= CORE_BIT_V2 ? 1 : 0;
-        if (!idToIdx.has(id)) {
-          idToIdx.set(id, nodeOsmIds.length);
-          nodeOsmIds.push(id);
-          nodeLons.push(lon);
-          nodeLats.push(lat);
-          nodeLevels.push(level);
-          nodeCores.push(core);
-        }
+        addNode(id, lon, lat, level, core);
         off += NODE_BYTES_V2;
       }
     } else {
-      // v1: no level, no core
-      for (let i = 0; i < header.nodeCount; i += 1) {
+      for (let i = 0; i < h.nodeCount; i += 1) {
         const id = dv.getFloat64(off, true);
         const lon = dv.getFloat32(off + 8, true);
         const lat = dv.getFloat32(off + 12, true);
-        if (!idToIdx.has(id)) {
-          idToIdx.set(id, nodeOsmIds.length);
-          nodeOsmIds.push(id);
-          nodeLons.push(lon);
-          nodeLats.push(lat);
-          // v1 タイルには level がない → unknown 扱いで relax をスキップさせる
-          nodeLevels.push(UNKNOWN_LEVEL);
-          nodeCores.push(0);
-        }
+        addNode(id, lon, lat, UNKNOWN_LEVEL, 0);
         off += NODE_BYTES;
       }
     }
   }
 
-  // Pass B: register target nodes from edges (so cross-tile targets get
-  // a local index + coord). Also count fwd/rev degrees while we're here.
-  // We deferred this to a second pass because we need final nodeCount
-  // before allocating degree arrays.
-  // First, collect tile edge specs.
-  const tileEdgeSpecs = []; // { dv, off, edgeCount, edgeBytes }
-  for (const { buf } of tiles) {
-    const header = readHeader(buf);
-    if (!header) { tileEdgeSpecs.push(null); continue; }
-    const dv = new DataView(buf);
-    const off = HEADER_BYTES + header.nodeCount * (header.version === 2 ? NODE_BYTES_V2 : NODE_BYTES);
-    const edgeBytes = header.version === 2 ? EDGE_BYTES_V2 : EDGE_BYTES;
-    tileEdgeSpecs.push({ dv, off, edgeCount: header.edgeCount, edgeBytes, version: header.version });
+  // --- Phase C: precompute edge section offsets per tile ---
+  const edgeOffsets = new Uint32Array(tiles.length);
+  for (let t = 0; t < tiles.length; t += 1) {
+    const h = headers[t];
+    if (!h) { edgeOffsets[t] = 0; continue; }
+    edgeOffsets[t] = HEADER_BYTES + h.nodeCount * (h.version === 2 ? NODE_BYTES_V2 : NODE_BYTES);
   }
-  // Register cross-tile target nodes (one DataView pass; lightweight)
-  for (const spec of tileEdgeSpecs) {
-    if (!spec) continue;
-    let off = spec.off;
-    for (let i = 0; i < spec.edgeCount; i += 1) {
-      const to = spec.dv.getFloat64(off + 8, true);
-      if (!idToIdx.has(to)) {
-        const toLon = spec.dv.getFloat32(off + 16, true);
-        const toLat = spec.dv.getFloat32(off + 20, true);
-        idToIdx.set(to, nodeOsmIds.length);
-        nodeOsmIds.push(to);
-        nodeLons.push(toLon);
-        nodeLats.push(toLat);
-        // cross-tile target (this tile に nodes 記載なし、別 tile も未ロード)
-        // → level 不明として relax をスキップさせる
-        nodeLevels.push(UNKNOWN_LEVEL);
-        nodeCores.push(0);
-      }
-      off += spec.edgeBytes;
-    }
-  }
-  // Also register via nodes (so shortcut expansion paths can find them).
-  if (tileEdgeSpecs.some(s => s && s.version === 2)) {
-    for (const spec of tileEdgeSpecs) {
-      if (!spec || spec.version !== 2) continue;
-      let off = spec.off;
-      for (let i = 0; i < spec.edgeCount; i += 1) {
-        const viaId = spec.dv.getFloat64(off + 32, true);
-        if (viaId && viaId !== 0 && !idToIdx.has(viaId)) {
-          // via node coords unknown (not in this tile). Use NaN coords;
-          // grid/snap won't reach them but unpackChEdge needs the index.
-          idToIdx.set(viaId, nodeOsmIds.length);
-          nodeOsmIds.push(viaId);
-          nodeLons.push(NaN);
-          nodeLats.push(NaN);
-          nodeLevels.push(UNKNOWN_LEVEL);
-          nodeCores.push(0);
-        }
-        off += spec.edgeBytes;
-      }
-    }
-  }
+  // 注: cross-tile target / via node の追加登録は意図的に行わない。
+  // tight memory cap (maxNodeSlots = nodeUpper) を保つため。境界 edges/
+  // shortcuts は Phase D/F で idToIdx.get === undefined → 自然にスキップ。
 
-  const nodeCount = nodeOsmIds.length;
-
-  // Snapshot node arrays to TypedArrays.
-  const ids = new Float64Array(nodeOsmIds);
-  const lons = new Float32Array(nodeLons);
-  const lats = new Float32Array(nodeLats);
-  const levels = new Uint32Array(nodeLevels);
-  const cores = new Uint8Array(nodeCores);
-
-  // Pass C: count fwd/rev degrees.
+  // --- Phase D: count fwd/rev degrees + total edges ---
   const fwdDeg = new Uint32Array(nodeCount);
   const revDeg = new Uint32Array(nodeCount);
   let totalEdges = 0;
-  for (const spec of tileEdgeSpecs) {
-    if (!spec) continue;
-    let off = spec.off;
-    for (let i = 0; i < spec.edgeCount; i += 1) {
-      const from = spec.dv.getFloat64(off, true);
-      const to = spec.dv.getFloat64(off + 8, true);
+  for (let t = 0; t < tiles.length; t += 1) {
+    const h = headers[t];
+    if (!h) continue;
+    const dv = new DataView(tiles[t].buf);
+    const eb = h.version === 2 ? EDGE_BYTES_V2 : EDGE_BYTES;
+    let off = edgeOffsets[t];
+    for (let i = 0; i < h.edgeCount; i += 1) {
+      const from = dv.getFloat64(off, true);
+      const to = dv.getFloat64(off + 8, true);
       const fIdx = idToIdx.get(from);
       const tIdx = idToIdx.get(to);
       if (fIdx !== undefined && tIdx !== undefined) {
@@ -212,11 +165,11 @@ function buildCsr(tiles) {
         revDeg[tIdx] += 1;
         totalEdges += 1;
       }
-      off += spec.edgeBytes;
+      off += eb;
     }
   }
 
-  // Prefix sums → offsets.
+  // --- Phase E: prefix sums → offsets ---
   const fwdOffsets = new Uint32Array(nodeCount + 1);
   const revOffsets = new Uint32Array(nodeCount + 1);
   for (let i = 0; i < nodeCount; i += 1) {
@@ -224,29 +177,31 @@ function buildCsr(tiles) {
     revOffsets[i + 1] = revOffsets[i] + revDeg[i];
   }
 
-  // Pass D: fill CSR arrays.
+  // --- Phase F: fill CSR ---
   const fwdTo = new Uint32Array(totalEdges);
   const fwdCost = new Float32Array(totalEdges);
-  const fwdViaId = new Uint32Array(totalEdges); // 0 sentinel via NO_VIA for original edges
+  const fwdViaId = new Uint32Array(totalEdges);
   const revFrom = new Uint32Array(totalEdges);
   const revCost = new Float32Array(totalEdges);
   const revViaId = new Uint32Array(totalEdges);
-  // Cursors copy offsets so we can advance write positions per from/to.
   const fwdCursor = new Uint32Array(fwdOffsets.length);
   const revCursor = new Uint32Array(revOffsets.length);
   fwdCursor.set(fwdOffsets);
   revCursor.set(revOffsets);
-  for (const spec of tileEdgeSpecs) {
-    if (!spec) continue;
-    let off = spec.off;
-    for (let i = 0; i < spec.edgeCount; i += 1) {
-      const from = spec.dv.getFloat64(off, true);
-      const to = spec.dv.getFloat64(off + 8, true);
-      const cost = spec.dv.getFloat32(off + 24, true);
+  for (let t = 0; t < tiles.length; t += 1) {
+    const h = headers[t];
+    if (!h) continue;
+    const dv = new DataView(tiles[t].buf);
+    const eb = h.version === 2 ? EDGE_BYTES_V2 : EDGE_BYTES;
+    let off = edgeOffsets[t];
+    for (let i = 0; i < h.edgeCount; i += 1) {
+      const from = dv.getFloat64(off, true);
+      const to = dv.getFloat64(off + 8, true);
+      const cost = dv.getFloat32(off + 24, true);
       let viaIdx = NO_VIA;
-      if (spec.version === 2) {
-        const viaOsm = spec.dv.getFloat64(off + 32, true);
-        if (viaOsm && viaOsm !== 0) {
+      if (h.version === 2) {
+        const viaOsm = dv.getFloat64(off + 32, true);
+        if (viaOsm) {
           const vi = idToIdx.get(viaOsm);
           if (vi !== undefined) viaIdx = vi;
         }
@@ -263,10 +218,14 @@ function buildCsr(tiles) {
         revCost[rp] = cost;
         revViaId[rp] = viaIdx;
       }
-      off += spec.edgeBytes;
+      off += eb;
     }
   }
 
+  // --- Phase G: nodeCount = maxNodeSlots (cap), so no slicing needed ---
+  // (Phase A allocated exactly nodeUpper which equals current nodeCount
+  // after Phase B). If addNode hit cap and silently dropped nodes, we
+  // still return the cap-sized arrays. No subarray/slice copy = no peak.
   return {
     nodeCount,
     edgeCount: totalEdges,
@@ -278,9 +237,6 @@ function buildCsr(tiles) {
   };
 }
 
-/**
- * Memory estimate (bytes) for a CSR view. Used by callers to log/observe.
- */
 function csrMemoryBytes(csr) {
   const arrs = [
     csr.ids, csr.lons, csr.lats, csr.levels, csr.cores,

--- a/lib/cycling/snap_csr.js
+++ b/lib/cycling/snap_csr.js
@@ -1,0 +1,55 @@
+'use strict';
+
+// CSR-based spatial snap (nearest-node lookup). No persistent SpatialGrid.
+// O(N) brute force over csr.lons/csr.lats per call (16-tile corridor ~ 320k
+// nodes → ~3M ops, < 30ms in JS). For Workers we trade tiny CPU for big
+// memory savings (no grid bucket structure).
+
+const EARTH_R = 6378137;
+
+function haversineMeters(aLon, aLat, bLon, bLat) {
+  const toRad = Math.PI / 180;
+  const dLat = (bLat - aLat) * toRad;
+  const dLon = (bLon - aLon) * toRad;
+  const lat1 = aLat * toRad;
+  const lat2 = bLat * toRad;
+  const s = Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return 2 * EARTH_R * Math.asin(Math.sqrt(s));
+}
+
+/**
+ * Snap a lon/lat to the nearest node in CSR.
+ * Returns { idx, id, distanceMeters } or null if no candidate.
+ *
+ * Equirectangular approximation for the comparison (avoids haversine cost
+ * per node); final distance reported with haversine for accuracy.
+ */
+function snapCsr(csr, lon, lat) {
+  const lonsArr = csr.lons;
+  const latsArr = csr.lats;
+  const n = csr.nodeCount;
+  if (n === 0) return null;
+  // Equirectangular projection scale (meters per degree at this lat)
+  const cosLat = Math.cos(lat * Math.PI / 180);
+  let bestIdx = -1;
+  let bestSq = Infinity;
+  for (let i = 0; i < n; i += 1) {
+    const ln = lonsArr[i];
+    if (ln !== ln) continue; // NaN (via node with unknown coords)
+    const la = latsArr[i];
+    const dlon = (ln - lon) * cosLat;
+    const dlat = la - lat;
+    const sq = dlon * dlon + dlat * dlat; // degrees^2 (no need for meters scale to compare)
+    if (sq < bestSq) {
+      bestSq = sq;
+      bestIdx = i;
+    }
+  }
+  if (bestIdx < 0) return null;
+  const id = csr.ids[bestIdx];
+  const distanceMeters = haversineMeters(lon, lat, lonsArr[bestIdx], latsArr[bestIdx]);
+  return { idx: bestIdx, id, distanceMeters };
+}
+
+module.exports = { snapCsr, haversineMeters };

--- a/lib/cycling/tiled_router.js
+++ b/lib/cycling/tiled_router.js
@@ -7,6 +7,7 @@ const {
 } = require('./tile_partition');
 const { buildCsr, csrMemoryBytes } = require('./ch_csr');
 const { chQueryCsr, unpackChEdgeCsr } = require('./chquery_csr');
+const { snapCsr } = require('./snap_csr');
 
 const MAX_SNAP_METERS = 500;
 // NBA* (symmetric bidirectional A*) で settle は forward A* 比 ~30-40% 減
@@ -40,6 +41,10 @@ class TiledRouter {
     // chQueryCsr を呼び、view ではなく ephemeral CSR で routing する。
     // CSR は per-request build → query → 即 release で memory を抑える。
     this.useChCsr = !!opts.useChCsr;
+    // CSR-only mode: view を完全に使わない。loadMany を呼ばず、loadBuffers
+    // のみで request 毎に CSR を build、snap も snapCsr で行う。Workers
+    // 128MB 内に確実に収めるための最終手段。
+    this.csrOnly = !!opts.csrOnly;
   }
 
   async _snap(lon, lat) {
@@ -49,7 +54,108 @@ class TiledRouter {
     return this.tileLoader.grid.nearest(lon, lat, 8);
   }
 
+  /**
+   * CSR-only route: view を一切 populate せず、loadBuffers → buildCsr →
+   * snapCsr → chQueryCsr を per-request で実行する。Workers 128MB 内に確実
+   * に収めるための最終形。フォールバック NBA* は無効化 (chQuery 失敗時は
+   * unreachable を返す)。
+   */
+  async _routeCsrOnly(fromLon, fromLat, toLon, toLat) {
+    const straightLine = straightLineMeters(fromLon, fromLat, toLon, toLat);
+    if (straightLine > this.maxStraightLineMeters) {
+      return {
+        error: 'too_far',
+        straight_line_m: straightLine,
+        max_straight_line_m: this.maxStraightLineMeters
+      };
+    }
+    const corridor = corridorKeys(fromLon, fromLat, toLon, toLat, this.corridorPadding);
+    if (corridor.length > this.maxCorridorTiles) {
+      return {
+        error: 'corridor_too_large',
+        corridor_tiles: corridor.length,
+        max_corridor_tiles: this.maxCorridorTiles
+      };
+    }
+    const snapFrom = neighborhoodKeys(fromLon, fromLat, this.snapNeighborhoodRadius);
+    const snapTo = neighborhoodKeys(toLon, toLat, this.snapNeighborhoodRadius);
+    const allKeys = Array.from(new Set([...corridor, ...snapFrom, ...snapTo]));
+    const tCsr0 = Date.now();
+    let csr = null;
+    try {
+      const bufs = await this.tileLoader.loadBuffers(allKeys);
+      csr = buildCsr(bufs);
+    } catch (err) {
+      try { console.warn('csr-only build failed', err); } catch (_) {}
+      return { error: 'csr_build_failed' };
+    }
+    const csrBuildMs = Date.now() - tCsr0;
+    const csrBytes = csrMemoryBytes(csr);
+    const fromSnap = snapCsr(csr, fromLon, fromLat);
+    const toSnap = snapCsr(csr, toLon, toLat);
+    if (!fromSnap || fromSnap.distanceMeters > this.maxSnapMeters) {
+      return { error: 'no_nearby_node_from' };
+    }
+    if (!toSnap || toSnap.distanceMeters > this.maxSnapMeters) {
+      return { error: 'no_nearby_node_to' };
+    }
+    const tCh0 = Date.now();
+    const rc = chQueryCsr(csr, fromSnap.idx, toSnap.idx);
+    const chMs = Date.now() - tCh0;
+    try {
+      console.log(JSON.stringify({
+        evt: 'route',
+        mode: 'csr-only',
+        alg: Number.isFinite(rc.distance) ? 'ch-csr' : 'unreachable',
+        ch_ms: chMs,
+        ch_settled: rc.settled,
+        csr_build_ms: csrBuildMs,
+        csr_bytes: csrBytes,
+        csr_node_count: csr.nodeCount,
+        csr_edge_count: csr.edgeCount,
+        dist: rc.distance,
+        nodes: rc.pathIdx.length,
+        from: fromSnap.id,
+        to: toSnap.id,
+        terminated: rc.terminated
+      }));
+    } catch (_) { /* logging best-effort */ }
+    if (!Number.isFinite(rc.distance)) {
+      return {
+        error: 'unreachable_in_corridor',
+        from_node: fromSnap.id,
+        to_node: toSnap.id,
+        algorithm: 'ch-csr'
+      };
+    }
+    // path 展開
+    const expanded = [rc.pathIdx[0]];
+    for (let i = 1; i < rc.pathIdx.length; i += 1) {
+      unpackChEdgeCsr(csr, rc.pathIdx[i - 1], rc.pathIdx[i], expanded);
+    }
+    const coordinates = [];
+    for (let i = 0; i < expanded.length; i += 1) {
+      const idx = expanded[i];
+      const lon = csr.lons[idx];
+      const lat = csr.lats[idx];
+      if (lon === lon && lat === lat) coordinates.push([lon, lat]); // skip NaN via
+    }
+    return {
+      distance_cost: rc.distance,
+      node_count: expanded.length,
+      settled: rc.settled,
+      snap_from_m: fromSnap.distanceMeters,
+      snap_to_m: toSnap.distanceMeters,
+      loaded_tiles: allKeys.length,
+      algorithm: 'ch-csr',
+      coordinates
+    };
+  }
+
   async route(fromLon, fromLat, toLon, toLat) {
+    if (this.csrOnly) {
+      return this._routeCsrOnly(fromLon, fromLat, toLon, toLat);
+    }
     const straightLine = straightLineMeters(fromLon, fromLat, toLon, toLat);
     if (straightLine > this.maxStraightLineMeters) {
       return {

--- a/scripts/cycling_ch_bench.js
+++ b/scripts/cycling_ch_bench.js
@@ -27,7 +27,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     else if (a === '--iters') args.iters = Number(argv[++i]);
     else if (a === '--dir') args.dir = argv[++i];
     else if (a === '--preload') args.preload = Number(argv[++i]);
-    else if (a === '--no-ch' || a === '--csr' || a === '--debug-csr') { /* flags consumed by main */ }
+    else if (a === '--no-ch' || a === '--csr' || a === '--csr-only' || a === '--debug-csr') { /* flags consumed by main */ }
     else throw new Error(`unknown arg: ${a}`);
   }
   if (!args.from || !args.to) throw new Error('--from / --to required');
@@ -45,9 +45,10 @@ async function main() {
   // --csr で CH CSR モード (per-request CSR build) を試す。
   const enableCh = !process.argv.includes('--no-ch');
   const useChCsr = process.argv.includes('--csr');
-  console.log(`[setup] enableCh=${enableCh} useChCsr=${useChCsr}`);
+  const csrOnly = process.argv.includes('--csr-only');
+  console.log(`[setup] enableCh=${enableCh} useChCsr=${useChCsr} csrOnly=${csrOnly}`);
   const loader = new TileLoader(fetcher, { enableCh, maxTiles: 2048 });
-  const router = new TiledRouter(loader, { useChCsr });
+  const router = new TiledRouter(loader, { useChCsr, csrOnly });
   // expose csr caps for debugging
   if (useChCsr) {
     const { chQueryCsr } = require('../lib/cycling/chquery_csr');

--- a/worker.mjs
+++ b/worker.mjs
@@ -55,13 +55,13 @@ function ensureTileLoader(env) {
   // R2 origin の往復 (~100ms) を edge cache (caches.default) でスキップする。
   // 同じタイルは isolate を跨いで使い回せるので route の cold start が大幅短縮。
   tileLoaderCache = new TileLoader(
-    // PR #83 (CSR ephemeral) も exceededMemory。CSR build 自体の中間 JS array
-    // (nodeOsmIds, idToIdx Map など) + view + tileBufs で peak が 128MB を
-    // 超過する模様。view を残したまま CSR を併用する構成は厳しい。
-    // 次の試み: view 自体も typed-array 化し、TileLoader は buffer cache 専用
-    // にする (GraphView を per-request build)。それまでは安定動作の NBA*
-    // モード。cache v13。
-    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default, 'v13')
+    // PR #85: CSR-only モード (TileLoader.view を一切使わない)。
+    // - loadBuffers のみで R2 fetch (ArrayBuffer cache、view 非 populate)
+    // - 各 request で buildCsr → snapCsr → chQueryCsr → release
+    // - persistent な decoded state なし。peak memory ≈ csr ~50MB + bufs ~16MB
+    // PR #83 で view + csr ephemeral 構成が exceededMemory だったため、view
+    // 自体を捨てる。cache v14。
+    makeR2Fetcher(env.GRAPH, 'tiles/', caches.default, 'v14')
   );
   return tileLoaderCache;
 }
@@ -144,7 +144,7 @@ async function handleRoute(url, env) {
     }
     throw err;
   }
-  const router = new TiledRouter(loader);
+  const router = new TiledRouter(loader, { csrOnly: true });
   const r = await router.route(from[0], from[1], to[0], to[1]);
   if (r.error) {
     const status =
@@ -241,7 +241,7 @@ async function handleDnfPack(url, env) {
     }
     throw err;
   }
-  const router = new TiledRouter(loader);
+  const router = new TiledRouter(loader, { csrOnly: true });
   const r = await router.route(from[0], from[1], to[0], to[1]);
   if (r.error) {
     const status =


### PR DESCRIPTION
PR #83 失敗 (view + CSR で exceededMemory) を受けて、view を完全に捨てて毎リクエスト CSR を build する CSR-only mode を追加。peak memory ~66MB (CSR 50MB + buffer 16MB) で 128MB に確実に収まる想定。ローカル bench で 3km route 動作確認: alg=ch-csr, 17ms chQuery, dist=5668.6 ✓ correct. cache v14。