### PR TITLE
chore(wasm): cycling-router v0.4.0 を取得する

### DIFF
--- a/scripts/fetch_wasm.mjs
+++ b/scripts/fetch_wasm.mjs
@@ -19,14 +19,14 @@ import path from 'node:path';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 
-const VERSION = 'v0.3.0';
+const VERSION = 'v0.4.0';
 const REPO = 'ochanuco/cycling-router';
 const ASSET = `cycling-router-wasm-${VERSION}.tar.gz`;
 const URL = `https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}`;
 // 取得したアーカイブの検証用ダイジェスト。展開前に照合し、不一致なら中断する。
 // Release の差し替えや取得経路の改竄があれば、tar を展開して JS wrapper と
 // WASM を配置する前に気づける。
-const SHA256 = '2b0db3bd74da360359b9c9083b56ff89cd5f1b6ba951c31e0b3fc54464feba09';
+const SHA256 = 'c7edce8506318790a19cf76196ac3ce5e976db4f5c7e2dca6b7060266217044a';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const VENDOR = path.join(ROOT, 'vendor', 'wasm');


### PR DESCRIPTION
Refs #96

`scripts/fetch_wasm.mjs` の `VERSION` と `SHA256` を v0.4.0 に更新する。

## v0.4.0 の内容

[ochanuco/cycling-router v0.4.0](https://github.com/ochanuco/cycling-router/releases/tag/v0.4.0)

- **CH 前計算の shortcut 重複登録を修正**（cycling-router#12）。`targets` に同じノードが 2 回積まれると witness 結果が `INFINITY` のまま残り、witness が存在しても shortcut が入っていた
- `route_ch` の TypeScript 型を提供（cycling-router#11）
- fmt / clippy の解消、wasm32 を含む CI ゲートの追加（cycling-router#10）
- simd128 実装のスカラー実装との差分テスト（cycling-router#12）

## 検証

ローカルで `npm run wasm:fetch` を実行し、配置と動作を確認した。

```
fetching https://github.com/ochanuco/cycling-router/releases/download/v0.4.0/cycling-router-wasm-v0.4.0.tar.gz
wasm v0.4.0 placed in vendor/wasm/ and frontend/wasm/
```

- `REQUIRED` の 7 ファイルがすべて配置される（アーカイブの中身も確認済み）
- nodejs ターゲットで動作確認: `route_distances=111.2m` / `astar=200,0,1,2`、`astar` / `route_ch` / `route_distances` がすべて `function`
- `npm test` — 336 passed / 0 failed

### チェックサム検証が効くことの確認

`SHA256` をゼロ埋めに変えて実行したところ、**tar 展開前に中断し exit 1** になり、`vendor/wasm` は作られなかった。

```
fetch_wasm failed: checksum mismatch for cycling-router-wasm-v0.4.0.tar.gz
  expected: 0000...0000
  actual:   c7edce85...
```

## 注意

> [!IMPORTANT]
> cycling-router#12 の CH 修正により、**同じ入力から生成される CH タイルの内容が変わる**。R2 上の既存タイルは v0.3.0 の CH 前計算で作られたものなので、#96 の `COST_FACTOR` 変更とあわせてタイル再生成と R2 再アップロードが必要。この PR 単体ではルーティング結果は変わらない（クエリ側の WASM が新しくなるだけで、タイルは従来のまま）。