### PR TITLE
feat(ui): 未使用の地名検索バー (Nominatim) を削除

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,11 +1,4 @@
 const API_BASE = window.RIDEOASIS_API_BASE || '/api';
-// Public Nominatim forbids client-side autocomplete and limits usage to ~1 req/s.
-// The geo-search UI uses submit-only firing (Enter / search button) so a single
-// user-initiated request is sent per search. For higher volume or hosted use,
-// override this with a self-hosted Nominatim or proxy via window.RIDEOASIS_NOMINATIM_BASE.
-const PUBLIC_NOMINATIM_BASE = 'https://nominatim.openstreetmap.org/search';
-const NOMINATIM_BASE = window.RIDEOASIS_NOMINATIM_BASE || PUBLIC_NOMINATIM_BASE;
-const NOMINATIM_PUBLIC_MIN_INTERVAL_MS = 1000;
 
 const PRECISE_POINT_LEVEL = 8;
 const DEFAULT_MIN_POINT_LEVEL = 3;
@@ -13,8 +6,6 @@ const DISTANCE_OPTIONS = [100, 250, 500, 1000, 2000, 5000, 10000];
 const FOLLOW_MIN_REFRESH_INTERVAL_MS = 30000;
 const FOLLOW_FORWARD_HALF_CONE_DEG = 90;
 const FOLLOW_BEARING_MIN_MOVEMENT_M = 5;
