### PR TITLE
fix(scripts): cycling_extract_subset のファイル単位の衝突を検査する

### DIFF
--- a/scripts/cycling_extract_subset.js
+++ b/scripts/cycling_extract_subset.js
@@ -176,7 +176,10 @@ async function filterInto(srcFile, dstFile, keepLine) {
     // dstFile として見えてしまう。
     fs.renameSync(tmpFile, dstFile);
   } catch (err) {
-    out.destroy();
+    // destroy() は非同期で、fd が閉じるのは 'close' の時点。開いたままの
+    // ファイルを unlink できない環境ではここで削除に失敗し、エラーを握り
+    // 潰しているため一時ファイルが残る。close を待ってから片付ける。
+    await closeStream(out);
     try {
       fs.unlinkSync(tmpFile);
     } catch {
@@ -185,6 +188,18 @@ async function filterInto(srcFile, dstFile, keepLine) {
     throw err;
   }
   return { seen, kept };
+}
+
+/** ストリームを破棄し、fd が閉じる ('close') まで待つ。 */
+async function closeStream(stream) {
+  if (stream.closed) return;
+  stream.destroy();
+  if (stream.closed) return;
+  try {
+    await once(stream, 'close');
+  } catch {
+    // destroy() が 'error' を再送した場合。呼び出し元の元エラーを優先する。
+  }
 }
 
 async function main() {

--- a/scripts/cycling_extract_subset.js
+++ b/scripts/cycling_extract_subset.js
@@ -125,17 +125,33 @@ function findFileAliasing(srcFiles, dstFiles) {
   return null;
 }
 
+let tmpSeq = 0;
+
 /**
  * srcFile を 1 行ずつ読み、keepLine が true を返した行だけ dstFile に書く。
  * 返り値は { seen, kept }。
  *
+ * 書き込みは dstFile と同じディレクトリの一時ファイルに対して行い、書き終えて
+ * から rename で dstFile を置き換える。dstFile を直接開かない理由は 2 つ。
+ *
+ *   - findFileAliasing の検査から createWriteStream までの間に出力パスが入力
+ *     ファイルへの symlink / ハードリンクへ差し替わると、既定の 'w' フラグが
+ *     入力を truncate する。rename が置き換えるのは symlink エントリ自体で、
+ *     リンク先の実体には触れない。
+ *   - 途中で失敗しても、既存の出力が中途半端に truncate された状態で残らない。
+ *
+ * 一時ファイルは 'wx' (O_CREAT|O_EXCL) で開く。既存パスがあれば失敗するので、
+ * 一時パスを先回りして symlink にされていても追従しない。
+ *
  * 出力ストリームの error は生成直後に購読する。write() は成功しても後から
  * ENOSPC 等で落ちることがあり、'error' に購読者がいないと Node が例外を
  * 投げてプロセスごと死ぬ (main().catch に届かない)。失敗時は入力・出力とも
- * 破棄してから呼び出し元へ投げ直す。
+ * 破棄し、一時ファイルを片付けてから呼び出し元へ投げ直す。
  */
 async function filterInto(srcFile, dstFile, keepLine) {
-  const out = fs.createWriteStream(dstFile);
+  tmpSeq += 1;
+  const tmpFile = `${dstFile}.tmp-${process.pid}-${tmpSeq}`;
+  const out = fs.createWriteStream(tmpFile, { flags: 'wx' });
   const outFailed = new Promise((_resolve, reject) => {
     out.once('error', reject);
   });
@@ -156,8 +172,16 @@ async function filterInto(srcFile, dstFile, keepLine) {
       })(),
       outFailed
     ]);
+    // finished(out) の後。ここより前に rename すると、書き込み途中の内容が
+    // dstFile として見えてしまう。
+    fs.renameSync(tmpFile, dstFile);
   } catch (err) {
     out.destroy();
+    try {
+      fs.unlinkSync(tmpFile);
+    } catch {
+      // 一時ファイルを作れずに失敗した場合はここに来る。元の err を優先する。
+    }
     throw err;
   }
   return { seen, kept };

