### PR TITLE
chore: グラフ部分抽出スクリプトを追跡し、.dryrun/ を ignore する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ test-results/
 data/
 .local/
 .wrangler/
+# wrangler --dry-run のビルド出力 (worker.js / source map / wasm)
+.dryrun/
 cloudflare/seed.sql
 
 # WASM 成果物は ochanuco/cycling-router の GitHub Release から取得する。

--- a/scripts/cycling_extract_subset.js
+++ b/scripts/cycling_extract_subset.js
@@ -40,6 +40,8 @@ function parseBbox(str) {
   return { minLon: nums[0], minLat: nums[1], maxLon: nums[2], maxLat: nums[3] };
 }
 
+// onLine を await する。呼び出し側が書き込みの drain を待てるようにして、
+// 1GB 級の ndjson でも出力側のバッファが際限なく膨らまないようにする。
 async function streamLines(filePath, onLine) {
   const rl = readline.createInterface({
     input: fs.createReadStream(filePath, { encoding: 'utf8' }),
@@ -47,8 +49,13 @@ async function streamLines(filePath, onLine) {
   });
   for await (const line of rl) {
     if (!line) continue;
-    onLine(line);
+    await onLine(line);
   }
+}
+
+/** write() が false を返したら drain を待つ (バックプレッシャー)。 */
+async function writeLine(stream, line) {
+  if (!stream.write(line + '\n')) await once(stream, 'drain');
 }
 
 async function main() {
@@ -67,6 +74,14 @@ async function main() {
     return;
   }
 
+  // src と dst が同じだと、読みながら同じファイルを truncate して元データを
+  // 壊す。1GB 級の抽出元を失うと再取得コストが大きいので、書き始める前に弾く。
+  if (path.resolve(args.src) === path.resolve(args.dst)) {
+    process.stderr.write('--src and --dst must differ (would overwrite the source)\n');
+    process.exitCode = 1;
+    return;
+  }
+
   fs.mkdirSync(args.dst, { recursive: true });
 
   const t0 = Date.now();
@@ -76,8 +91,7 @@ async function main() {
   process.stderr.write('[pass 1/2] filtering nodes by bbox\n');
   let nodesSeen = 0;
   let nodesKept = 0;
-  let writes = 0;
-  await streamLines(path.join(args.src, 'nodes.ndjson'), (line) => {
+  await streamLines(path.join(args.src, 'nodes.ndjson'), async (line) => {
     nodesSeen += 1;
     const n = JSON.parse(line);
     if (
@@ -85,9 +99,8 @@ async function main() {
       n.lat >= bbox.minLat && n.lat <= bbox.maxLat
     ) {
       keepIds.add(n.id);
-      nodesOut.write(line + '\n');
+      await writeLine(nodesOut, line);
       nodesKept += 1;
-      writes += 1;
     }
   });
   nodesOut.end();
@@ -99,11 +112,11 @@ async function main() {
   let edgesKept = 0;
   const t1 = Date.now();
   process.stderr.write('[pass 2/2] filtering edges (both endpoints in bbox)\n');
-  await streamLines(path.join(args.src, 'edges.ndjson'), (line) => {
+  await streamLines(path.join(args.src, 'edges.ndjson'), async (line) => {
     edgesSeen += 1;
     const e = JSON.parse(line);
     if (keepIds.has(e.from) && keepIds.has(e.to)) {
-      edgesOut.write(line + '\n');
+      await writeLine(edgesOut, line);
       edgesKept += 1;
     }
   });

--- a/scripts/cycling_extract_subset.js
+++ b/scripts/cycling_extract_subset.js
@@ -83,6 +83,44 @@ function canonicalPath(p) {
   }
 }
 
+/**
+ * srcFile を 1 行ずつ読み、keepLine が true を返した行だけ dstFile に書く。
+ * 返り値は { seen, kept }。
+ *
+ * 出力ストリームの error は生成直後に購読する。write() は成功しても後から
+ * ENOSPC 等で落ちることがあり、'error' に購読者がいないと Node が例外を
+ * 投げてプロセスごと死ぬ (main().catch に届かない)。失敗時は入力・出力とも
+ * 破棄してから呼び出し元へ投げ直す。
+ */
+async function filterInto(srcFile, dstFile, keepLine) {
+  const out = fs.createWriteStream(dstFile);
+  const outFailed = new Promise((_resolve, reject) => {
+    out.once('error', reject);
+  });
+  let seen = 0;
+  let kept = 0;
+  try {
+    await Promise.race([
+      (async () => {
+        await streamLines(srcFile, async (line) => {
+          seen += 1;
+          if (keepLine(line)) {
+            await writeLine(out, line);
+            kept += 1;
+          }
+        });
+        out.end();
+        await finished(out);
+      })(),
+      outFailed
+    ]);
+  } catch (err) {
+    out.destroy();
+    throw err;
+  }
+  return { seen, kept };
+}
+
 async function main() {
   const args = parseArgs();
   if (args.help || !args.src || !args.dst || !args.bbox) {
@@ -113,43 +151,33 @@ async function main() {
 
   const t0 = Date.now();
   const keepIds = new Set();
-  const nodesOut = fs.createWriteStream(path.join(args.dst, 'nodes.ndjson'));
 
   process.stderr.write('[pass 1/2] filtering nodes by bbox\n');
-  let nodesSeen = 0;
-  let nodesKept = 0;
-  await streamLines(path.join(args.src, 'nodes.ndjson'), async (line) => {
-    nodesSeen += 1;
-    const n = JSON.parse(line);
-    if (
-      n.lon >= bbox.minLon && n.lon <= bbox.maxLon &&
-      n.lat >= bbox.minLat && n.lat <= bbox.maxLat
-    ) {
-      keepIds.add(n.id);
-      await writeLine(nodesOut, line);
-      nodesKept += 1;
+  const nodes = await filterInto(
+    path.join(args.src, 'nodes.ndjson'),
+    path.join(args.dst, 'nodes.ndjson'),
+    (line) => {
+      const n = JSON.parse(line);
+      const inside =
+        n.lon >= bbox.minLon && n.lon <= bbox.maxLon &&
+        n.lat >= bbox.minLat && n.lat <= bbox.maxLat;
+      if (inside) keepIds.add(n.id);
+      return inside;
     }
-  });
-  nodesOut.end();
-  await finished(nodesOut);
-  process.stderr.write(`  nodes ${nodesKept}/${nodesSeen} in ${Date.now() - t0}ms\n`);
+  );
+  process.stderr.write(`  nodes ${nodes.kept}/${nodes.seen} in ${Date.now() - t0}ms\n`);
 
-  const edgesOut = fs.createWriteStream(path.join(args.dst, 'edges.ndjson'));
-  let edgesSeen = 0;
-  let edgesKept = 0;
   const t1 = Date.now();
   process.stderr.write('[pass 2/2] filtering edges (both endpoints in bbox)\n');
-  await streamLines(path.join(args.src, 'edges.ndjson'), async (line) => {
-    edgesSeen += 1;
-    const e = JSON.parse(line);
-    if (keepIds.has(e.from) && keepIds.has(e.to)) {
-      await writeLine(edgesOut, line);
-      edgesKept += 1;
+  const edges = await filterInto(
+    path.join(args.src, 'edges.ndjson'),
+    path.join(args.dst, 'edges.ndjson'),
+    (line) => {
+      const e = JSON.parse(line);
+      return keepIds.has(e.from) && keepIds.has(e.to);
     }
-  });
-  edgesOut.end();
-  await finished(edgesOut);
-  process.stderr.write(`  edges ${edgesKept}/${edgesSeen} in ${Date.now() - t1}ms\n`);
+  );
+  process.stderr.write(`  edges ${edges.kept}/${edges.seen} in ${Date.now() - t1}ms\n`);
   process.stderr.write(`done in ${((Date.now() - t0) / 1000).toFixed(1)}s\n`);
 }
 

--- a/scripts/cycling_extract_subset.js
+++ b/scripts/cycling_extract_subset.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const { once } = require('events');
+const { finished } = require('stream/promises');
+
+// Extracts a bbox subset of nodes.ndjson + edges.ndjson into a separate dir.
+// Used as a backup / verification dataset when full Kansai CH preprocessing
+// is too slow.
+//
+// Usage:
+//   node scripts/cycling_extract_subset.js \
+//     --src data/cycling --dst data/cycling-osaka \
+//     --bbox 135.4,34.6,135.6,34.8
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const args = { src: null, dst: null, bbox: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--src') args.src = argv[++i] || null;
+    else if (a === '--dst') args.dst = argv[++i] || null;
+    else if (a === '--bbox') args.bbox = argv[++i] || null;
+    else if (a === '-h' || a === '--help') args.help = true;
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return args;
+}
+
+function parseBbox(str) {
+  if (!str) return null;
+  const parts = str.split(',');
+  if (parts.length !== 4) return null;
+  // Number('') は 0 になるため、空要素をそのまま渡すと `135.4,,135.6,34.8` の
+  // ようなタイポが「緯度 0 (赤道)」として通ってしまう。空白のみの要素も含めて
+  // 先に NaN へ倒して弾く。
+  const nums = parts.map((p) => (p.trim() === '' ? NaN : Number(p)));
+  if (!nums.every(Number.isFinite)) return null;
+  return { minLon: nums[0], minLat: nums[1], maxLon: nums[2], maxLat: nums[3] };
+}
+
+async function streamLines(filePath, onLine) {
+  const rl = readline.createInterface({
+    input: fs.createReadStream(filePath, { encoding: 'utf8' }),
+    crlfDelay: Infinity
+  });
+  for await (const line of rl) {
+    if (!line) continue;
+    onLine(line);
+  }
+}
+
+async function main() {
+  const args = parseArgs();
+  if (args.help || !args.src || !args.dst || !args.bbox) {
+    process.stdout.write(
+      'Usage: node scripts/cycling_extract_subset.js --src <dir> --dst <dir> --bbox minLon,minLat,maxLon,maxLat\n'
+    );
+    if (!args.help) process.exitCode = 1;
+    return;
+  }
+  const bbox = parseBbox(args.bbox);
+  if (!bbox) {
+    process.stderr.write('invalid bbox\n');
+    process.exitCode = 1;
+    return;
+  }
+
+  fs.mkdirSync(args.dst, { recursive: true });
+
+  const t0 = Date.now();
+  const keepIds = new Set();
+  const nodesOut = fs.createWriteStream(path.join(args.dst, 'nodes.ndjson'));
+
+  process.stderr.write('[pass 1/2] filtering nodes by bbox\n');
+  let nodesSeen = 0;
+  let nodesKept = 0;
+  let writes = 0;
+  await streamLines(path.join(args.src, 'nodes.ndjson'), (line) => {
+    nodesSeen += 1;
+    const n = JSON.parse(line);
+    if (
+      n.lon >= bbox.minLon && n.lon <= bbox.maxLon &&
+      n.lat >= bbox.minLat && n.lat <= bbox.maxLat
+    ) {
+      keepIds.add(n.id);
+      nodesOut.write(line + '\n');
+      nodesKept += 1;
+      writes += 1;
+    }
+  });
+  nodesOut.end();
+  await finished(nodesOut);
+  process.stderr.write(`  nodes ${nodesKept}/${nodesSeen} in ${Date.now() - t0}ms\n`);
+
+  const edgesOut = fs.createWriteStream(path.join(args.dst, 'edges.ndjson'));
+  let edgesSeen = 0;
+  let edgesKept = 0;
+  const t1 = Date.now();
+  process.stderr.write('[pass 2/2] filtering edges (both endpoints in bbox)\n');
+  await streamLines(path.join(args.src, 'edges.ndjson'), (line) => {
+    edgesSeen += 1;
+    const e = JSON.parse(line);
+    if (keepIds.has(e.from) && keepIds.has(e.to)) {
+      edgesOut.write(line + '\n');
+      edgesKept += 1;
+    }
+  });
+  edgesOut.end();
+  await finished(edgesOut);
+  process.stderr.write(`  edges ${edgesKept}/${edgesSeen} in ${Date.now() - t1}ms\n`);
+  process.stderr.write(`done in ${((Date.now() - t0) / 1000).toFixed(1)}s\n`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    process.stderr.write(`error: ${err && err.stack ? err.stack : err}\n`);
+    process.exit(1);
+  });
+}
+
+module.exports = { parseArgs, parseBbox };

--- a/scripts/cycling_extract_subset.js
+++ b/scripts/cycling_extract_subset.js
@@ -43,19 +43,44 @@ function parseBbox(str) {
 // onLine を await する。呼び出し側が書き込みの drain を待てるようにして、
 // 1GB 級の ndjson でも出力側のバッファが際限なく膨らまないようにする。
 async function streamLines(filePath, onLine) {
-  const rl = readline.createInterface({
-    input: fs.createReadStream(filePath, { encoding: 'utf8' }),
-    crlfDelay: Infinity
+  const input = fs.createReadStream(filePath, { encoding: 'utf8' });
+  const rl = readline.createInterface({ input, crlfDelay: Infinity });
+  // 入力ストリームのエラー (ENOENT / EACCES など) を明示的に拾って reject する。
+  // readline 経由の伝播に頼ると、失敗が握り潰されて「0 件抽出で成功」に
+  // 見えかねない。
+  const failed = new Promise((_resolve, reject) => {
+    input.once('error', reject);
   });
-  for await (const line of rl) {
-    if (!line) continue;
-    await onLine(line);
+  const consume = (async () => {
+    for await (const line of rl) {
+      if (!line) continue;
+      await onLine(line);
+    }
+  })();
+  try {
+    await Promise.race([consume, failed]);
+  } finally {
+    rl.close();
+    input.destroy();
   }
 }
 
 /** write() が false を返したら drain を待つ (バックプレッシャー)。 */
 async function writeLine(stream, line) {
   if (!stream.write(line + '\n')) await once(stream, 'drain');
+}
+
+/**
+ * 比較用にパスを正規化する。symlink を解決したいが、dst はまだ存在しない
+ * ことがあるので、その場合は絶対パスのまま返す。
+ */
+function canonicalPath(p) {
+  const abs = path.resolve(p);
+  try {
+    return fs.realpathSync(abs);
+  } catch {
+    return abs;
+  }
 }
 
 async function main() {
@@ -76,7 +101,9 @@ async function main() {
 
   // src と dst が同じだと、読みながら同じファイルを truncate して元データを
   // 壊す。1GB 級の抽出元を失うと再取得コストが大きいので、書き始める前に弾く。
-  if (path.resolve(args.src) === path.resolve(args.dst)) {
+  // path.resolve だけでは symlink 経由の別名 (data/cycling と data/alias が
+  // 同じ実体) をすり抜けるため、実在するパスは realpath まで解決して比べる。
+  if (canonicalPath(args.src) === canonicalPath(args.dst)) {
     process.stderr.write('--src and --dst must differ (would overwrite the source)\n');
     process.exitCode = 1;
     return;

--- a/tests/cycling_extract_subset.test.js
+++ b/tests/cycling_extract_subset.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseArgs, parseBbox } = require('../scripts/cycling_extract_subset');
+
+test('parseArgs: --src / --dst / --bbox を読み取る', () => {
+  const r = parseArgs(['--src', 'data/cycling', '--dst', 'data/cycling-osaka', '--bbox', '135.4,34.6,135.6,34.8']);
+  assert.equal(r.src, 'data/cycling');
+  assert.equal(r.dst, 'data/cycling-osaka');
+  assert.equal(r.bbox, '135.4,34.6,135.6,34.8');
+});
+
+test('parseArgs: 省略した引数は null のまま', () => {
+  const r = parseArgs(['--src', 'data/cycling']);
+  assert.equal(r.src, 'data/cycling');
+  assert.equal(r.dst, null);
+  assert.equal(r.bbox, null);
+});
+
+test('parseArgs: --help でフラグ立つ', () => {
+  assert.equal(parseArgs(['--help']).help, true);
+  assert.equal(parseArgs(['-h']).help, true);
+});
+
+test('parseArgs: 未知引数は例外', () => {
+  assert.throws(() => parseArgs(['--unknown']), /Unknown argument/);
+});
+
+test('parseArgs: 値が欠けたオプションは null になり後続の必須チェックに落ちる', () => {
+  const r = parseArgs(['--src']);
+  assert.equal(r.src, null);
+});
+
+test('parseBbox: 4 要素を minLon/minLat/maxLon/maxLat に割り当てる', () => {
+  const b = parseBbox('135.4,34.6,135.6,34.8');
+  assert.deepEqual(b, { minLon: 135.4, minLat: 34.6, maxLon: 135.6, maxLat: 34.8 });
+});
+
+test('parseBbox: 負値を含む bbox も扱える', () => {
+  const b = parseBbox('-10.5,-20.25,10.5,20.25');
+  assert.deepEqual(b, { minLon: -10.5, minLat: -20.25, maxLon: 10.5, maxLat: 20.25 });
+});
+
+test('parseBbox: 未指定は null', () => {
+  assert.equal(parseBbox(null), null);
+  assert.equal(parseBbox(''), null);
+});
+
+test('parseBbox: 要素数が 4 でなければ null', () => {
+  assert.equal(parseBbox('135.4,34.6,135.6'), null);
+  assert.equal(parseBbox('135.4,34.6,135.6,34.8,1'), null);
+});
+
+test('parseBbox: 数値でない要素があれば null', () => {
+  assert.equal(parseBbox('135.4,abc,135.6,34.8'), null);
+  assert.equal(parseBbox('135.4,,135.6,34.8'), null);
+});
+
+test('parseBbox: NaN / Infinity は弾く', () => {
+  assert.equal(parseBbox('NaN,34.6,135.6,34.8'), null);
+  assert.equal(parseBbox('135.4,34.6,Infinity,34.8'), null);
+});

--- a/tests/cycling_extract_subset.test.js
+++ b/tests/cycling_extract_subset.test.js
@@ -157,3 +157,26 @@ test('抽出: bbox が不正なら異常終了する', (t) => {
 
   assert.throws(() => runExtract(src, dst, '135.4,,135.6,34.8'));
 });
+
+test('抽出: symlink 経由で src と dst が同じ実体でも中断する', (t) => {
+  const nodes = [{ id: 1, lon: 135.5, lat: 34.7 }];
+  const { dir, src } = makeFixture(nodes, [{ from: 1, to: 1, cost_m: 1 }]);
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  // path.resolve だけでは別パスに見えるが、実体は src と同じ
+  const alias = path.join(dir, 'alias');
+  fs.symlinkSync(src, alias);
+
+  const before = fs.readFileSync(path.join(src, 'nodes.ndjson'), 'utf8');
+  assert.throws(() => runExtract(src, alias, '135.4,34.6,135.6,34.8'));
+  assert.equal(fs.readFileSync(path.join(src, 'nodes.ndjson'), 'utf8'), before);
+});
+
+test('抽出: 入力 ndjson が無ければ異常終了する (無言で 0 件成功にしない)', (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'extract-subset-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const src = path.join(dir, 'src');
+  fs.mkdirSync(src, { recursive: true });
+
+  assert.throws(() => runExtract(src, path.join(dir, 'dst'), '135.4,34.6,135.6,34.8'));
+});

--- a/tests/cycling_extract_subset.test.js
+++ b/tests/cycling_extract_subset.test.js
@@ -180,3 +180,20 @@ test('抽出: 入力 ndjson が無ければ異常終了する (無言で 0 件�
 
   assert.throws(() => runExtract(src, path.join(dir, 'dst'), '135.4,34.6,135.6,34.8'));
 });
+
+test('抽出: 出力先に書けない場合も異常終了する', (t) => {
+  const nodes = [{ id: 1, lon: 135.5, lat: 34.7 }];
+  const { dir, src, dst } = makeFixture(nodes, []);
+  t.after(() => {
+    fs.chmodSync(dst, 0o755);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  // 出力ディレクトリを読み取り専用にして createWriteStream を失敗させる。
+  // 'error' に購読者がいないと Node がプロセスごと落とすため、main().catch まで
+  // 届くことをここで担保する。
+  fs.mkdirSync(dst, { recursive: true });
+  fs.chmodSync(dst, 0o500);
+
+  assert.throws(() => runExtract(src, dst, '135.4,34.6,135.6,34.8'));
+});

--- a/tests/cycling_extract_subset.test.js
+++ b/tests/cycling_extract_subset.test.js
@@ -2,8 +2,42 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 
 const { parseArgs, parseBbox } = require('../scripts/cycling_extract_subset');
+
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'cycling_extract_subset.js');
+
+/** src/dst を持つ一時ディレクトリを作り、nodes/edges.ndjson を書き込む。 */
+function makeFixture(nodes, edges) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'extract-subset-'));
+  const src = path.join(dir, 'src');
+  fs.mkdirSync(src, { recursive: true });
+  fs.writeFileSync(
+    path.join(src, 'nodes.ndjson'),
+    nodes.map((n) => JSON.stringify(n)).join('\n') + '\n'
+  );
+  fs.writeFileSync(
+    path.join(src, 'edges.ndjson'),
+    edges.map((e) => JSON.stringify(e)).join('\n') + '\n'
+  );
+  return { dir, src, dst: path.join(dir, 'dst') };
+}
+
+function readNdjson(file) {
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+function runExtract(src, dst, bbox) {
+  return execFileSync(process.execPath, [SCRIPT, '--src', src, '--dst', dst, '--bbox', bbox], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+}
 
 test('parseArgs: --src / --dst / --bbox を読み取る', () => {
   const r = parseArgs(['--src', 'data/cycling', '--dst', 'data/cycling-osaka', '--bbox', '135.4,34.6,135.6,34.8']);
@@ -61,4 +95,65 @@ test('parseBbox: 数値でない要素があれば null', () => {
 test('parseBbox: NaN / Infinity は弾く', () => {
   assert.equal(parseBbox('NaN,34.6,135.6,34.8'), null);
   assert.equal(parseBbox('135.4,34.6,Infinity,34.8'), null);
+});
+
+// --- 抽出フロー (fixture) -------------------------------------------------
+
+test('抽出: bbox 境界上のノードは含み、外のノードは落とす', (t) => {
+  // bbox = 135.4,34.6,135.6,34.8
+  const nodes = [
+    { id: 1, lon: 135.4, lat: 34.6 },   // 南西の角 (境界上 → 含む)
+    { id: 2, lon: 135.6, lat: 34.8 },   // 北東の角 (境界上 → 含む)
+    { id: 3, lon: 135.5, lat: 34.7 },   // 内側
+    { id: 4, lon: 135.39, lat: 34.7 },  // 西に外れる
+    { id: 5, lon: 135.5, lat: 34.81 }   // 北に外れる
+  ];
+  const { dir, src, dst } = makeFixture(nodes, []);
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  runExtract(src, dst, '135.4,34.6,135.6,34.8');
+
+  const kept = readNdjson(path.join(dst, 'nodes.ndjson')).map((n) => n.id).sort();
+  assert.deepEqual(kept, [1, 2, 3]);
+});
+
+test('抽出: 両端が残ったエッジだけを出力する', (t) => {
+  const nodes = [
+    { id: 1, lon: 135.4, lat: 34.6 },   // 境界上
+    { id: 2, lon: 135.5, lat: 34.7 },   // 内側
+    { id: 3, lon: 135.6, lat: 34.8 },   // 境界上
+    { id: 9, lon: 135.9, lat: 34.9 }    // 範囲外
+  ];
+  const edges = [
+    { from: 1, to: 2, cost_m: 10 },     // 両端とも残る → 出力
+    { from: 2, to: 3, cost_m: 20 },     // 両端とも残る (境界端どうしを含む) → 出力
+    { from: 1, to: 3, cost_m: 30 },     // 境界上どうし → 出力
+    { from: 2, to: 9, cost_m: 40 },     // 片端が範囲外 → 落とす
+    { from: 9, to: 1, cost_m: 50 }      // 片端が範囲外 (向き違い) → 落とす
+  ];
+  const { dir, src, dst } = makeFixture(nodes, edges);
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  runExtract(src, dst, '135.4,34.6,135.6,34.8');
+
+  const kept = readNdjson(path.join(dst, 'edges.ndjson')).map((e) => `${e.from}-${e.to}`).sort();
+  assert.deepEqual(kept, ['1-2', '1-3', '2-3']);
+});
+
+test('抽出: src と dst が同じなら書き込む前に中断する', (t) => {
+  const nodes = [{ id: 1, lon: 135.5, lat: 34.7 }];
+  const { dir, src } = makeFixture(nodes, [{ from: 1, to: 1, cost_m: 1 }]);
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const before = fs.readFileSync(path.join(src, 'nodes.ndjson'), 'utf8');
+  assert.throws(() => runExtract(src, src, '135.4,34.6,135.6,34.8'));
+  // 元ファイルが truncate されていないこと
+  assert.equal(fs.readFileSync(path.join(src, 'nodes.ndjson'), 'utf8'), before);
+});
+
+test('抽出: bbox が不正なら異常終了する', (t) => {
+  const { dir, src, dst } = makeFixture([{ id: 1, lon: 135.5, lat: 34.7 }], []);
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  assert.throws(() => runExtract(src, dst, '135.4,,135.6,34.8'));
 });


### PR DESCRIPTION
未追跡のまま残っていた 2 つを仕分けた。

| 対象 | 判断 | 理由 |
|---|---|---|
| `scripts/cycling_extract_subset.js` | **追跡する** | `nodes/edges.ndjson` を bbox で切り出す実用ツール。`data/cycling-osaka` はこれで生成されている |
| `.dryrun/` | **ignore する** | `wrangler --dry-run` のビルド出力。生成物であり、内容も古い |

## cycling_extract_subset.js を追跡する理由

関西全体（`data/cycling`、1.1GB）の CH 前計算が重いときに、検証用の部分データセットを作るためのスクリプト。

```bash
node scripts/cycling_extract_subset.js \
  --src data/cycling --dst data/cycling-osaka \
  --bbox 135.4,34.6,135.6,34.8
```

#95 で手動2点モードの経路品質を測ったときに使った `data/cycling-osaka` はこれで作られたもので、#96（`COST_FACTOR` の改善）で郊外データを検証する際にも必要になる。手元にしかないと再現できないため追跡対象にする。

## parseBbox のバグ修正

追跡にあたりテストを書いたところ、1 件バグが見つかった。

```js
parseBbox('135.4,,135.6,34.8')
// 修正前: { minLon: 135.4, minLat: 0, maxLon: 135.6, maxLat: 34.8 }
// 修正後: null
```

`Number('')` が `0` を返し `Number.isFinite(0)` が true になるため、**要素が欠けた指定が「緯度 0（赤道）」として通っていた**。`--bbox` のタイポで意図しない範囲を抽出してしまう。空要素と空白のみの要素を先に `NaN` へ倒して弾くようにした。

## テスト

`tests/cycling_extract_subset.test.js` を新設（11 件）。作業ルールに従い、正常系と異常系（値欠落・要素数不足・非数値・`NaN`/`Infinity`）の両方を担保している。

- `npm test` — **326 passed / 0 failed**（新規 11 件を含む）

## .dryrun/ を ignore する理由

`.dryrun/README.md` に「built output assets for the worker "ride-oasis" generated at 2026-05-25」と明記されている生成物。内容も古く、**#97 で削除した `rust_router_bg.wasm` を含んだまま**だった。

## 残った既知の挙動（この PR では変更していない）

`parseBbox` は min/max の大小関係を検証しない。`--bbox 135.6,34.8,135.4,34.6` のように逆順で指定すると、エラーにならず抽出結果が 0 件になる。実行時のログ（`nodes 0/N`）で気づけるため今回は触っていない。