-const GEO_SEARCH_MIN_QUERY = 2;
-const GEO_SEARCH_LIMIT = 5;
 
 const elements = {
   status: document.getElementById('status'),
@@ -34,11 +25,6 @@ const elements = {
   popupBody: document.getElementById('popup-body'),
   popupClose: document.getElementById('popup-close'),
   followToggle: document.getElementById('follow-toggle'),
-  geoSearchForm: document.getElementById('geo-search-form'),
-  geoSearchInput: document.getElementById('geo-search-input'),
-  geoSearchSubmit: document.getElementById('geo-search-submit'),
-  geoSearchClear: document.getElementById('geo-search-clear'),
-  geoSearchResults: document.getElementById('geo-search-results'),
   resultsSheet: document.getElementById('results-sheet'),
   resultsToggle: document.getElementById('results-toggle'),
   cueSheetButton: document.getElementById('cue-sheet-button'),
@@ -271,9 +257,6 @@ let followWatchId = null;
 let followLastCoord = null;
 let followBearingDeg = null;
 let followLastRefreshAt = 0;
-let geoSearchAbortController = null;
-let latestGeoSearchToken = 0;
-let lastGeoSearchRequestTs = 0;
 
 /** Returns the currently selected route source mode. */
 function selectedSourceMode() {
@@ -2564,185 +2547,6 @@ async function handleFollowToggle() {
   }
 }
 
-/** Empties the geo-search dropdown and hides it. */
-function clearGeoSearchResults() {
-  elements.geoSearchResults.innerHTML = '';
-  elements.geoSearchResults.hidden = true;
-}
-
-/** Renders Nominatim search results into the dropdown with two actions per row. */
-function renderGeoSearchResults(items) {
-  elements.geoSearchResults.innerHTML = '';
-  if (!items.length) {
-    const empty = document.createElement('li');
-    empty.className = 'geo-search-empty';
-    empty.textContent = '該当する地名が見つかりません';
-    elements.geoSearchResults.appendChild(empty);
-    elements.geoSearchResults.hidden = false;
-    return;
-  }
-  for (const item of items) {
-    const li = document.createElement('li');
-    li.className = 'geo-search-result';
-
-    const name = document.createElement('span');
-    name.className = 'geo-search-result-name';
-    name.textContent = item.display_name;
-
-    const actions = document.createElement('div');
-    actions.className = 'geo-search-result-actions';
-
-    const fitBtn = document.createElement('button');
-    fitBtn.type = 'button';
-    fitBtn.className = 'geo-search-result-fit';
-    fitBtn.textContent = 'この場所を表示';
-    fitBtn.addEventListener('click', () => fitMapToPlace(item));
-
-    const searchBtn = document.createElement('button');
-    searchBtn.type = 'button';
-    searchBtn.className = 'geo-search-result-search';
-    searchBtn.textContent = 'ここで検索';
-    searchBtn.addEventListener('click', () => searchAtPlace(item));
-
-    actions.append(fitBtn, searchBtn);
-    li.append(name, actions);
-    elements.geoSearchResults.appendChild(li);
-  }
-  elements.geoSearchResults.hidden = false;
-}
-
-/** Calls Nominatim and returns up to GEO_SEARCH_LIMIT places matching the query. */
-async function fetchPlaces(query) {
-  if (geoSearchAbortController) {
-    geoSearchAbortController.abort();
-  }
-  geoSearchAbortController = new AbortController();
-  const params = new URLSearchParams({
-    q: query,
-    format: 'json',
-    countrycodes: 'jp',
-    'accept-language': 'ja',
-    limit: String(GEO_SEARCH_LIMIT),
-    addressdetails: '0'
-  });
-  const response = await fetch(`${NOMINATIM_BASE}?${params.toString()}`, {
-    signal: geoSearchAbortController.signal,
-    headers: { Accept: 'application/json' }
-  });
-  if (!response.ok) {
-    throw new Error(`Nominatim error (${response.status})`);
-  }
-  return response.json();
-}
-
-/** Cancels any in-flight geo-search request and invalidates pending response tokens. */
-function cancelPendingGeoSearch() {
-  latestGeoSearchToken += 1;
-  if (geoSearchAbortController) {
-    geoSearchAbortController.abort();
-    geoSearchAbortController = null;
-  }
-}
-
-/** Fits the map view to a Nominatim place's bounding box. */
-function fitMapToPlace(item) {
-  cancelPendingGeoSearch();
-  const bbox = Array.isArray(item.boundingbox) ? item.boundingbox.map(Number) : null;
-  if (!bbox || bbox.length !== 4 || !bbox.every(Number.isFinite)) {
-    return;
-  }
-  const [minLat, maxLat, minLon, maxLon] = bbox;
-  const extent = ol.proj.transformExtent(
-    [minLon, minLat, maxLon, maxLat],
-    'EPSG:4326',
-    'EPSG:3857'
-  );
-  map.getView().fit(extent, { padding: [40, 40, 40, 40], duration: 250, maxZoom: 14 });
-  clearGeoSearchResults();
-}
-
-/** Uses a Nominatim place as the current-location anchor and runs nearby search. */
-async function searchAtPlace(item) {
-  const lat = Number(item.lat);
-  const lon = Number(item.lon);
-  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
-
-  cancelPendingGeoSearch();
-  manualPoints = [];
-
-  const currentRadio = document.querySelector('input[name="source-mode"][value="current"]');
-  if (currentRadio) {
-    currentRadio.checked = true;
-    syncSourceModeUi();
-  }
-
-  const loadToken = ++latestRouteLoadToken;
-  cancelPendingRefreshes();
-  if (loadToken !== latestRouteLoadToken) return;
-  const coord = [lon, lat];
-  routeFeature = null;
-  routeCoordinates = [coord];
-  routeElevations = [];
-  rebuildRouteElevationCache();
-  renderCurrentLocation(coord);
-  resetResults();
-  updateRoutePointCount();
-  fitToVisibleData();
-  renderElevationChart();
-  setStatus(`「${item.display_name}」を中心に検索中...`);
-  clearGeoSearchResults();
-  await refreshMap([...routeCoordinates]);
-}
-
-/** Updates clear-button visibility on input change. Submission is explicit (Enter / button). */
-function handleGeoSearchInput() {
-  const query = elements.geoSearchInput.value.trim();
-  elements.geoSearchClear.hidden = query.length === 0;
-}
-
-/** Submit-only Nominatim search triggered by Enter key or the search button. */
-async function handleGeoSearchSubmit(event) {
-  event.preventDefault();
-  const query = elements.geoSearchInput.value.trim();
-  if (query.length < GEO_SEARCH_MIN_QUERY) {
-    cancelPendingGeoSearch();
-    clearGeoSearchResults();
-    return;
-  }
-
-  if (NOMINATIM_BASE === PUBLIC_NOMINATIM_BASE) {
-    const sinceLast = Date.now() - lastGeoSearchRequestTs;
-    if (sinceLast < NOMINATIM_PUBLIC_MIN_INTERVAL_MS) {
-      const waitSec = Math.ceil((NOMINATIM_PUBLIC_MIN_INTERVAL_MS - sinceLast) / 100) / 10;
-      setStatus(`連続検索を抑制中: ${waitSec}秒後に再試行してください`);
-      return;
-    }
-  }
-
-  cancelPendingGeoSearch();
-  lastGeoSearchRequestTs = Date.now();
-  const token = ++latestGeoSearchToken;
-  try {
-    const items = await fetchPlaces(query);
-    if (token !== latestGeoSearchToken) return;
-    renderGeoSearchResults(items);
-  } catch (error) {
-    if (error?.name === 'AbortError') return;
-    if (token !== latestGeoSearchToken) return;
-    console.error(error);
-    clearGeoSearchResults();
-  }
-}
-
-/** Clears the search box and hides results. */
-function handleGeoSearchClear() {
-  elements.geoSearchInput.value = '';
-  elements.geoSearchClear.hidden = true;
-  cancelPendingGeoSearch();
-  clearGeoSearchResults();
-  elements.geoSearchInput.focus();
-}
-
 /** Reads the currently checked filter inputs into the {chains, precision, cptypes} state shape. */
 function readFilterStateForUrl() {
   const allChainInputs = Array.from(document.querySelectorAll('.chain-filters input[type="checkbox"]'));
@@ -2851,21 +2655,6 @@ function bindEvents() {
   elements.useCurrentLocation.addEventListener('click', handleCurrentLocation);
   elements.followToggle.addEventListener('change', handleFollowToggle);
   elements.manualReset.addEventListener('click', resetManualState);
-  elements.geoSearchForm.addEventListener('submit', handleGeoSearchSubmit);
-  elements.geoSearchInput.addEventListener('input', handleGeoSearchInput);
-  elements.geoSearchClear.addEventListener('click', handleGeoSearchClear);
-  document.addEventListener('click', (event) => {
-    if (elements.geoSearchResults.hidden) return;
-    const target = event.target;
-    if (target instanceof Node && (
-      elements.geoSearchResults.contains(target) ||
-      elements.geoSearchInput.contains(target)
-    )) {
-      return;
-    }
-    cancelPendingGeoSearch();
-    clearGeoSearchResults();
-  });
   elements.pointList.addEventListener('mouseover', (event) => {
     const item = findPointListItem(event.target);
     if (!item || item === findPointListItem(event.relatedTarget)) return;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,23 +18,6 @@
         <div class="status" id="status" role="status" aria-live="polite">経路を指定してください</div>
       </header>
 
-      <section class="search-row">
-        <form class="geo-search" id="geo-search-form" autocomplete="off" role="search">
-          <span class="geo-search-icon" aria-hidden="true">🔍</span>
-          <input
-            id="geo-search-input"
-            type="search"
-            placeholder="地名で検索 (例: 箱根)"
-            autocomplete="off"
-            enterkeyhint="search"
-            aria-label="地名で検索"
-          />
-          <button id="geo-search-clear" type="button" class="geo-search-clear" hidden aria-label="検索語を消す">×</button>
-          <button type="submit" id="geo-search-submit" class="geo-search-submit">検索</button>
-        </form>
-        <ul id="geo-search-results" class="geo-search-results" hidden role="listbox"></ul>
-      </section>
-
       <section class="mode-bar">
         <div class="mode-chips" role="radiogroup" aria-label="ルートの指定">
           <label class="mode-chip">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -33,7 +33,6 @@
   --tap-min: 44px;
 
   --top-bar-h: 48px;
-  --search-row-h: 56px;
   --results-collapsed-h: 56px;
   --results-expanded-h: 56vh;
 }
@@ -81,7 +80,7 @@ input[type="search"]::-webkit-search-cancel-button {
 /* ========== App grid ========== */
 .app {
   display: grid;
-  grid-template-rows: var(--top-bar-h) var(--search-row-h) auto 1fr auto;
+  grid-template-rows: var(--top-bar-h) auto 1fr auto;
   height: 100vh;
   height: 100dvh;
   background: var(--c-bg);
@@ -132,168 +131,6 @@ input[type="search"]::-webkit-search-cancel-button {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-/* ========== Search row ========== */
-.search-row {
-  position: relative;
-  padding: var(--space-2) var(--space-4);
-  background: var(--c-surface);
-  border-bottom: 1px solid var(--c-line);
-  z-index: 30;
-}
-
-.geo-search {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1);
-  height: 40px;
-  padding: 0 var(--space-2) 0 var(--space-3);
-  border: 1px solid var(--c-line-strong);
-  border-radius: var(--r-pill);
-  background: var(--c-surface-muted);
-  transition: border-color 120ms ease, background 120ms ease;
-}
-
-.geo-search:focus-within {
-  border-color: var(--c-accent);
-  background: var(--c-surface);
-}
-
-.geo-search-icon {
-  flex-shrink: 0;
-  color: var(--c-ink-muted);
-  font-size: 14px;
-}
-
-.geo-search input[type="search"] {
-  flex: 1;
-  min-width: 0;
-  border: 0;
-  background: transparent;
-  outline: none;
-  font-size: 15px;
-  padding: 0 var(--space-1);
-}
-
-.geo-search-clear {
-  flex-shrink: 0;
-  width: 28px;
-  height: 28px;
-  border: 0;
-  border-radius: 50%;
-  background: var(--c-line);
-  color: var(--c-ink-muted);
-  font-size: 16px;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.geo-search-clear:hover,
-.geo-search-clear:focus-visible {
-  background: var(--c-line-strong);
-}
-
-.geo-search-submit {
-  flex-shrink: 0;
-  height: 32px;
-  padding: 0 var(--space-3);
-  border: 0;
-  border-radius: var(--r-pill);
-  background: var(--c-accent);
-  color: #fff;
-  font-size: 13px;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.geo-search-submit:hover,
-.geo-search-submit:focus-visible {
-  background: var(--c-accent-strong);
-}
-
-.geo-search-results {
-  position: absolute;
-  top: calc(100% - 4px);
-  left: var(--space-4);
-  right: var(--space-4);
-  max-height: min(60vh, 360px);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  background: var(--c-surface);
-  border: 1px solid var(--c-line);
-  border-radius: var(--r-md);
-  box-shadow: var(--shadow-lg);
-  overflow: auto;
-  z-index: 40;
-}
-
-.geo-search-result,
-.geo-search-empty {
-  padding: var(--space-3) var(--space-4);
-  border-top: 1px solid var(--c-line);
-  font-size: 13px;
-}
-
-.geo-search-result:first-child,
-.geo-search-empty:first-child {
-  border-top: 0;
-}
-
-.geo-search-result {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-}
-
-.geo-search-result-name {
-  color: var(--c-ink);
-  font-weight: 700;
-  line-height: 1.4;
-}
-
-.geo-search-result-actions {
-  display: flex;
-  gap: var(--space-2);
-  flex-wrap: wrap;
-}
-
-.geo-search-result-actions button {
-  flex: 1;
-  min-height: 36px;
-  padding: 6px 10px;
-  border: 1px solid var(--c-line-strong);
-  border-radius: var(--r-md);
-  background: var(--c-surface);
-  color: var(--c-ink);
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.geo-search-result-actions button:hover,
-.geo-search-result-actions button:focus-visible {
-  border-color: var(--c-accent);
-  background: var(--c-accent-soft);
-  color: var(--c-accent-strong);
-}
-
-.geo-search-result-actions .geo-search-result-search {
-  background: var(--c-accent);
-  border-color: var(--c-accent);
-  color: #fff;
-}
-
-.geo-search-result-actions .geo-search-result-search:hover,
-.geo-search-result-actions .geo-search-result-search:focus-visible {
-  background: var(--c-accent-strong);
-  border-color: var(--c-accent-strong);
-  color: #fff;
-}
-
-.geo-search-empty {
-  color: var(--c-ink-muted);
 }
 
 /* ========== Mode bar ========== */
@@ -989,24 +826,23 @@ input[type="search"]::-webkit-search-cancel-button {
 /* ========== Desktop refinements ========== */
 @media (min-width: 821px) {
   .app {
-    grid-template-rows: var(--top-bar-h) var(--search-row-h) auto 1fr;
+    grid-template-rows: var(--top-bar-h) auto 1fr;
     grid-template-columns: 1fr min(420px, 38%);
   }
 
   .top-bar,
-  .search-row,
   .mode-bar {
     grid-column: 1 / -1;
   }
 
   .map-shell {
-    grid-row: 4;
+    grid-row: 3;
     grid-column: 1;
     border-right: 1px solid var(--c-line);
   }
 
   .results-sheet {
-    grid-row: 4;
+    grid-row: 3;
     grid-column: 2;
     max-height: none;
     border-top: 0;
@@ -1037,19 +873,9 @@ input[type="search"]::-webkit-search-cancel-button {
     font-size: 18px;
   }
 
-  .search-row,
   .mode-bar {
     padding-left: var(--space-5);
     padding-right: var(--space-5);
-  }
-
-  .geo-search-results {
-    left: var(--space-5);
-    right: auto;
-    width: min(640px, calc(100% - var(--space-5) * 2));
-  }
-
-  .mode-bar {
     flex-direction: row;
     align-items: center;
     gap: var(--space-4);
@@ -1076,15 +902,9 @@ input[type="search"]::-webkit-search-cancel-button {
     padding: 0 var(--space-3);
   }
 
-  .search-row,
   .mode-bar {
     padding-left: var(--space-3);
     padding-right: var(--space-3);
-  }
-
-  .geo-search-results {
-    left: var(--space-3);
-    right: var(--space-3);
   }
 
   .brand-text {


### PR DESCRIPTION
#93 で提案されていた変更のうち、**地名検索バーの削除だけ**を取り込む。

## #93 をそのまま使わなかった理由

#93 は周回モードを前提とした「検索/生成の2グループ」UI 再編でした。

```
検索モード（既存ルートを読み込む）: GPX / 現在地
生成モード（ルートを作る）      : 手動2点 / 周回   ← #95 で削除済み
```

分岐元が `5081388`（loop 削除の2つ前）で、`frontend/app.js` / `index.html` / `styles.css` の**3ファイルすべてでコンフリクト**します。ブランチには `value="loop"` のラジオが1箇所、`loopCandidates` / `handleGenerateLoop` が26箇所残っており、そのままマージすると削除した周回モードが復活します。

地名検索バーの削除は loop と独立して価値があるため、現在の main から実装し直しました。2グループ化はモードが3つになった今では意味が薄いので見送っています。

## 変更

**412行削除 / 4行追加**

- `frontend/index.html` — `search-row` section を削除
- `frontend/app.js` — Nominatim 関連の定数・要素参照・状態・関数群（9関数）・イベント配線を削除。ブロック外から参照されていたのは**イベント登録のみ**で、他モジュールへの影響がないことを確認済み
- `frontend/styles.css` — `.search-row` / `.geo-search*` と `--search-row-h` を削除

### グリッドの調整

検索行が消えてグリッドが1段減るため、以下も合わせて直しています。

| 対象 | 変更 |
|---|---|
| `.app` の `grid-template-rows`（通常時） | `top-bar / search-row / auto / 1fr / auto` → `top-bar / auto / 1fr / auto` |
| `.app` の `grid-template-rows`（デスクトップ） | 同様に1段削減 |
| `.map-shell` / `.results-sheet` の `grid-row` | `4` → `3` |

`.search-row,` を外した結果で隣接重複した `.mode-bar` のルールも統合しました。

## 検証

- `npm test` — **315 passed / 0 failed**
- Playwright で desktop (1280×800) / mobile (390×844) を確認
  - `.search-row` と `#geo-search-form` が **0件**
  - モードチップは `GPX` / `現在地` / `手動2点`
  - モード切替と手動2点の経路生成を一巡させて **JS エラー 0件**
  - 検索行が消えた分だけ地図が広がることを目視確認（mobile で地図高さ 497px）

## #93 の扱い

この PR がマージされたら #93 は閉じてよい状態になります。