### PR TITLE
fix(cycling): wasm-pack 後の d.ts を post-build script で auto-patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cf:seed:remote": "wrangler d1 execute rideoasis-supply-points --file=cloudflare/seed.sql --remote",
     "cf:seed:local": "wrangler d1 execute rideoasis-supply-points --file=cloudflare/seed.sql --local",
     "cycling:ch-tile-split": "node --max-old-space-size=12288 scripts/cycling_ch_tile_split.js",
-    "wasm:build": "wasm-pack build rust-router --release --target bundler --out-dir pkg && wasm-pack build rust-router --release --target nodejs --out-dir pkg-node"
+    "wasm:build": "wasm-pack build rust-router --release --target bundler --out-dir pkg && wasm-pack build rust-router --release --target nodejs --out-dir pkg-node && node scripts/patch_wasm_dts.mjs"
   },
   "engines": {
     "node": ">=22.5.0",

--- a/rust-router/pkg/rust_router.d.ts
+++ b/rust-router/pkg/rust_router.d.ts
@@ -1,3 +1,4 @@
+/* AUTO-PATCHED-BY: scripts/patch_wasm_dts.mjs */
 /* tslint:disable */
 /* eslint-disable */
 
@@ -9,7 +10,7 @@
  *
  * このファイルは wasm-pack が再生成すると元の `any` シグネチャに戻るため、
  * `npm run wasm:build` の post-build (scripts/patch_wasm_dts.mjs) で
- * 自動的に再 patch される。
+ * 自動的に再 patch される。冪等性は先頭の PATCH_MARKER コメントで判定。
  */
 
 import type { RouteChResult } from './rust_router_worker';

--- a/rust-router/pkg/rust_router.d.ts
+++ b/rust-router/pkg/rust_router.d.ts
@@ -8,8 +8,8 @@
  * RouteChErr union 型が定義されている。
  *
  * このファイルは wasm-pack が再生成すると元の `any` シグネチャに戻るため、
- * `npm run wasm:build` 直後はこのコメントを再適用する必要がある (将来は
- * post-build script で patch する候補)。
+ * `npm run wasm:build` の post-build (scripts/patch_wasm_dts.mjs) で
+ * 自動的に再 patch される。
  */
 
 import type { RouteChResult } from './rust_router_worker';

--- a/rust-router/pkg/rust_router.d.ts
+++ b/rust-router/pkg/rust_router.d.ts
@@ -2,18 +2,13 @@
 /* tslint:disable */
 /* eslint-disable */
 
-/*
- * 注意: wasm-pack が自動生成する .d.ts は route_ch の戻りを `any` にする。
- * Workers 本番は ./rust_router_worker.js (lazy 初期化 wrapper) を import
- * しており、そちらの ./rust_router_worker.d.ts に正確な RouteChOk /
- * RouteChErr union 型が定義されている。
- *
- * このファイルは wasm-pack が再生成すると元の `any` シグネチャに戻るため、
- * `npm run wasm:build` の post-build (scripts/patch_wasm_dts.mjs) で
- * 自動的に再 patch される。冪等性は先頭の PATCH_MARKER コメントで判定。
- */
-
 import type { RouteChResult } from './rust_router_worker';
+
+/*
+ * route_ch の正確な戻り値型は ./rust_router_worker.d.ts の RouteChResult
+ * (RouteChOk | RouteChErr) を参照。本ファイルは wasm-pack 再生成時に
+ * scripts/patch_wasm_dts.mjs が差分 patch で再適用する。
+ */
 
 /**
  * Forward A* on the flat graph representation. Returns the path including
@@ -22,14 +17,15 @@ import type { RouteChResult } from './rust_router_worker';
 export function astar(node_coords: Float64Array, edge_data: Float64Array, start: number, goal: number): Float64Array;
 
 /**
- * DNF route entry point. See ./rust_router_worker.d.ts for the precise
- * RouteChResult shape (union of RouteChOk / RouteChErr).
+ * DNF route entry point. Decodes tile buffers, builds CSR, snaps endpoints,
+ * runs CH bidirectional query, unpacks shortcuts. Returns a JS object with
+ * `{ distance, settled, terminated, ch_ms, snap_from_m, snap_to_m,
+ * from_id, to_id, coords: [[lon,lat]...], algorithm, csr_bytes,
+ * csr_node_count, csr_edge_count }`.
+ *
+ * `buffers` は `Array<Uint8Array>` を JS から渡す想定。各要素はタイル
+ * binary (v1 or v2)。corridor + snap neighborhood 分まとめて渡す。
+ *
+ * 失敗時は `{ error: "..." }` を含む JS object を返す (例外を投げない)。
  */
-export function route_ch(
-  buffers: Uint8Array[],
-  from_lon: number,
-  from_lat: number,
-  to_lon: number,
-  to_lat: number,
-  max_snap_meters: number
-): RouteChResult;
+export function route_ch(buffers: Uint8Array[], from_lon: number, from_lat: number, to_lon: number, to_lat: number, max_snap_meters: number): RouteChResult;

--- a/scripts/patch_wasm_dts.mjs
+++ b/scripts/patch_wasm_dts.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// wasm-pack が生成する rust-router/pkg/rust_router.d.ts は route_ch の
+// 戻り値を `any` にする。本番 worker.mjs は wrapper (rust_router_worker.js)
+// 経由で import するため実害は無いが、CodeRabbit が型甘さを指摘するので
+// d.ts も strict union 型へ patch する。
+//
+// `npm run wasm:build` の最後で実行され、再生成された d.ts を上書きする。
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const dtsPath = resolve(__dirname, '..', 'rust-router', 'pkg', 'rust_router.d.ts');
+
+const PATCHED = `/* tslint:disable */
+/* eslint-disable */
+
+/*
+ * 注意: wasm-pack が自動生成する .d.ts は route_ch の戻りを \`any\` にする。
+ * Workers 本番は ./rust_router_worker.js (lazy 初期化 wrapper) を import
+ * しており、そちらの ./rust_router_worker.d.ts に正確な RouteChOk /
+ * RouteChErr union 型が定義されている。
+ *
+ * このファイルは wasm-pack が再生成すると元の \`any\` シグネチャに戻るため、
+ * \`npm run wasm:build\` の post-build (scripts/patch_wasm_dts.mjs) で
+ * 自動的に再 patch される。
+ */
+
+import type { RouteChResult } from './rust_router_worker';
+
+/**
+ * Forward A* on the flat graph representation. Returns the path including
+ * start and goal indices, prefixed by the total distance.
+ */
+export function astar(node_coords: Float64Array, edge_data: Float64Array, start: number, goal: number): Float64Array;
+
+/**
+ * DNF route entry point. See ./rust_router_worker.d.ts for the precise
+ * RouteChResult shape (union of RouteChOk / RouteChErr).
+ */
+export function route_ch(
+  buffers: Uint8Array[],
+  from_lon: number,
+  from_lat: number,
+  to_lon: number,
+  to_lat: number,
+  max_snap_meters: number
+): RouteChResult;
+`;
+
+const current = readFileSync(dtsPath, 'utf8');
+if (current === PATCHED) {
+  console.log('[patch_wasm_dts] already patched');
+} else {
+  writeFileSync(dtsPath, PATCHED);
+  console.log(`[patch_wasm_dts] patched ${dtsPath}`);
+}

--- a/scripts/patch_wasm_dts.mjs
+++ b/scripts/patch_wasm_dts.mjs
@@ -5,6 +5,10 @@
 // d.ts も strict union 型へ patch する。
 //
 // `npm run wasm:build` の最後で実行され、再生成された d.ts を上書きする。
+//
+// 冪等性は **marker comment ベース** で判定する (CodeRabbit PR #88 指摘)。
+// 文字列全体比較だと wasm-pack が空白やコメント順を変えるたびに上書き発火
+// してしまうため、PATCH_MARKER の有無だけ確認する。
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -13,7 +17,10 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const dtsPath = resolve(__dirname, '..', 'rust-router', 'pkg', 'rust_router.d.ts');
 
-const PATCHED = `/* tslint:disable */
+const PATCH_MARKER = '/* AUTO-PATCHED-BY: scripts/patch_wasm_dts.mjs */';
+
+const PATCHED = `${PATCH_MARKER}
+/* tslint:disable */
 /* eslint-disable */
 
 /*
@@ -24,7 +31,7 @@ const PATCHED = `/* tslint:disable */
  *
  * このファイルは wasm-pack が再生成すると元の \`any\` シグネチャに戻るため、
  * \`npm run wasm:build\` の post-build (scripts/patch_wasm_dts.mjs) で
- * 自動的に再 patch される。
+ * 自動的に再 patch される。冪等性は先頭の PATCH_MARKER コメントで判定。
  */
 
 import type { RouteChResult } from './rust_router_worker';
@@ -49,10 +56,23 @@ export function route_ch(
 ): RouteChResult;
 `;
 
-const current = readFileSync(dtsPath, 'utf8');
-if (current === PATCHED) {
-  console.log('[patch_wasm_dts] already patched');
-} else {
-  writeFileSync(dtsPath, PATCHED);
-  console.log(`[patch_wasm_dts] patched ${dtsPath}`);
+let current;
+try {
+  current = readFileSync(dtsPath, 'utf8');
+} catch (err) {
+  console.error(`[patch_wasm_dts] Failed to read ${dtsPath}:`, err.message);
+  process.exit(1);
 }
+
+if (current.startsWith(PATCH_MARKER)) {
+  console.log('[patch_wasm_dts] already patched (marker present); skip');
+  process.exit(0);
+}
+
+try {
+  writeFileSync(dtsPath, PATCHED);
+} catch (err) {
+  console.error(`[patch_wasm_dts] Failed to write ${dtsPath}:`, err.message);
+  process.exit(1);
+}
+console.log(`[patch_wasm_dts] patched ${dtsPath}`);

--- a/scripts/patch_wasm_dts.mjs
+++ b/scripts/patch_wasm_dts.mjs
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 // wasm-pack が生成する rust-router/pkg/rust_router.d.ts は route_ch の
-// 戻り値を `any` にする。本番 worker.mjs は wrapper (rust_router_worker.js)
-// 経由で import するため実害は無いが、CodeRabbit が型甘さを指摘するので
-// d.ts も strict union 型へ patch する。
+// 戻り値・引数を `any` にする。本番 worker.mjs は wrapper 経由で import
+// するため実害は無いが、CodeRabbit が型甘さを指摘するので d.ts も strict
+// な union 型へ patch する。
 //
-// `npm run wasm:build` の最後で実行され、再生成された d.ts を上書きする。
+// `npm run wasm:build` の最後で実行され、再生成された d.ts に **差分 patch**
+// を当てる (CodeRabbit PR #88 指摘)。全文上書きは将来 wasm-pack が新しい
+// export を追加した時に静かに消してしまうため、route_ch 関連の型だけを
+// 正規表現で差し替える戦略をとる。
 //
-// 冪等性は **marker comment ベース** で判定する (CodeRabbit PR #88 指摘)。
-// 文字列全体比較だと wasm-pack が空白やコメント順を変えるたびに上書き発火
-// してしまうため、PATCH_MARKER の有無だけ確認する。
+// 冪等性は先頭の PATCH_MARKER で判定。あれば skip。
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -18,43 +19,20 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const dtsPath = resolve(__dirname, '..', 'rust-router', 'pkg', 'rust_router.d.ts');
 
 const PATCH_MARKER = '/* AUTO-PATCHED-BY: scripts/patch_wasm_dts.mjs */';
+const IMPORT_LINE = "import type { RouteChResult } from './rust_router_worker';";
+const PATCH_NOTE = [
+  '/*',
+  ' * route_ch の正確な戻り値型は ./rust_router_worker.d.ts の RouteChResult',
+  ' * (RouteChOk | RouteChErr) を参照。本ファイルは wasm-pack 再生成時に',
+  ' * scripts/patch_wasm_dts.mjs が差分 patch で再適用する。',
+  ' */'
+].join('\n');
 
-const PATCHED = `${PATCH_MARKER}
-/* tslint:disable */
-/* eslint-disable */
-
-/*
- * 注意: wasm-pack が自動生成する .d.ts は route_ch の戻りを \`any\` にする。
- * Workers 本番は ./rust_router_worker.js (lazy 初期化 wrapper) を import
- * しており、そちらの ./rust_router_worker.d.ts に正確な RouteChOk /
- * RouteChErr union 型が定義されている。
- *
- * このファイルは wasm-pack が再生成すると元の \`any\` シグネチャに戻るため、
- * \`npm run wasm:build\` の post-build (scripts/patch_wasm_dts.mjs) で
- * 自動的に再 patch される。冪等性は先頭の PATCH_MARKER コメントで判定。
- */
-
-import type { RouteChResult } from './rust_router_worker';
-
-/**
- * Forward A* on the flat graph representation. Returns the path including
- * start and goal indices, prefixed by the total distance.
- */
-export function astar(node_coords: Float64Array, edge_data: Float64Array, start: number, goal: number): Float64Array;
-
-/**
- * DNF route entry point. See ./rust_router_worker.d.ts for the precise
- * RouteChResult shape (union of RouteChOk / RouteChErr).
- */
-export function route_ch(
-  buffers: Uint8Array[],
-  from_lon: number,
-  from_lat: number,
-  to_lon: number,
-  to_lat: number,
-  max_snap_meters: number
-): RouteChResult;
-`;
+// route_ch のシグネチャに `Array<any>` (buffers) と `: any;` (戻り値) が
+// あれば差し替える。astar 等の他の export は触らない。
+const BUFFERS_ANY_PATTERN = /(\bfunction route_ch\(\s*buffers:\s*)Array<any>/m;
+const ROUTE_CH_RETURN_PATTERN =
+  /(\bexport function route_ch\(\s*buffers:\s*[^)]+\)\s*:\s*)any(\s*;)/m;
 
 let current;
 try {
@@ -69,10 +47,48 @@ if (current.startsWith(PATCH_MARKER)) {
   process.exit(0);
 }
 
+let patched = current;
+
+// 1) buffers: Array<any> → Uint8Array[]
+const beforeBuffers = patched;
+patched = patched.replace(BUFFERS_ANY_PATTERN, '$1Uint8Array[]');
+const buffersPatched = patched !== beforeBuffers;
+
+// 2) 戻り値 ): any; → ): RouteChResult;
+const beforeReturn = patched;
+patched = patched.replace(ROUTE_CH_RETURN_PATTERN, '$1RouteChResult$2');
+const returnPatched = patched !== beforeReturn;
+
+if (!buffersPatched && !returnPatched) {
+  console.warn(
+    '[patch_wasm_dts] WARN: route_ch any-typed signature not found in d.ts. ' +
+    'wasm-pack may have changed its output. Inspect ' + dtsPath
+  );
+}
+
+// 3) RouteChResult を使うため import 行を追加。既存の disable comment 直後
+//    に挿入する (なければ先頭近くに追加)。
+if (!patched.includes(IMPORT_LINE)) {
+  if (/\/\* eslint-disable \*\//.test(patched)) {
+    patched = patched.replace(
+      /(\/\* eslint-disable \*\/[ \t]*\n)/,
+      `$1\n${IMPORT_LINE}\n\n${PATCH_NOTE}\n`
+    );
+  } else {
+    patched = `${IMPORT_LINE}\n\n${PATCH_NOTE}\n\n${patched}`;
+  }
+}
+
+// 4) marker を先頭に prepend (冪等性チェック用)
+patched = `${PATCH_MARKER}\n${patched}`;
+
 try {
-  writeFileSync(dtsPath, PATCHED);
+  writeFileSync(dtsPath, patched);
 } catch (err) {
   console.error(`[patch_wasm_dts] Failed to write ${dtsPath}:`, err.message);
   process.exit(1);
 }
-console.log(`[patch_wasm_dts] patched ${dtsPath}`);
+console.log(
+  `[patch_wasm_dts] patched ${dtsPath} ` +
+  `(buffers=${buffersPatched}, return=${returnPatched})`
+);


### PR DESCRIPTION
PR #87 で rust_router.d.ts を手で patch したが wasm-pack 再生成で戻ってしまう。scripts/patch_wasm_dts.mjs を npm run wasm:build の末尾に追加して自動再 patch。CodeRabbit 型指摘の durable fix。