### PR TITLE
feat(cycling): CSR-only mode 長距離 fallback (plain bidi Dijkstra)

### DIFF
--- a/lib/cycling/chquery_csr.js
+++ b/lib/cycling/chquery_csr.js
@@ -23,6 +23,8 @@ const INF = Infinity;
  * @param {number} [opts.settledCap=20000]
  * @param {number} [opts.popsCap=80000]
  * @param {number} [opts.timeBudgetMs=1500]
+ * @param {boolean} [opts.noLevelConstraint=false]  CH の level/core 制約を
+ *   skip (plain bidirectional Dijkstra として振る舞う)。fallback 用途。
  * @returns {{ distance, pathIdx, settled }}
  *   pathIdx は local-index 配列。caller が CSR.ids で OSM id に戻す。
  *   shortcut の展開はここでは行わず caller 側 (unpackChEdgeCsr) で行う。
@@ -31,6 +33,7 @@ function chQueryCsr(csr, startIdx, goalIdx, opts) {
   const settledCap = opts?.settledCap ?? 20000;
   const popsCap = opts?.popsCap ?? 80000;
   const timeBudgetMs = opts?.timeBudgetMs ?? 1500;
+  const noLevelConstraint = !!opts?.noLevelConstraint;
 
   const n = csr.nodeCount;
   if (startIdx === goalIdx) {
@@ -110,8 +113,10 @@ function chQueryCsr(csr, startIdx, goalIdx, opts) {
         // view-base chQueryOnView の `levels.get(v) === undefined` 相当:
         // cross-tile target など level 不明な node への relax は禁止。
         if (vLevel === UNKNOWN_LEVEL) continue;
-        const coreCoreLateral = uIsCore && cores[v] === 1;
-        if (!coreCoreLateral && vLevel <= uLevel) continue;
+        if (!noLevelConstraint) {
+          const coreCoreLateral = uIsCore && cores[v] === 1;
+          if (!coreCoreLateral && vLevel <= uLevel) continue;
+        }
         const nd = d + fwdCost[e];
         if (nd < distF[v]) {
           distF[v] = nd;
@@ -135,8 +140,10 @@ function chQueryCsr(csr, startIdx, goalIdx, opts) {
         const v = revFrom[e];
         const vLevel = levels[v];
         if (vLevel === UNKNOWN_LEVEL) continue;
-        const coreCoreLateral = uIsCore && cores[v] === 1;
-        if (!coreCoreLateral && vLevel <= uLevel) continue;
+        if (!noLevelConstraint) {
+          const coreCoreLateral = uIsCore && cores[v] === 1;
+          if (!coreCoreLateral && vLevel <= uLevel) continue;
+        }
         const nd = d + revCost[e];
         if (nd < distB[v]) {
           distB[v] = nd;

--- a/lib/cycling/tiled_router.js
+++ b/lib/cycling/tiled_router.js
@@ -99,15 +99,35 @@ class TiledRouter {
     if (!toSnap || toSnap.distanceMeters > this.maxSnapMeters) {
       return { error: 'no_nearby_node_to' };
     }
+    // CSR-only mode: chQuery cap を緩める (memory はもう CSR で固定なので
+    // CPU 計算量だけ気にすればよく、Workers 30s CPU 内なら 5s 程度は問題なし)。
     const tCh0 = Date.now();
-    const rc = chQueryCsr(csr, fromSnap.idx, toSnap.idx);
+    let rc = chQueryCsr(csr, fromSnap.idx, toSnap.idx, {
+      settledCap: 80000,
+      popsCap: 200000,
+      timeBudgetMs: 5000
+    });
     const chMs = Date.now() - tCh0;
+    // CH cap 到達時は plain bidi Dijkstra fallback (CSR 上、level 制約なし)。
+    // 長距離 route で CH builder の suboptimality に救済を入れる。
+    let fallbackMs = null;
+    if (!Number.isFinite(rc.distance)) {
+      const tFb0 = Date.now();
+      rc = chQueryCsr(csr, fromSnap.idx, toSnap.idx, {
+        settledCap: 200000,
+        popsCap: 500000,
+        timeBudgetMs: 10000,
+        noLevelConstraint: true
+      });
+      fallbackMs = Date.now() - tFb0;
+    }
     try {
       console.log(JSON.stringify({
         evt: 'route',
         mode: 'csr-only',
-        alg: Number.isFinite(rc.distance) ? 'ch-csr' : 'unreachable',
+        alg: !Number.isFinite(rc.distance) ? 'unreachable' : (fallbackMs !== null ? 'csr-dijkstra' : 'ch-csr'),
         ch_ms: chMs,
+        fallback_ms: fallbackMs,
         ch_settled: rc.settled,
         csr_build_ms: csrBuildMs,
         csr_bytes: csrBytes,
@@ -125,7 +145,7 @@ class TiledRouter {
         error: 'unreachable_in_corridor',
         from_node: fromSnap.id,
         to_node: toSnap.id,
-        algorithm: 'ch-csr'
+        algorithm: fallbackMs !== null ? 'csr-dijkstra-failed' : 'ch-csr-failed'
       };
     }
     // path 展開
@@ -147,7 +167,7 @@ class TiledRouter {
       snap_from_m: fromSnap.distanceMeters,
       snap_to_m: toSnap.distanceMeters,
       loaded_tiles: allKeys.length,
-      algorithm: 'ch-csr',
+      algorithm: fallbackMs !== null ? 'csr-dijkstra' : 'ch-csr',
       coordinates
     };
   }


### PR DESCRIPTION
PR #85 (CSR-only) で 3km route 本番動作確認後、長距離 (7km/14km) は SETTLED_CAP 超過で 404 を返していた。chQueryCsr の cap を緩めて (settled 20k → 80k 等)、それでも到達不能なら noLevelConstraint=true で plain bidi Dijkstra として再走査する fallback を追加。

ローカル 14km route で alg=ch-csr 完走 (cap 引き上げで fallback まで行かず、distance 17838.5 ✓ view 一致)。