### PR TITLE
fix(cycling): COST_FACTOR の residential/living_street を 1.15 へ

### DIFF
--- a/lib/cycling/tag_classifier.js
+++ b/lib/cycling/tag_classifier.js
@@ -34,10 +34,18 @@ const DEFAULT_ALLOWED_HIGHWAY = new Set([
   'road'
 ]);
 
+// graph_builder は `cost_m = length_m * costFactor` しか計算しないため、係数は
+// そのまま「この道を通るためにどれだけ遠回りしてよいか」を意味する。1.0 未満は
+// 「最短距離より優先して選ぶ」、1.0 超は「避けるが代替が無ければ通る」。
+//
+// residential / living_street は 0.9 だった (= 生活道路のためなら 10% 遠回り
+// してでも入る)。都市部5ルートの実測で生活道路の通過割合が 16.1% に達し、
+// 「田んぼ道や生活道路をぐねぐね入る」体感の主因になっていた。1.15 にすると
+// 2.4% まで下がり、総距離・曲がり回数は変わらない (#96)。
 const COST_FACTOR = {
   cycleway: 0.7,
-  residential: 0.9,
-  living_street: 0.9,
+  residential: 1.15,
+  living_street: 1.15,
   unclassified: 1.0,
   tertiary: 1.0,
   tertiary_link: 1.0,

--- a/tests/cycling_astar.test.js
+++ b/tests/cycling_astar.test.js
@@ -140,6 +140,21 @@ test('MIN_COST_FACTOR は 0.7 (cycleway 相当, admissibility 保証)', () => {
   assert.equal(MIN_COST_FACTOR, 0.7);
 });
 
+test('MIN_COST_FACTOR は COST_FACTOR の最小値以下 (A* の admissibility)', () => {
+  // heuristic は haversine * MIN_COST_FACTOR。これより安い道が 1 種類でも
+  // あると heuristic が実コストを上回りうる = admissible でなくなり、A* が
+  // 最短でない経路を「最短」として返す。値の同期をリテラルで固定するのでは
+  // なく、実際の COST_FACTOR から検証する。
+  const { COST_FACTOR } = require('../lib/cycling/tag_classifier');
+  const factors = Object.values(COST_FACTOR);
+  assert.ok(factors.length > 0);
+  const min = Math.min(...factors);
+  assert.ok(
+    MIN_COST_FACTOR <= min,
+    `MIN_COST_FACTOR (${MIN_COST_FACTOR}) が COST_FACTOR の最小値 (${min}) を上回っている`
+  );
+});
+
 test('aStarOnView: 旧形式 view (nodeIdToIndex/indexToNodeId 無し) でも動く', () => {
   // 外部から手作りされた view (TileLoader を介さない) は sidecar を持たない
   // ことがある。後方互換のため即時クラッシュではなくフォールバックで index

--- a/tests/cycling_astar.test.js
+++ b/tests/cycling_astar.test.js
@@ -141,10 +141,15 @@ test('MIN_COST_FACTOR は 0.7 (cycleway 相当, admissibility 保証)', () => {
 });
 
 test('MIN_COST_FACTOR は COST_FACTOR の最小値以下 (A* の admissibility)', () => {
-  // heuristic は haversine * MIN_COST_FACTOR。これより安い道が 1 種類でも
-  // あると heuristic が実コストを上回りうる = admissible でなくなり、A* が
-  // 最短でない経路を「最短」として返す。値の同期をリテラルで固定するのでは
-  // なく、実際の COST_FACTOR から検証する。
+  // heuristic は「直線距離 * MIN_COST_FACTOR」。直線距離は equirectangular
+  // 近似 (Math.hypot(dxm, dym)) で、aStarOnView / bidiDijkstraOnView とも同じ
+  // 式を使う (bidi 側のローカル関数は haversineTo という名前だが中身は同じ
+  // 平面近似)。
+  //
+  // MIN_COST_FACTOR より安い係数が 1 種類でもあると heuristic が実コストを
+  // 上回りうる = admissible でなくなり、A* が最短でない経路を「最短」として
+  // 返す。値の同期をリテラルで固定するのではなく、実際の COST_FACTOR から
+  // 検証する。
   const { COST_FACTOR } = require('../lib/cycling/tag_classifier');
   const factors = Object.values(COST_FACTOR);
   assert.ok(factors.length > 0);

--- a/tests/cycling_graph_builder.test.js
+++ b/tests/cycling_graph_builder.test.js
@@ -8,6 +8,7 @@ const {
   buildEdges,
   collectReferencedNodeIds
 } = require('../lib/cycling/graph_builder');
+const { COST_FACTOR } = require('../lib/cycling/tag_classifier');
 
 function nodeMap(entries) {
   return new Map(entries);
@@ -32,7 +33,10 @@ test('単一way: residentialの3ノード列から2エッジ生成', () => {
   );
   for (const e of edges) {
     assert.ok(e.length_m > 0);
-    assert.equal(e.cost_m, e.length_m * 0.9);
+    // 係数そのものは tag_classifier の責務。ここで見たいのは
+    // cost_m = length_m * COST_FACTOR[kind] という関係が成り立つことなので、
+    // 数値をリテラルで固定せず COST_FACTOR を参照する。
+    assert.equal(e.cost_m, e.length_m * COST_FACTOR.residential);
     assert.equal(e.kind, 'residential');
     assert.equal(e.oneway, false);
     assert.equal(e.way_id, 1);

--- a/tests/cycling_tag_classifier.test.js
+++ b/tests/cycling_tag_classifier.test.js
@@ -3,7 +3,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { classifyWay, isOneway } = require('../lib/cycling/tag_classifier');
+const { classifyWay, isOneway, COST_FACTOR } = require('../lib/cycling/tag_classifier');
 
 test('高速道路は自転車不可', () => {
   const r = classifyWay({ highway: 'motorway' });
@@ -18,16 +18,37 @@ test('国道(primary)は通行可で重みは長め', () => {
   assert.ok(r.costFactor > 1.0);
 });
 
-test('住宅街(residential)は通行可で重みは軽め', () => {
+test('住宅街(residential)は通行可だが最短距離より不利', () => {
+  // 1.0 未満だと「生活道路のためなら遠回りしてでも入る」という意味になり、
+  // 経路が住宅地の細道を積極的に選ぶ (#96)。
   const r = classifyWay({ highway: 'residential' });
   assert.equal(r.allowed, true);
-  assert.ok(r.costFactor <= 1.0);
+  assert.ok(r.costFactor > 1.0, `residential は 1.0 超であるべき: ${r.costFactor}`);
+});
+
+test('住宅街(residential)は幹線道路よりは軽い', () => {
+  // 避けたいが、幹線道路に追い出すほどではない。この順序が崩れると
+  // 「幹線道路を除く」意図と衝突する。
+  const residential = classifyWay({ highway: 'residential' });
+  const secondary = classifyWay({ highway: 'secondary' });
+  const primary = classifyWay({ highway: 'primary' });
+  assert.ok(residential.costFactor < secondary.costFactor);
+  assert.ok(secondary.costFactor < primary.costFactor);
+});
+
+test('living_street は residential と同じ重み', () => {
+  const living = classifyWay({ highway: 'living_street' });
+  const residential = classifyWay({ highway: 'residential' });
+  assert.equal(living.costFactor, residential.costFactor);
 });
 
 test('cycleway は最も軽い重み', () => {
   const r = classifyWay({ highway: 'cycleway' });
   assert.equal(r.allowed, true);
-  assert.ok(r.costFactor < 0.9);
+  const others = Object.entries(COST_FACTOR).filter(([kind]) => kind !== 'cycleway');
+  for (const [kind, factor] of others) {
+    assert.ok(r.costFactor < factor, `cycleway は ${kind} (${factor}) より軽いはず`);
+  }
 });
 
 test('footway は bicycle=yes でのみ通行可', () => {


### PR DESCRIPTION
Refs #96（タイル再生成は未実施のため close しない）

## 変更

`lib/cycling/tag_classifier.js` の `residential` / `living_street` を `0.9` → `1.15`。

`graph_builder.js` は `cost_m = length_m * costFactor` しか計算しないため、係数はそのまま「この道を通るためにどれだけ遠回りしてよいか」を意味する。`0.9` は「生活道路のためなら 10% 遠回りしてでも入る」という指示になっていた。

都市部5ルートの実測（Issue #96）では、生活道路の通過割合 16.1% → 2.4%、**総距離・曲がり回数は変化なし**。

## テスト側の見直し

期待値の更新だけでなく、壊れやすかった箇所を直した。

- `residential` の期待値を「1.0 未満」から「**1.0 超だが `secondary` より軽い**」へ。単なる数値追従ではなく、避けたいが幹線道路に追い出すほどではない、という順序関係を表明する
- `living_street` が `residential` と同値であることを明示
- `cycleway` は `0.9` 未満というリテラル比較をやめ、`COST_FACTOR` 全体と比較して最小であることを検証
- `graph_builder` のコスト計算テストは `0.9` リテラルをやめ `COST_FACTOR.residential` を参照。係数そのものは `tag_classifier` の責務で、ここで見たいのは `cost_m = length_m * COST_FACTOR[kind]` という関係

### A* の admissibility を実際に検証するテストを追加

既存のテストは `MIN_COST_FACTOR === 0.7` というリテラル一致しか見ていなかった。heuristic は `haversine * MIN_COST_FACTOR` なので、**これより安い係数が 1 種類でも増えると heuristic が実コストを上回りうる = admissible でなくなり、A* が最短でない経路を「最短」として返す**。

`MIN_COST_FACTOR <= min(COST_FACTOR)` を実際の `COST_FACTOR` から検証するテストを追加した。`cycleway` を `0.65` に下げる変異を入れて、このテストだけが落ちることを確認済み。

## 検証

`npm test` — 336 passed / 0 failed。

## 残作業（このPRには含まない）

Issue #96 の手順3、CH タイルの再生成と R2 再アップロード。CH は前計算なので、係数変更だけではルーティング結果に反映されない。

再生成には ochanuco/cycling-router#12 の CH 修正（shortcut の重複登録）も同時に取り込むべきなので、cycling-router のリリース → `scripts/fetch_wasm.mjs` の `VERSION` / `SHA256` 更新 → 一度だけ再生成、という順序になる。