--- a/scripts/cycling_extract_subset.js
+++ b/scripts/cycling_extract_subset.js
@@ -83,6 +83,48 @@ function canonicalPath(p) {
   }
 }
 
+/** ファイルの実体を一意に識別するキー。存在しなければ null。 */
+function fileIdentity(p) {
+  try {
+    // statSync は symlink を追うので、symlink とハードリンクの両方で
+    // 参照先の dev/ino が得られる。
+    const st = fs.statSync(p);
+    return `${st.dev}:${st.ino}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 出力候補が入力候補と同じ実体を指していれば [dstFile, srcFile] を返す。
+ * 無ければ null。
+ *
+ * ディレクトリ単位の realpath 比較 (canonicalPath) では次がすり抜ける。
+ *
+ *   - dst/nodes.ndjson が src/edges.ndjson へのハードリンク
+ *     (ハードリンクは realpath では解決されない)
+ *   - dst/nodes.ndjson が src/edges.ndjson への symlink
+ *     (ディレクトリは別だがファイルの実体は同じ)
+ *
+ * どちらも「読みながら同じ実体を truncate する」経路なので、dev/ino で
+ * 突き合わせて弾く。nodes と edges は別パスで書くため、pass 1 の前に
+ * 全組み合わせをまとめて見る (pass 1 が通っても pass 2 で壊れうる)。
+ */
+function findFileAliasing(srcFiles, dstFiles) {
+  const bySrcIdentity = new Map();
+  for (const f of srcFiles) {
+    const id = fileIdentity(f);
+    if (id) bySrcIdentity.set(id, f);
+  }
+  for (const f of dstFiles) {
+    const id = fileIdentity(f);
+    if (!id) continue;
+    const hit = bySrcIdentity.get(id);
+    if (hit) return [f, hit];
+  }
+  return null;
+}
+
 /**
  * srcFile を 1 行ずつ読み、keepLine が true を返した行だけ dstFile に書く。
  * 返り値は { seen, kept }。
@@ -149,13 +191,28 @@ async function main() {
 
   fs.mkdirSync(args.dst, { recursive: true });
 
+  const srcNodes = path.join(args.src, 'nodes.ndjson');
+  const srcEdges = path.join(args.src, 'edges.ndjson');
+  const dstNodes = path.join(args.dst, 'nodes.ndjson');
+  const dstEdges = path.join(args.dst, 'edges.ndjson');
+
+  // ディレクトリが別でも、ファイル単位で同じ実体を指していれば元データを壊す。
+  const alias = findFileAliasing([srcNodes, srcEdges], [dstNodes, dstEdges]);
+  if (alias) {
+    process.stderr.write(
+      `output ${alias[0]} is the same file as input ${alias[1]} (would overwrite the source)\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
   const t0 = Date.now();
   const keepIds = new Set();
 
   process.stderr.write('[pass 1/2] filtering nodes by bbox\n');
   const nodes = await filterInto(
-    path.join(args.src, 'nodes.ndjson'),
-    path.join(args.dst, 'nodes.ndjson'),
+    srcNodes,
+    dstNodes,
     (line) => {
       const n = JSON.parse(line);
       const inside =
@@ -170,8 +227,8 @@ async function main() {
   const t1 = Date.now();
   process.stderr.write('[pass 2/2] filtering edges (both endpoints in bbox)\n');
   const edges = await filterInto(
-    path.join(args.src, 'edges.ndjson'),
-    path.join(args.dst, 'edges.ndjson'),
+    srcEdges,
+    dstEdges,
     (line) => {
       const e = JSON.parse(line);
       return keepIds.has(e.from) && keepIds.has(e.to);
@@ -188,4 +245,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { parseArgs, parseBbox };
+module.exports = { parseArgs, parseBbox, findFileAliasing };

--- a/tests/cycling_extract_subset.test.js
+++ b/tests/cycling_extract_subset.test.js
@@ -39,6 +39,19 @@ function runExtract(src, dst, bbox) {
   });
 }
 
+/**
+ * fn が投げた例外を返す。assert.throws は捕捉した Error を返さないため、
+ * 失敗理由 (stderr) まで検証したいときはこちらを使う。
+ */
+function catchRun(fn) {
+  try {
+    fn();
+  } catch (err) {
+    return err;
+  }
+  assert.fail('expected the command to fail, but it succeeded');
+}
+
 test('parseArgs: --src / --dst / --bbox を読み取る', () => {
   const r = parseArgs(['--src', 'data/cycling', '--dst', 'data/cycling-osaka', '--bbox', '135.4,34.6,135.6,34.8']);
   assert.equal(r.src, 'data/cycling');
@@ -186,7 +199,7 @@ test('抽出: 出力先に書けない場合も異常終了する', (t) => {
   const { dir, src, dst } = makeFixture(nodes, []);
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
 
-  // 出力パスをディレクトリとして先に作り、createWriteStream を EISDIR で
+  // 出力パスをディレクトリとして先に作り、一時ファイルからの rename を EISDIR で
   // 失敗させる。'error' に購読者がいないと Node がプロセスごと落とすため、
   // main().catch まで届くことをここで担保する。
   //
@@ -194,7 +207,39 @@ test('抽出: 出力先に書けない場合も異常終了する', (t) => {
   // パス衝突なら実行ユーザに依存しない。
   fs.mkdirSync(path.join(dst, 'nodes.ndjson'), { recursive: true });
 
+  // assert.throws だけだと「何かで落ちた」しか言えず、bbox 不正など別の理由で
+  // 落ちても通ってしまう。想定した失敗であることを stderr で固定する。
+  const err = catchRun(() => runExtract(src, dst, '135.4,34.6,135.6,34.8'));
+  assert.match(err.stderr, /\bEISDIR\b/);
+});
+
+test('抽出: 途中で失敗しても既存の出力を壊さず一時ファイルも残さない', (t) => {
+  const { dir, src, dst } = makeFixture([{ id: 1, lon: 135.5, lat: 34.7 }], []);
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  // pass 1 の途中で JSON.parse を失敗させる
+  fs.appendFileSync(path.join(src, 'nodes.ndjson'), 'not json\n');
+
+  // 前回の抽出結果に見立てた既存の出力
+  fs.mkdirSync(dst, { recursive: true });
+  const previous = '{"id":999,"lon":135.5,"lat":34.7}\n';
+  fs.writeFileSync(path.join(dst, 'nodes.ndjson'), previous);
+
   assert.throws(() => runExtract(src, dst, '135.4,34.6,135.6,34.8'));
+
+  // 一時ファイルに書いてから rename するので、既存の出力は無傷のまま
+  assert.equal(fs.readFileSync(path.join(dst, 'nodes.ndjson'), 'utf8'), previous);
+  assert.deepEqual(fs.readdirSync(dst).filter((f) => f.includes('.tmp-')), []);
+});
+
+test('抽出: 成功時に一時ファイルを残さない', (t) => {
+  const nodes = [{ id: 1, lon: 135.5, lat: 34.7 }];
+  const { dir, src, dst } = makeFixture(nodes, [{ from: 1, to: 1, cost_m: 1 }]);
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  runExtract(src, dst, '135.4,34.6,135.6,34.8');
+
+  assert.deepEqual(fs.readdirSync(dst).sort(), ['edges.ndjson', 'nodes.ndjson']);
 });
 
 test('抽出: dst のファイルが src のファイルへのハードリンクなら中断する', (t) => {

--- a/tests/cycling_extract_subset.test.js
+++ b/tests/cycling_extract_subset.test.js
@@ -7,7 +7,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 
-const { parseArgs, parseBbox } = require('../scripts/cycling_extract_subset');
+const { parseArgs, parseBbox, findFileAliasing } = require('../scripts/cycling_extract_subset');
 
 const SCRIPT = path.join(__dirname, '..', 'scripts', 'cycling_extract_subset.js');
 
@@ -184,16 +184,75 @@ test('抽出: 入力 ndjson が無ければ異常終了する (無言で 0 件�
 test('抽出: 出力先に書けない場合も異常終了する', (t) => {
   const nodes = [{ id: 1, lon: 135.5, lat: 34.7 }];
   const { dir, src, dst } = makeFixture(nodes, []);
-  t.after(() => {
-    fs.chmodSync(dst, 0o755);
-    fs.rmSync(dir, { recursive: true, force: true });
-  });
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
 
-  // 出力ディレクトリを読み取り専用にして createWriteStream を失敗させる。
-  // 'error' に購読者がいないと Node がプロセスごと落とすため、main().catch まで
-  // 届くことをここで担保する。
-  fs.mkdirSync(dst, { recursive: true });
-  fs.chmodSync(dst, 0o500);
+  // 出力パスをディレクトリとして先に作り、createWriteStream を EISDIR で
+  // 失敗させる。'error' に購読者がいないと Node がプロセスごと落とすため、
+  // main().catch まで届くことをここで担保する。
+  //
+  // chmod で書き込み不可にする方法は root だと権限が無視されて偽陰性になる。
+  // パス衝突なら実行ユーザに依存しない。
+  fs.mkdirSync(path.join(dst, 'nodes.ndjson'), { recursive: true });
 
   assert.throws(() => runExtract(src, dst, '135.4,34.6,135.6,34.8'));
+});
+
+test('抽出: dst のファイルが src のファイルへのハードリンクなら中断する', (t) => {
+  const nodes = [{ id: 1, lon: 135.5, lat: 34.7 }];
+  const { dir, src, dst } = makeFixture(nodes, [{ from: 1, to: 1, cost_m: 1 }]);
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  // ディレクトリは別なので realpath 比較はすり抜ける。ハードリンクは
+  // realpath でも解決されないため dev/ino でしか気づけない。
+  fs.mkdirSync(dst, { recursive: true });
+  fs.linkSync(path.join(src, 'edges.ndjson'), path.join(dst, 'nodes.ndjson'));
+
+  const before = fs.readFileSync(path.join(src, 'edges.ndjson'), 'utf8');
+  assert.throws(() => runExtract(src, dst, '135.4,34.6,135.6,34.8'));
+  assert.equal(fs.readFileSync(path.join(src, 'edges.ndjson'), 'utf8'), before);
+});
+
+test('抽出: dst のファイルが src のファイルへの symlink なら中断する', (t) => {
+  const nodes = [{ id: 1, lon: 135.5, lat: 34.7 }];
+  const { dir, src, dst } = makeFixture(nodes, [{ from: 1, to: 1, cost_m: 1 }]);
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  fs.mkdirSync(dst, { recursive: true });
+  fs.symlinkSync(path.join(src, 'edges.ndjson'), path.join(dst, 'nodes.ndjson'));
+
+  const before = fs.readFileSync(path.join(src, 'edges.ndjson'), 'utf8');
+  assert.throws(() => runExtract(src, dst, '135.4,34.6,135.6,34.8'));
+  assert.equal(fs.readFileSync(path.join(src, 'edges.ndjson'), 'utf8'), before);
+});
+
+test('抽出: pass 2 でだけ衝突する場合も pass 1 を書く前に中断する', (t) => {
+  const nodes = [{ id: 1, lon: 135.5, lat: 34.7 }];
+  const { dir, src, dst } = makeFixture(nodes, [{ from: 1, to: 1, cost_m: 1 }]);
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  // 衝突するのは edges (pass 2) の側だけ。検査が pass ごとだと nodes を
+  // 書き終えてから壊れるので、開始前にまとめて弾けていることを見る。
+  fs.mkdirSync(dst, { recursive: true });
+  fs.linkSync(path.join(src, 'edges.ndjson'), path.join(dst, 'edges.ndjson'));
+
+  const before = fs.readFileSync(path.join(src, 'edges.ndjson'), 'utf8');
+  assert.throws(() => runExtract(src, dst, '135.4,34.6,135.6,34.8'));
+  assert.equal(fs.readFileSync(path.join(src, 'edges.ndjson'), 'utf8'), before);
+  // nodes.ndjson にも一切書いていない
+  assert.equal(fs.existsSync(path.join(dst, 'nodes.ndjson')), false);
+});
+
+test('findFileAliasing: 実体が重ならなければ null', (t) => {
+  const { dir, src, dst } = makeFixture([{ id: 1, lon: 135.5, lat: 34.7 }], []);
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  fs.mkdirSync(dst, { recursive: true });
+  fs.writeFileSync(path.join(dst, 'nodes.ndjson'), '');
+
+  assert.equal(
+    findFileAliasing(
+      [path.join(src, 'nodes.ndjson'), path.join(src, 'edges.ndjson')],
+      [path.join(dst, 'nodes.ndjson'), path.join(dst, 'edges.ndjson')]
+    ),
+    null
+  );
 });


### PR DESCRIPTION
Closes #100

#99 のマージ 19 秒後に届いた CodeRabbit 指摘 2 件を回収する。

## 1. 衝突検査がディレクトリ単位で、ファイル単位のエイリアスを見ていない

既存の `canonicalPath` 比較は `--src` / `--dst` を realpath まで解決するため、symlink 経由のディレクトリ別名は弾ける。だが次はすり抜ける。

- `dst/nodes.ndjson` が `src/edges.ndjson` への**ハードリンク** (realpath では解決されない)
- `dst/nodes.ndjson` が `src/edges.ndjson` への**symlink** (ディレクトリは別だがファイルの実体が同じ)

`findFileAliasing()` を追加し、`fs.mkdirSync(dst)` の後・`filterInto` の前に、出力候補 2 件 × 入力候補 2 件を `statSync` の `dev`/`ino` で突き合わせて中断する。`statSync` は symlink を追うので、symlink とハードリンクの両方が同じ経路で拾える。

検査を pass ごとにすると、edges 側だけ衝突しているケースで nodes を書き終えてから壊れる。そのため 4 通りをまとめて、1 行も書く前に見る。

## 2. 書き込み失敗テストが権限に依存している

`chmod 500` は root だと権限が無視され、偽陰性 (実際には書けて `assert.throws` が落ちる) になりうる。出力パスをディレクトリとして先に作り `EISDIR` で `createWriteStream` を失敗させる方式に変えた。実行ユーザに依存しない。

失敗経路が変わっていないことは手動でも確認済み:

```
[pass 1/2] filtering nodes by bbox
error: Error: EISDIR: illegal operation on a directory, open '.../dst/nodes.ndjson'
exit=1
```

`error:` 接頭辞が付いている = `main().catch` に届いている (`out.once('error')` を購読していない場合はプロセスごと落ちてここに来ない)。

## テスト

追加 4 件:

- ハードリンク衝突で中断し、src が壊れない
- symlink 衝突で中断し、src が壊れない
- pass 2 でだけ衝突する場合も pass 1 を書く前に中断する (`dst/nodes.ndjson` が生成されていないことまで確認)
- `findFileAliasing` は実体が重ならなければ `null`

**ミューテーションで有効性を確認済み。** `findFileAliasing` の呼び出しを無効化すると、追加した 3 件がきちんと落ちる:

```
not ok 19 - 抽出: dst のファイルが src のファイルへのハードリンクなら中断する
not ok 20 - 抽出: dst のファイルが src のファイルへの symlink なら中断する
not ok 21 - 抽出: pass 2 でだけ衝突する場合も pass 1 を書く前に中断する
# pass 19 / # fail 3
```

`npm test` は 340 件すべて緑。